### PR TITLE
Fix GIIRS IODA metadata initalization if not all variables are in first file

### DIFF
--- a/src/ssec/giirs_ssec2ioda.py
+++ b/src/ssec/giirs_ssec2ioda.py
@@ -188,7 +188,7 @@ class Giirs2Ioda:
                 # Read metadata
                 for new_key, old_key in self.LOC_MDATA_MAP.items():
                     if old_key in ncd.variables:
-                        if not new_key in self.LocMdata:
+                        if new_key not in self.LocMdata:
                             # If we haven't seen this key before initialize it now and set to fillvalue for all previous locs
                             self._initialize_metadata_key(new_key, old_key, ncd)
                         self.LocMdata[new_key][nlocs_tot:nlocs_tot+nlocs] = np.asarray(ncd.variables[old_key])[mask]

--- a/src/ssec/giirs_ssec2ioda.py
+++ b/src/ssec/giirs_ssec2ioda.py
@@ -149,12 +149,12 @@ class Giirs2Ioda:
                     detector_array = np.arange(1, ndetectors+1, dtype=np.int32)
 
                     # Determine maximum size of output and pre-allocate output arrays
-                    nlocs_max = ndetectors * len(filenames)  # Maximum possible locs
+                    self.nlocs_max = ndetectors * len(filenames)  # Maximum possible locs
                     # obs_vals (nchans, nlocs) will contain all observed values
                     # values are appended for each dataset
-                    obs_vals = np.full((nchans, nlocs_max), nc.default_fillvals['f4'], dtype=np.float32, order='F')
+                    obs_vals = np.full((nchans, self.nlocs_max), nc.default_fillvals['f4'], dtype=np.float32, order='F')
                     # Note, scan_position is integer valued, but currently must be a float32 to be recognized by UFO/CRTM operator
-                    self.LocMdata['scan_position'] = np.full(nlocs_max, nc.default_fillvals['f4'], dtype=np.float32)
+                    self.LocMdata['scan_position'] = np.full(self.nlocs_max, nc.default_fillvals['f4'], dtype=np.float32)
                     self.units_values['scan_position'] = '1'
 
                     self.VarMdata['channel_wavenumber'] = self.writer.FillNcVector(LW_wnum, 'float')
@@ -162,10 +162,7 @@ class Giirs2Ioda:
                     self.units_values['channel_wavenumber'] = ncd.variables['LW_wnum'].getncattr('units')
                     self.units_values['channel_number'] = '1'
                     for new_key, old_key in self.LOC_MDATA_MAP.items():
-                        if old_key in ncd.variables:
-                            self.LocMdata[new_key] = np.full(nlocs_max, nc.default_fillvals['f4'], dtype=np.float32)
-                            if 'units' in ncd.variables[old_key].ncattrs():
-                                self.units_values[new_key] = ncd.variables[old_key].getncattr('units')
+                        self._initialize_metadata_key(new_key, old_key, ncd)
                 else:
                     # Check this file uses the same dimensions as the initial file
                     this_nchans = ncd.dimensions["LWchannel"].size
@@ -191,6 +188,9 @@ class Giirs2Ioda:
                 # Read metadata
                 for new_key, old_key in self.LOC_MDATA_MAP.items():
                     if old_key in ncd.variables:
+                        if not new_key in self.LocMdata:
+                            # If we haven't seen this key before initialize it now and set to fillvalue for all previous locs
+                            self._initialize_metadata_key(new_key, old_key, ncd)
                         self.LocMdata[new_key][nlocs_tot:nlocs_tot+nlocs] = np.asarray(ncd.variables[old_key])[mask]
                 self.LocMdata['scan_position'][nlocs_tot:nlocs_tot+nlocs] = detector_array[mask]  # detector number
 
@@ -240,6 +240,18 @@ class Giirs2Ioda:
         K3 = cls._K2 * wavnum**3
         bt = cls._K1 * wavnum / np.log1p(K3/radiance)
         return bt
+
+    def _initialize_metadata_key(self, new_key, old_key, ncd):
+        """
+        Common initialization for LocMdata metadata for new variable names
+        new_key - IODA variable name
+        old_key - GIIRS SSEC NetCDF variable name
+        ncd - GIIRS NetCDF scan file
+        """
+        if old_key in ncd.variables:
+            self.LocMdata[new_key] = np.full(self.nlocs_max, nc.default_fillvals['f4'], dtype=np.float32)
+            if 'units' in ncd.variables[old_key].ncattrs():
+                self.units_values[new_key] = ncd.variables[old_key].getncattr('units')
 
 
 def main():


### PR DESCRIPTION
## Description

The `giirs_ssec2ioda.py` executable reads in a sequence of GIIRS NetCDF data files and accumulates the combined data into a single IODA file.  The first GIIRS file read in is used to initialize the metadata variables that will be sent to the `NcWriter` object.

Some metadata variables are optional and don't occurr in every GIIRS file, primarily the `Cloud_Fraction` variable.  If the first file read in does not contain `Cloud_Fraction` or any other optional variable, the output numpy array is never initalized and the conversion will error out if a subseqent file then has this variable.

This PR seperates the metadata variable initalization into a private method and calls it as needed if a new variable is discovered in a later file.

This is a blocker for the NRT GFS website workflow, so I am moving the active workflow to point to this branch.  Please don't delete this branch after merging until I can move the NRT rapids-bundle back to develop sometime after next week.

