### PR TITLE
Modified gsi ncdiags converter to remove extreme negative values, like -9.99e+9.

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -733,6 +733,7 @@ class Conv(BaseGSI):
                                 tmp[tmp > 4e4] = self.INT_FILL
                             else:
                                 tmp[tmp > 4e8] = self.FLOAT_FILL
+                                tmp[tmp < -9e9] = self.FLOAT_FILL
                             outdata[gvname] = tmp
                     # store values in output data dictionary
                     outdata[varDict[outvars[o]]['valKey']] = obsdata


### PR DESCRIPTION
This is an experiment to solve an issue with the ncdiags files detailed in JCSDA-internal/ufo#466. One of the variables uses an anomalous value to denote missing data (-9.99e+09), and this is causing problems in ufo's bias correction algorithms.

Currently not tested on S4 due to https://github.com/JCSDA-internal/jedi-stack/issues/49, but in theory it should work.
