### PR TITLE
Addition of LaunchTime (float, unit: hours) to the dictionary of gsi_ncdiag.py.

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -111,6 +111,7 @@ all_LocKeyList = {
     'SCCF_chan_wavelen': ('channel_wavelength', 'float'),
     'QI_with_FC': ('satwind_quality_ind_with_fc', 'float'),
     'QI_without_FC': ('satwind_quality_ind_no_fc', 'float'),
+    'LaunchTime': ('LaunchTime', 'float'),
 }
 
 checkuv = {
@@ -457,6 +458,7 @@ units_values = {
     'clw_retrieved_from_observation': 'kg/m/m',
     'clw_retrieved_from_background': 'kg/m/m',
     'scat_retrieved_from_observation': '1',
+    'LaunchTime': 'hours',
 }
 
 # @TestReference


### PR DESCRIPTION

## Description

Addition of the LaunchTime float variable in the dictionary of `gsi_ncdiag.py.` This is intended for radiosondes. Knowledge of the sondes launch time allows to uniquely identify all individual data points, spread over the processors in JEDI, belonging to the same sounding. This is helpful to reproduce GSI observation error inflation that applies when several data points of the same soundings are found within the same grid box at the same time.  

Provide a detailed description of what this PR does.

The entry `LaunchTime` is added to the dictionary of `gsi_ncdiag.py` as a float with units in hours. When the variable LaunchTime is present in `GSI_diags` conventional files, the change will insure that the following variable is created in the corresponding `obs` file upon conversion:

 ```
       float LaunchTime@MetaData(nlocs) ;
                string LaunchTime@MetaData:units = "hours" ;
```


What problem does it fix? What new capability does it add?

The addition allow for GSI observation error inflation to properly work in JEDI.

[See the JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html) for further information.

### Issue(s) addressed

#https://github.com/JCSDA-internal/ufo/issues/480

Link the issues to be closed with this PR
- fixes #[480](https://github.com/JCSDA-internal/ufo/issues/480)

If this does not close an existing issue, then [be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)

## Acceptance Criteria (Definition of Done)

The changes were tested during the **January 2021 Obs Team Code Sprint** and validated in issue [#480](https://github.com/JCSDA-internal/ufo/issues/480) that has been closed.

What does it mean for this PR to be finished?

`obs` file generated from `GSI_diags` files using `ioda-onverters` will be consistent with the sondes YAML file [sonde_gfs_qc.yaml](https://github.com/JCSDA-internal/ufo/blob/develop/test/testinput/instrumentTests/Sonde/sonde_gfs_qc.yaml) that was added to the ufo repository during the **January 2021 Obs Team Code Sprint.**

## Dependencies

To activate the changes, the variable LaunchTime must be present inside the input GSI_diags files. Those files are generated by GSI and the corresponding changes are needed in GSI. 

Not Waiting on other PRs.

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

No JEDI-internal repository will need changes. GSI will be changed.

## Test Data

Please list the test data (if any) that needs to be updated on AWS to the best of your knowledge (example below).

The following test data are needed for testing. They can be found in the [ufo-data](https://github.com/JCSDA-internal/ufo-data/tree/develop/testinput_tier_1) tier1 repository.

[sondes_obs_2020110112_m.nc4  ](https://github.com/JCSDA-internal/ufo-data/blob/develop/testinput_tier_1/sondes_obs_2018041500_m.nc4)  
[sondes_obs_2020110112_vs.nc4  ](https://github.com/JCSDA-internal/ufo-data/blob/develop/testinput_tier_1/sondes_obs_2018041500_vs.nc4) 
