### PR TITLE
Feature/bufr ext

### DIFF
--- a/src/bufr/BufrParser/BufrDescription.cpp
+++ b/src/bufr/BufrParser/BufrDescription.cpp
@@ -17,6 +17,7 @@
 #include "Exports/MnemonicExport.h"
 #include "Exports/DatetimeExport.h"
 #include "Exports/Export.h"
+#include "Exports/Transforms/Transform.h"
 
 
 static const char* FILENAME = "obsdatain";
@@ -26,6 +27,7 @@ static const char* CHANNEL_NAME = "channels";
 static const char* EXPORT_NAME = "exports";
 static const char* DATETIME_NAME = "datetime";
 static const char* MNEMONIC_NAME = "mnemonic";
+static const char* TRANSFORM_NAME = "transform";
 
 
 namespace Ingester
@@ -62,7 +64,14 @@ namespace Ingester
             }
             else if (subconf.has(MNEMONIC_NAME))
             {
-                addExport(key, std::make_shared<MnemonicExport>(subconf.getString(MNEMONIC_NAME)));
+                Transforms transforms;
+//                if (subconf.has(TRANSFORM_NAME))
+//                {
+//                    for
+//                    transforms.push_back()
+//                }
+
+                addExport(key, std::make_shared<MnemonicExport>(subconf.getString(MNEMONIC_NAME), transforms));
             }
         }
     }

--- a/src/bufr/BufrParser/BufrDescription.cpp
+++ b/src/bufr/BufrParser/BufrDescription.cpp
@@ -18,6 +18,7 @@
 #include "Exports/DatetimeExport.h"
 #include "Exports/Export.h"
 #include "Exports/Transforms/Transform.h"
+#include "Exports/Transforms/TransformBuilder.h"
 
 
 static const char* FILENAME = "obsdatain";
@@ -27,8 +28,6 @@ static const char* CHANNEL_NAME = "channels";
 static const char* EXPORT_NAME = "exports";
 static const char* DATETIME_NAME = "datetime";
 static const char* MNEMONIC_NAME = "mnemonic";
-static const char* TRANSFORM_NAME = "transform";
-
 
 namespace Ingester
 {
@@ -64,14 +63,9 @@ namespace Ingester
             }
             else if (subconf.has(MNEMONIC_NAME))
             {
-                Transforms transforms;
-//                if (subconf.has(TRANSFORM_NAME))
-//                {
-//                    for
-//                    transforms.push_back()
-//                }
-
-                addExport(key, std::make_shared<MnemonicExport>(subconf.getString(MNEMONIC_NAME), transforms));
+                Transforms transforms = TransformBuilder::makeTransforms(subconf);
+                addExport(key, std::make_shared<MnemonicExport>(subconf.getString(MNEMONIC_NAME),
+                                                                transforms));
             }
         }
     }
@@ -85,5 +79,4 @@ namespace Ingester
     {
         exportMap_.insert({key, bufrExport});
     }
-
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/MnemonicExport.cpp
+++ b/src/bufr/BufrParser/Exports/MnemonicExport.cpp
@@ -20,11 +20,12 @@ namespace Ingester
 
     std::shared_ptr<DataObject> MnemonicExport::exportData(BufrDataMap map)
     {
-        return std::make_shared<ArrayDataObject> (map.at(mnemonic_));
-//        return applyTransforms(std::make_shared<ArrayDataObject> (map.at(mnemonic_)));
+        auto data = map.at(mnemonic_);
+        applyTransforms(data);
+        return std::make_shared<ArrayDataObject>(data);
     }
 
-    void MnemonicExport::applyTransforms(std::shared_ptr<ArrayDataObject> data)
+    void MnemonicExport::applyTransforms(IngesterArray& data)
     {
         for (auto transform : transforms_)
         {

--- a/src/bufr/BufrParser/Exports/MnemonicExport.cpp
+++ b/src/bufr/BufrParser/Exports/MnemonicExport.cpp
@@ -12,13 +12,23 @@
 
 namespace Ingester
 {
-    MnemonicExport::MnemonicExport(std::string mnemonic) :
-    mnemonic_(mnemonic)
+    MnemonicExport::MnemonicExport(std::string mnemonic, Transforms transforms) :
+      mnemonic_(mnemonic),
+      transforms_(transforms)
     {
     }
 
     std::shared_ptr<DataObject> MnemonicExport::exportData(BufrDataMap map)
     {
         return std::make_shared<ArrayDataObject> (map.at(mnemonic_));
+//        return applyTransforms(std::make_shared<ArrayDataObject> (map.at(mnemonic_)));
+    }
+
+    void MnemonicExport::applyTransforms(std::shared_ptr<ArrayDataObject> data)
+    {
+        for (auto transform : transforms_)
+        {
+            transform->apply(data);
+        }
     }
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/MnemonicExport.h
+++ b/src/bufr/BufrParser/Exports/MnemonicExport.h
@@ -32,6 +32,6 @@ namespace Ingester
         std::string mnemonic_;
         Transforms transforms_;
 
-        void applyTransforms(std::shared_ptr<ArrayDataObject> data);
+        void applyTransforms(IngesterArray& data);
     };
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/MnemonicExport.h
+++ b/src/bufr/BufrParser/Exports/MnemonicExport.h
@@ -8,12 +8,14 @@
 #pragma once
 
 #include <string>
+#include <memory>
 
 #include "eckit/config/LocalConfiguration.h"
 
 #include "Export.h"
 #include "IngesterTypes.h"
 #include "DataObject/ArrayDataObject.h"
+#include "Transforms/Transform.h"
 
 
 namespace Ingester
@@ -21,12 +23,15 @@ namespace Ingester
     class MnemonicExport final : public Export
     {
      public:
-        explicit MnemonicExport(std::string mnemonicStr);
+        explicit MnemonicExport(std::string mnemonicStr, Transforms transforms);
         ~MnemonicExport() final = default;
 
         std::shared_ptr<DataObject> exportData(BufrDataMap map) final;
 
      private:
         std::string mnemonic_;
+        Transforms transforms_;
+
+        void applyTransforms(std::shared_ptr<ArrayDataObject> data);
     };
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.cpp
+++ b/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.cpp
@@ -12,9 +12,9 @@ namespace Ingester
     {
     }
 
-    void OffsetTransform::apply(std::shared_ptr<ArrayDataObject> array)
+    void OffsetTransform::apply(IngesterArray& array)
     {
-        array = array->get().get() + offset_;
+        array = array + offset_;
     }
 
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.cpp
+++ b/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.cpp
@@ -1,0 +1,20 @@
+//
+// Created by Ronald McLaren on 9/24/20.
+//
+
+#include "OffsetTransform.h"
+
+
+namespace Ingester
+{
+    OffsetTransform::OffsetTransform(double offset) :
+      offset_(offset)
+    {
+    }
+
+    void OffsetTransform::apply(std::shared_ptr<ArrayDataObject> array)
+    {
+        array = array->get().get() + offset_;
+    }
+
+}  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.h
@@ -1,0 +1,23 @@
+//
+// Created by Ronald McLaren on 9/24/20.
+//
+
+#pragma once
+
+#include "Transform.h"
+
+
+namespace Ingester
+{
+    class OffsetTransform : public Transform
+    {
+     public:
+        explicit OffsetTransform(double offset);
+        ~OffsetTransform() = default;
+
+        void apply(std::shared_ptr<ArrayDataObject> array) override;
+
+     private:
+        const double offset_;
+    };
+}  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/OffsetTransform.h
@@ -15,7 +15,7 @@ namespace Ingester
         explicit OffsetTransform(double offset);
         ~OffsetTransform() = default;
 
-        void apply(std::shared_ptr<ArrayDataObject> array) override;
+        void apply(IngesterArray& array) override;
 
      private:
         const double offset_;

--- a/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.cpp
+++ b/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.cpp
@@ -12,8 +12,8 @@ namespace Ingester
     {
     }
 
-    void ScalingTransform::apply(std::shared_ptr<ArrayDataObject> array)
+    void ScalingTransform::apply(IngesterArray& array)
     {
-        return array * scaling_;
+        array = array * scaling_;
     }
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.cpp
+++ b/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.cpp
@@ -1,0 +1,19 @@
+//
+// Created by Ronald McLaren on 9/24/20.
+//
+
+#include "ScalingTransform.h"
+
+
+namespace Ingester
+{
+    ScalingTransform::ScalingTransform(double scaling) :
+      scaling_(scaling)
+    {
+    }
+
+    void ScalingTransform::apply(std::shared_ptr<ArrayDataObject> array)
+    {
+        return array * scaling_;
+    }
+}  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.h
@@ -15,7 +15,7 @@ namespace Ingester
         explicit ScalingTransform(double scaling_);
         ~ScalingTransform() = default;
 
-        void apply(std::shared_ptr<ArrayDataObject> array) override;
+        void apply(IngesterArray& array) override;
 
      private:
         const double scaling_;

--- a/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/ScalingTransform.h
@@ -1,0 +1,23 @@
+//
+// Created by Ronald McLaren on 9/24/20.
+//
+
+#pragma once
+
+#include "Transform.h"
+
+
+namespace Ingester
+{
+    class ScalingTransform : public Transform
+    {
+     public:
+        explicit ScalingTransform(double scaling_);
+        ~ScalingTransform() = default;
+
+        void apply(std::shared_ptr<ArrayDataObject> array) override;
+
+     private:
+        const double scaling_;
+    };
+}  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/Transform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/Transform.h
@@ -15,7 +15,7 @@ namespace Ingester
     {
     public:
         ~Transform() = default;
-        virtual void apply(std::shared_ptr <ArrayDataObject> array) = 0;
+        virtual void apply(IngesterArray& array) = 0;
     };
 
     typedef std::vector <std::shared_ptr<Transform>> Transforms;

--- a/src/bufr/BufrParser/Exports/Transforms/Transform.h
+++ b/src/bufr/BufrParser/Exports/Transforms/Transform.h
@@ -1,0 +1,22 @@
+//
+// Created by Ronald McLaren on 9/24/20.
+//
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "IngesterTypes.h"
+
+namespace Ingester
+{
+    class Transform
+    {
+    public:
+        ~Transform() = default;
+        virtual void apply(std::shared_ptr <ArrayDataObject> array) = 0;
+    };
+
+    typedef std::vector <std::shared_ptr<Transform>> Transforms;
+}  // namespace Ingester

--- a/src/bufr/BufrParser/Exports/Transforms/TransformBuilder.cpp
+++ b/src/bufr/BufrParser/Exports/Transforms/TransformBuilder.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Ronald McLaren on 9/25/20.
+//
+
+#include "TransformBuilder.h"
+
+#include "eckit/exception/Exceptions.h"
+
+#include "ScalingTransform.h"
+#include "OffsetTransform.h"
+
+
+static const char* TRANSFORMS_SECTION = "transforms";
+static const char* OFFSET_KEY = "offset";
+static const char* SCALE_KEY = "scale";
+
+namespace Ingester
+{
+    std::shared_ptr<Transform> TransformBuilder::makeTransform(const eckit::Configuration& conf)
+    {
+        std::shared_ptr <Transform> transform;
+        if (conf.has(OFFSET_KEY))
+        {
+            transform = std::make_shared<OffsetTransform>(conf.getFloat(OFFSET_KEY));
+        }
+        else if (conf.has(SCALE_KEY))
+        {
+            transform = std::make_shared<ScalingTransform>(conf.getFloat(SCALE_KEY));
+        }
+        else
+        {
+            throw eckit::BadParameter("Tried to create unknown export transform type. "
+                                      "Check your configuration.");
+        }
+
+        return transform;
+    }
+
+    Transforms TransformBuilder::makeTransforms(const eckit::Configuration& conf)
+    {
+        Transforms transforms;
+        if (conf.has(TRANSFORMS_SECTION))
+        {
+            for (const auto& transformConf : conf.getSubConfigurations(TRANSFORMS_SECTION))
+            {
+                transforms.push_back(makeTransform(transformConf));
+            }
+        }
+
+        return transforms;
+    }
+}

--- a/src/bufr/BufrParser/Exports/Transforms/TransformBuilder.h
+++ b/src/bufr/BufrParser/Exports/Transforms/TransformBuilder.h
@@ -1,0 +1,22 @@
+//
+// Created by Ronald McLaren on 9/25/20.
+//
+
+#pragma once
+
+#include <memory.h>
+
+#include "eckit/config/LocalConfiguration.h"
+
+#include "Transform.h"
+
+
+namespace Ingester
+{
+    class TransformBuilder
+    {
+     public:
+        static std::shared_ptr<Transform> makeTransform(const eckit::Configuration& conf);
+        static Transforms makeTransforms(const eckit::Configuration& conf);
+    };
+}  // namespace Ingester

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -67,8 +67,8 @@ add_library( ${PROJECT_NAME}::ingester ALIAS ingester )
 add_executable(test_ingester.x test_ingester.cpp)
 target_link_libraries(test_ingester.x PRIVATE ${PROJECT_NAME}::ingester)
 
-add_executable(toIoda.x main.cpp)
-target_link_libraries(toIoda.x PRIVATE ${PROJECT_NAME}::ingester)
+add_executable(convertToIoda.x main.cpp)
+target_link_libraries(convertToIoda.x PRIVATE ${PROJECT_NAME}::ingester)
 
 add_test(NAME ${PROJECT_NAME}_bufr_coding_norms
 COMMAND ${CMAKE_BINARY_DIR}/bin/${PROJECT_NAME}_cpplint.py --quiet --recursive ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -34,6 +34,13 @@ list(APPEND _ingester_srcs
   BufrParser/Exports/DatetimeExport.cpp
   BufrParser/Exports/MnemonicExport.h
   BufrParser/Exports/MnemonicExport.cpp
+  BufrParser/Exports/Transforms/Transform.h
+  BufrParser/Exports/Transforms/OffsetTransform.h
+  BufrParser/Exports/Transforms/OffsetTransform.cpp
+  BufrParser/Exports/Transforms/ScalingTransform.h
+  BufrParser/Exports/Transforms/ScalingTransform.cpp
+  BufrParser/Exports/Transforms/TransformBuilder.h
+  BufrParser/Exports/Transforms/TransformBuilder.cpp
   IodaEncoder/IodaEncoder.cpp
   IodaEncoder/IodaEncoder.h
   IodaEncoder/IodaDescription.cpp

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -67,8 +67,8 @@ add_library( ${PROJECT_NAME}::ingester ALIAS ingester )
 add_executable(test_ingester.x test_ingester.cpp)
 target_link_libraries(test_ingester.x PRIVATE ${PROJECT_NAME}::ingester)
 
-add_executable(bufrToIoda.x main.cpp)
-target_link_libraries(bufrToIoda.x PRIVATE ${PROJECT_NAME}::ingester)
+add_executable(toIoda.x main.cpp)
+target_link_libraries(toIoda.x PRIVATE ${PROJECT_NAME}::ingester)
 
 add_test(NAME ${PROJECT_NAME}_bufr_coding_norms
 COMMAND ${CMAKE_BINARY_DIR}/bin/${PROJECT_NAME}_cpplint.py --quiet --recursive ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -60,8 +60,8 @@ add_library( ${PROJECT_NAME}::ingester ALIAS ingester )
 add_executable(test_ingester.x test_ingester.cpp)
 target_link_libraries(test_ingester.x PRIVATE ${PROJECT_NAME}::ingester)
 
-add_executable(convertBufrToIoda.x main.cpp)
-target_link_libraries(convertBufrToIoda.x PRIVATE ${PROJECT_NAME}::ingester)
+add_executable(bufrToIoda.x main.cpp)
+target_link_libraries(bufrToIoda.x PRIVATE ${PROJECT_NAME}::ingester)
 
 add_test(NAME ${PROJECT_NAME}_bufr_coding_norms
 COMMAND ${CMAKE_BINARY_DIR}/bin/${PROJECT_NAME}_cpplint.py --quiet --recursive ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/bufr/DataContainer.cpp
+++ b/src/bufr/DataContainer.cpp
@@ -8,7 +8,10 @@
 
 #include <map>
 #include <string>
+#include <ostream>
+
 #include "Eigen/Dense"
+#include "eckit/exception/Exceptions.h"
 
 #include "DataContainer.h"
 
@@ -19,8 +22,9 @@ namespace Ingester
     {
         if (hasKey(fieldName))
         {
-            std::cout << "ERROR: Field called " << fieldName << " already exists." << std::endl;
-            abort();
+            std::ostringstream errorStr;
+            errorStr << "ERROR: Field called " << fieldName << " already exists.";
+            throw eckit::BadParameter(errorStr.str());
         }
 
         dataMap_.insert({fieldName, data});
@@ -30,8 +34,9 @@ namespace Ingester
     {
         if (!hasKey(fieldName))
         {
-            std::cout << "ERROR: Field called " << fieldName << " doesn't exist." << std::endl;
-            abort();
+            std::ostringstream errorStr;
+            errorStr << "ERROR: Field called " << fieldName << " doesn't exists.";
+            throw eckit::BadParameter(errorStr.str());
         }
 
         return dataMap_.at(fieldName);

--- a/src/bufr/DataObject/ArrayDataObject.cpp
+++ b/src/bufr/DataObject/ArrayDataObject.cpp
@@ -22,7 +22,7 @@ namespace Ingester
     {
         static ioda::VariableCreationParameters params = makeCreationParams();
 
-        auto var = obsGroup.vars.createWithScales<float>(name, dimensions, params);
+        auto var = obsGroup.vars.createWithScales<double>(name, dimensions, params);
         var.writeWithEigenRegular(eigArray_);
         return var;
     }
@@ -37,7 +37,7 @@ namespace Ingester
         ioda::VariableCreationParameters params;
         params.chunk = true;
         params.compressWithGZIP();
-        params.setFillValue<float>(-999);
+        params.setFillValue<double>(-999);
 
         return params;
     }

--- a/src/bufr/DataObject/ArrayDataObject.h
+++ b/src/bufr/DataObject/ArrayDataObject.h
@@ -24,7 +24,7 @@ namespace Ingester
                                       std::vector<ioda::Variable> dimensions) final;
         void print() final;
 
-        IngesterArray get() const { return eigArray_; }
+        inline IngesterArray get() const { return eigArray_; }
 
      private:
         const IngesterArray eigArray_;

--- a/src/bufr/DataObject/StrVecDataObject.cpp
+++ b/src/bufr/DataObject/StrVecDataObject.cpp
@@ -41,7 +41,6 @@ namespace Ingester
         ioda::VariableCreationParameters params;
         params.chunk = true;
         params.compressWithGZIP();
-        params.setFillValue<std::string>("");
 
         return params;
     }

--- a/src/bufr/IodaEncoder/IodaDescription.cpp
+++ b/src/bufr/IodaEncoder/IodaDescription.cpp
@@ -9,6 +9,9 @@
 
 #include <iostream>
 
+#include "eckit/exception/Exceptions.h"
+
+
 static const char* BACKEND_SECTION = "backend";
 static const char* FILENAME_SECTION = "obsdataout";
 static const char* DIMENSIONS_SECTION = "dimensions";
@@ -36,8 +39,7 @@ namespace Ingester
         }
         else
         {
-            std::cout << "Forgot to specify the ioda::backend." << std::endl;
-            abort();
+            throw eckit::BadParameter("Forgot to specify the ioda::backend.");
         }
 
         if (conf.has(FILENAME_SECTION))
@@ -52,8 +54,7 @@ namespace Ingester
             }
             else
             {
-                std::cout << "Filename is required with the configured backend." << std::endl;
-                abort();
+                throw eckit::BadParameter("Filename is required with the configured backend.");
             }
         }
 
@@ -123,8 +124,7 @@ namespace Ingester
         }
         else
         {
-            std::cout << "Unknown ioda::backend specified." << std::endl;
-            abort();
+            throw eckit::BadParameter("Unknown ioda::backend specified.");
         }
     }
 }  // namespace Ingester

--- a/src/bufr/IodaEncoder/IodaDescription.cpp
+++ b/src/bufr/IodaEncoder/IodaDescription.cpp
@@ -7,6 +7,8 @@
 
 #include "IodaDescription.h"
 
+#include <boost/algorithm/string.hpp>
+
 #include "eckit/exception/Exceptions.h"
 
 namespace
@@ -122,11 +124,12 @@ namespace Ingester
 
     void IodaDescription::setBackend(std::string backend)
     {
-        if (backend == "netcdf")
+        auto backend_lowercase = boost::algorithm::to_lower_copy(backend);
+        if (backend_lowercase == "netcdf")
         {
             setBackend(ioda::Engines::BackendNames::Hdf5File);
         }
-        else if (backend == "inmemory" || backend == "in-memory")
+        else if (backend_lowercase == "inmemory" || backend_lowercase == "in-memory")
         {
             setBackend(ioda::Engines::BackendNames::ObsStore);
         }

--- a/src/bufr/IodaEncoder/IodaDescription.h
+++ b/src/bufr/IodaEncoder/IodaDescription.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
-
+#include "ioda/Engines/Factory.h"
 
 namespace Ingester
 {
@@ -51,13 +51,20 @@ namespace Ingester
         void addScale(ScaleDescription scale);
         void addVariable(VariableDescription variable);
 
+        inline void setBackend(ioda::Engines::BackendNames backend) { backend_ = backend; }
+        inline void setFilepath(std::string filepath) { filepath_ = filepath; }
+
+        inline ioda::Engines::BackendNames getBackend() const { return backend_; }
+        inline std::string getFilepath() const { return filepath_; }
         inline ScaleDescriptions getScales() const { return dimensions_; }
         inline VariableDescriptions getVariables() const { return variables_; }
-        inline std::string getFilepath() const { return filepath_; }
 
      private:
+        ioda::Engines::BackendNames backend_;
         std::string filepath_;
         ScaleDescriptions dimensions_;
         VariableDescriptions variables_;
+
+        void setBackend(std::string backend);
     };
 }  // namespace Ingester

--- a/src/bufr/IodaEncoder/IodaEncoder.cpp
+++ b/src/bufr/IodaEncoder/IodaEncoder.cpp
@@ -78,8 +78,6 @@ namespace Ingester
             }
 
             auto data = dataContainer->get(varDesc.source);
-
-            std::cout << varDesc.name << std::endl;
             auto var = data->createVariable(obsGroup, varDesc.name, dimensions);
 
             var.atts.add<std::string>("long_name", { varDesc.longName }, {1});

--- a/src/bufr/main.cpp
+++ b/src/bufr/main.cpp
@@ -7,9 +7,11 @@
 
 #include <string>
 #include <iostream>
+#include <ostream>
 #include <iomanip>
 
 #include "eckit/config/YAMLConfiguration.h"
+#include "eckit/exception/Exceptions.h"
 #include "eckit/filesystem/PathName.h"
 
 #include "BufrParser/BufrDescription.h"
@@ -24,14 +26,15 @@ namespace Ingester
 {
     void handleBadYaml(std::string additionalMsg = "")
     {
-        std::cout << "Must provide a YAML file that maps BUFR to IODA arguments." << std::endl;
+        std::ostringstream errorStr;
+        errorStr << "Must provide a YAML file that maps BUFR to IODA arguments." << "\n";
 
-    if (!additionalMsg.empty())
-    {
-        std::cout << additionalMsg << std::endl;
-    }
+        if (!additionalMsg.empty())
+        {
+            errorStr << additionalMsg;
+        }
 
-        abort();
+        throw eckit::BadParameter(errorStr.str());
     }
 
     void parseFile(std::string yamlPath)

--- a/test/testinput/bufrtest_bufrdescription.yaml
+++ b/test/testinput/bufrtest_bufrdescription.yaml
@@ -35,7 +35,7 @@ bufr:
       mnemonic: TMBR
 
 ioda:
-  backend: inmemory
+  backend: netcdf
   obsdataout: "./testoutput/ioda_encoder_result.nc"
 
   dimensions:

--- a/test/testinput/bufrtest_bufrdescription.yaml
+++ b/test/testinput/bufrtest_bufrdescription.yaml
@@ -27,7 +27,7 @@ bufr:
     longitude:
       mnemonic: CLON
       transforms:
-        - offset: -180
+        - offset: 0
 
     latitude:
       mnemonic: CLAT

--- a/test/testinput/bufrtest_bufrdescription.yaml
+++ b/test/testinput/bufrtest_bufrdescription.yaml
@@ -28,7 +28,6 @@ bufr:
       mnemonic: CLON
       transforms:
         - offset: -180
-        - scale: 1.25
 
     latitude:
       mnemonic: CLAT
@@ -36,7 +35,8 @@ bufr:
       mnemonic: TMBR
 
 ioda:
-  backend: inmemory
+  backend: netcdf
+  obsdataout: "./testoutput/ioda_encoder_result.nc"
 
   dimensions:
     - name: "nlocs"

--- a/test/testinput/bufrtest_bufrdescription.yaml
+++ b/test/testinput/bufrtest_bufrdescription.yaml
@@ -35,7 +35,7 @@ bufr:
       mnemonic: TMBR
 
 ioda:
-  backend: netcdf
+  backend: inmemory
   obsdataout: "./testoutput/ioda_encoder_result.nc"
 
   dimensions:
@@ -45,11 +45,11 @@ ioda:
       size: "15" #explicit info
 
   variables:
-#    - name: "datetime@MetaData"
-#      source: "timestamp"
-#      dimensions: [ "nlocs" ]
-#      longName: "Datetime"
-#      units: "datetime"
+    - name: "datetime@MetaData"
+      source: "timestamp"
+      dimensions: [ "nlocs" ]
+      longName: "Datetime"
+      units: "datetime"
 
     - name: "latitude@MetaData"
       source: "latitude"

--- a/test/testinput/bufrtest_bufrdescription.yaml
+++ b/test/testinput/bufrtest_bufrdescription.yaml
@@ -36,7 +36,7 @@ bufr:
       mnemonic: TMBR
 
 ioda:
-  obsdataout: "./testoutput/ioda_encoder_result.nc"
+  backend: inmemory
 
   dimensions:
     - name: "nlocs"
@@ -45,11 +45,11 @@ ioda:
       size: "15" #explicit info
 
   variables:
-    - name: "datetime@MetaData"
-      source: "timestamp"
-      dimensions: [ "nlocs" ]
-      longName: "Datetime"
-      units: "datetime"
+#    - name: "datetime@MetaData"
+#      source: "timestamp"
+#      dimensions: [ "nlocs" ]
+#      longName: "Datetime"
+#      units: "datetime"
 
     - name: "latitude@MetaData"
       source: "latitude"


### PR DESCRIPTION
## Description

- Adds support for transforms to BUFR exports.
- Fixes bug were in memory (ObsSpace backend) creation of numerical value would fail because of a type mismatch (used floats instead of doubles)
- Fixed bug were in memory (ObsSpace backend) creation of std::string variables would fail (worked around ioda-engines bug (zenhub::ioda-engines:140 )).
- Changed name of main executable to toIoda.x to accommodate the fact that it might do more than just BUFR.
- Added backend parameter to YAML file so that the user can explicitly set either "inmemory" or "netcdf" backends.


## Dependencies

- waiting on JCSDA/ioda-converter/pull/331
