### PR TITLE
Add channel dependent metadata for GMI

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -495,6 +495,13 @@ test_fields_with_channels = {
     'Transmittance_at_Cloud_Top': ('tao_cldtop', 'float'),
     'NSST_Retrieval_check': ('nsstret_check', 'integer'),
 }
+gmi_chan_dep_loc_vars = {
+    'Sat_Zenith_Angle',
+    'Sat_Azimuth_Angle',
+    'Sol_Zenith_Angle',
+    'Sol_Azimuth_Angle',
+    'Scan_Angle',
+}
 
 
 class BaseGSI:
@@ -1172,6 +1179,15 @@ class Radiances(BaseGSI):
                 obstimes = [self.validtime + dt.timedelta(hours=float(tmp[a])) for a in range(len(tmp))]
                 obstimes = [a.strftime("%Y-%m-%dT%H:%M:%SZ") for a in obstimes]
                 loc_mdata[loc_mdata_name] = writer.FillNcVector(obstimes, "datetime")
+            elif self.sensor == "gmi" and lvar in gmi_chan_dep_loc_vars:
+                # Channels 1-9
+                tmp = self.var(lvar)[::nchans]
+                tmp[tmp > 4e8] = self.FLOAT_FILL
+                loc_mdata[loc_mdata_name] = tmp
+                # Channels 10-13
+                tmp = self.var(lvar)[nchans-1::nchans]
+                tmp[tmp > 4e8] = self.FLOAT_FILL
+                loc_mdata[loc_mdata_name+'1'] = tmp
             else:
                 tmp = self.var(lvar)[::nchans]
                 tmp[tmp > 4e8] = self.FLOAT_FILL


### PR DESCRIPTION
## Description

Some of the metadata for GMI is channel dependent. Channels 1-9 has one value while channels 10-13 has another. In this PR a second variable is added for these metadata variables appended with "1" and filled with the values for the channel 10-13.

Thanks at @CoryMartin-NOAA for the suggestion of how to add this.

## Acceptance Criteria (Definition of Done)

Enough data in GMI files to replicate the GSI with ioda converted gsi-diags.

