### PR TITLE
Fix case sensitivity issue in GsiSatBias

### DIFF
--- a/src/satbias/CMakeLists.txt
+++ b/src/satbias/CMakeLists.txt
@@ -4,7 +4,7 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 ecbuild_add_executable( TARGET  satbias2ioda.x
-                        SOURCES SatBiasConverter.cpp GsiSatbiasReader.cpp GsiSatbiasReader.h
+                        SOURCES SatBiasConverter.cpp GsiSatBiasReader.cpp GsiSatBiasReader.h
                         LIBS    Eigen3::Eigen ${oops_LIBRARIES} ioda_engines )
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_coding_norms


### PR DESCRIPTION
GsiSatBiasReader.cpp and GsiSatBiasReader.h are the names of the files (note the camel case)
I suspect this passed for @srherbener because MacOS is case-insensitive?

Fixed so it will compile on Hera (and presumably elsewhere)