### PR TITLE
Bugfix for pressure units

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -694,6 +694,11 @@ class Conv(BaseGSI):
 
                 for o in range(len(outvars)):
                     obsdata = self.var(conv_gsivarnames[v][o])[idx]
+                    if outvars[o] == 'surface_pressure':
+                        try:
+                            tmpps = self.var('surface_air_pressure')[0]
+                        except IndexError:
+                            obsdata = obsdata * 100. # convert to Pa from hPa
                     obserr = self.var('Errinv_Input')[idx]
                     mask = obserr < self.EPSILON
                     obserr[~mask] = 1.0 / obserr[~mask]
@@ -746,6 +751,13 @@ class Conv(BaseGSI):
                         obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                         obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
+                    # special logic for unit conversions depending on GSI version
+                    elif lvar == 'Pressure'
+                        try:
+                            tmpps = self.var('surface_air_pressure')[0]
+                            loc_mdata[loc_mdata_name] = self.var(lvar)[idx]
+                        except IndexError:
+                            loc_mdata[loc_mdata_name] = self.var(lvar)[idx] * 100. # convert to Pa from hPa
                     # special logic for missing station_elevation and height for surface obs
                     elif lvar in ['Station_Elevation', 'Height']:
                         if p == 'sfc':

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -696,9 +696,9 @@ class Conv(BaseGSI):
                     obsdata = self.var(conv_gsivarnames[v][o])[idx]
                     if outvars[o] == 'surface_pressure':
                         try:
-                            tmpps = self.var('surface_air_pressure')[0]
+                            tmpps = self.var('surface_pressure')[0]
                         except IndexError:
-                            obsdata = obsdata * 100. # convert to Pa from hPa
+                            obsdata = obsdata * 100.  # convert to Pa from hPa
                     obserr = self.var('Errinv_Input')[idx]
                     mask = obserr < self.EPSILON
                     obserr[~mask] = 1.0 / obserr[~mask]
@@ -752,12 +752,12 @@ class Conv(BaseGSI):
                         obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                         loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
                     # special logic for unit conversions depending on GSI version
-                    elif lvar == 'Pressure'
+                    elif lvar == 'Pressure':
                         try:
-                            tmpps = self.var('surface_air_pressure')[0]
+                            tmpps = self.var('surface_pressure')[0]
                             loc_mdata[loc_mdata_name] = self.var(lvar)[idx]
                         except IndexError:
-                            loc_mdata[loc_mdata_name] = self.var(lvar)[idx] * 100. # convert to Pa from hPa
+                            loc_mdata[loc_mdata_name] = self.var(lvar)[idx] * 100.  # convert to Pa from hPa
                     # special logic for missing station_elevation and height for surface obs
                     elif lvar in ['Station_Elevation', 'Height']:
                         if p == 'sfc':


### PR DESCRIPTION
There is a mismatch between standard GSI (hPa) and our "modified" GSI (Pa) in units of pressure, both for use as a coordinate (e.g. radiosondes) and for surface pressure obs.

This will check to see if the fields for GeoVaLs exist, and if so, do no unit conversion, otherwise it will convert from hPa to Pa.

Once @emilyhcliu and I have a new GSI GeoVaL generator, we will make sure we 1) remove the unit conversions in the source code and 2) modify the ioda-converters to handle all unit conversions.