### PR TITLE
Fix typo that is causing bufr headers to install to the root directory.

### DIFF
--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -70,7 +70,7 @@ ecbuild_add_library( TARGET   ingester
                      SOURCES  ${_ingester_srcs}
                      LIBS     ${_ingester_deps}
                      INSTALL_HEADERS LISTED
-                     HEADER_DESTINATION ${INSTALL_INCLUDEDIR}/bufr
+                     HEADER_DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bufr
                      LINKER_LANGUAGE CXX
                     )
 


### PR DESCRIPTION
## Description

Fix a typo in variable name for bufr CMake header install directory.

### Issue(s) addressed

Bad variable name causes headers to attempt to install to the root directory.

## Dependencies

None

## Impact

None