### PR TITLE
Assign dimensions to all variables in satbias files

### DIFF
--- a/src/satbias/SatBiasConverter.cpp
+++ b/src/satbias/SatBiasConverter.cpp
@@ -48,9 +48,9 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object, const std::stri
   ioda::ObsGroup ogrp = ioda::ObsGroup::generate(empty_base_object, newDims);
 
   // Save the predictors and the channels values
-  ioda::Variable predsVar = ogrp.vars.createWithScales<std::string>("predictors", ogrp.vars["npredictors"]);
+  ioda::Variable predsVar = ogrp.vars.createWithScales<std::string>("predictors", {ogrp.vars["npredictors"]});
   predsVar.write(predictors);
-  ioda::Variable chansVar = ogrp.vars.createWithScales<int>("channels", ogrp.vars["nchannels"]);
+  ioda::Variable chansVar = ogrp.vars.createWithScales<int>("channels", {ogrp.vars["nchannels"]});
   chansVar.write(channels);
 
   // Set up the creation parameters for the bias coefficients variable

--- a/src/satbias/SatBiasConverter.cpp
+++ b/src/satbias/SatBiasConverter.cpp
@@ -48,9 +48,9 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object, const std::stri
   ioda::ObsGroup ogrp = ioda::ObsGroup::generate(empty_base_object, newDims);
 
   // Save the predictors and the channels values
-  ioda::Variable predsVar = ogrp.vars.create<std::string>("predictors", {numPreds});
+  ioda::Variable predsVar = ogrp.vars.createWithScales<std::string>("predictors", ogrp.vars["npredictors"]);
   predsVar.write(predictors);
-  ioda::Variable chansVar = ogrp.vars.create<int>("channels", {numChans});
+  ioda::Variable chansVar = ogrp.vars.createWithScales<int>("channels", ogrp.vars["nchannels"]);
   chansVar.write(channels);
 
   // Set up the creation parameters for the bias coefficients variable

--- a/src/satbias/SatBiasConverter.cpp
+++ b/src/satbias/SatBiasConverter.cpp
@@ -48,7 +48,8 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object, const std::stri
   ioda::ObsGroup ogrp = ioda::ObsGroup::generate(empty_base_object, newDims);
 
   // Save the predictors and the channels values
-  ioda::Variable predsVar = ogrp.vars.createWithScales<std::string>("predictors", {ogrp.vars["npredictors"]});
+  ioda::Variable predsVar = ogrp.vars.createWithScales<std::string>(
+                            "predictors", {ogrp.vars["npredictors"]});
   predsVar.write(predictors);
   ioda::Variable chansVar = ogrp.vars.createWithScales<int>("channels", {ogrp.vars["nchannels"]});
   chansVar.write(channels);


### PR DESCRIPTION
## Description

This is a small fix to the bias files. See title.

## Test data

Once this PR is in, satbias files should be regenerated for all instruments. ufo develop can work with either the existing files or the new ones, but the ioda sprint needs the new files.
