### PR TITLE
Fix for using GSI-ncdiag converter with standard versions of GSI

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -1105,7 +1105,10 @@ class Radiances(BaseGSI):
                     varDict[vbc]['bcpKey'] = vbc, writer.ObiaspredName()
                     ibc += 1
         obsdata = self.var('Observation')
-        obserr = self.var('Input_Observation_Error')
+        try:
+            obserr = self.var('Input_Observation_Error')
+        except IndexError:
+            obserr = 1./self.var('Inverse_Observation_Error')
         obsqc = self.var('QC_Flag').astype(int)
         if (ObsBias):
             nametbc = [
@@ -1622,7 +1625,10 @@ class Ozone(BaseGSI):
         varDict[vname]['qcKey'] = vname, writer.OqcName()
 
         obsdata = self.var('Observation')
-        tmp = self.var('Input_Observation_Error')
+        try:
+            tmp = self.var('Input_Observation_Error')
+        except IndexError:
+            tmp = 1./self.var('Inverse_Observation_Error')
         tmp[tmp < self.EPSILON] = 0
         obserr = tmp
         obserr[np.isinf(obserr)] = self.FLOAT_FILL


### PR DESCRIPTION
The modified version of GSI to produce GeoVaLs uses "Input_Observation_Error" rather than "Inverse_Observation_Error".

For those who just want to produce IODA obs files using GSI, a standard version of GSI will only have Inverse_Obs_Error.

This PR will default to Input, and if it doesn't exist, use Inverse (and compute the inverse of it).
