### PR TITLE
Added code to handle the two namings of the bufr interface include file.

### DIFF
--- a/CI/buildspec_clang.yml
+++ b/CI/buildspec_clang.yml
@@ -73,6 +73,8 @@ phases:
   build:
     commands:
       - cd /build_container
+      - echo $PYTHONPATH
+      - export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages:$PYTHONPATH
       - ecbuild /jcsda/ioda-bundle
       - cd /build_container/iodaconv
       - make -j4 

--- a/CI/buildspec_clang.yml
+++ b/CI/buildspec_clang.yml
@@ -1,6 +1,7 @@
 version: 0.2
 
 env:
+  shell: bash
   parameter-store:
     GIT_USER: "/CodeBuild/Git_USER"
     GIT_PASS: "/CodeBuild/Git_PASS"
@@ -18,6 +19,7 @@ phases:
       - echo $PATH
       - echo $LD_LIBRARY_PATH
       - echo $PYTHONPATH
+      - export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages
 
       # Codebuild only runs on PUSH events if HEAD_REF
       # is refs/heads/develop (merge to develop). In this
@@ -73,8 +75,6 @@ phases:
   build:
     commands:
       - cd /build_container
-      - echo $PYTHONPATH
-      - export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages:$PYTHONPATH
       - ecbuild /jcsda/ioda-bundle
       - cd /build_container/iodaconv
       - make -j4 

--- a/CI/buildspec_gnu.yml
+++ b/CI/buildspec_gnu.yml
@@ -118,7 +118,7 @@ phases:
 
       - su - jcsdauser -c "export PATH=/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         && export LD_LIBRARY_PATH=/usr/local/lib
-        && export PYTHONPATH=/usr/local/lib
+        && export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages:$PYTHONPATH
         && cd /build_container/iodaconv
         && ctest"
 

--- a/CI/buildspec_gnu.yml
+++ b/CI/buildspec_gnu.yml
@@ -118,7 +118,7 @@ phases:
 
       - su - jcsdauser -c "export PATH=/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         && export LD_LIBRARY_PATH=/usr/local/lib
-        && export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages:$PYTHONPATH
+        && export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages
         && cd /build_container/iodaconv
         && ctest"
 
@@ -131,7 +131,7 @@ phases:
         su - jcsdauser -c "cd /build_container/iodaconv
         && export PATH=/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         && export LD_LIBRARY_PATH=/usr/local/lib
-        && export PYTHONPATH=/usr/local/lib
+        && export PYTHONPATH=/usr/local/lib:/usr/local/lib/python3.8/site-packages
         && ctest -VV --rerun-failed";
         else echo "Build failed";
         fi

--- a/src/bufr/BufrParser/BufrCollectors/BufrIntCollector.cpp
+++ b/src/bufr/BufrParser/BufrCollectors/BufrIntCollector.cpp
@@ -5,7 +5,11 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include "bufr.interface.h"
+#if __has_include("bufr_interface.h")  // TODO(rmclaren): Remove this in future
+    #include "bufr_interface.h"
+#else
+    #include "bufr.interface.h"
+#endif
 
 #include "BufrIntCollector.h"
 

--- a/src/bufr/BufrParser/BufrCollectors/BufrRepCollector.cpp
+++ b/src/bufr/BufrParser/BufrCollectors/BufrRepCollector.cpp
@@ -5,7 +5,11 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include "bufr.interface.h"
+#if __has_include("bufr_interface.h")  // TODO(rmclaren): Remove this in future
+    #include "bufr_interface.h"
+#else
+    #include "bufr.interface.h"
+#endif
 
 #include "BufrRepCollector.h"
 

--- a/src/bufr/BufrParser/BufrParser.cpp
+++ b/src/bufr/BufrParser/BufrParser.cpp
@@ -13,7 +13,11 @@
 
 #include "eckit/exception/Exceptions.h"
 
-#include "bufr.interface.h"
+#if __has_include("bufr_interface.h")  // TODO(rmclaren): Remove this in future
+    #include "bufr_interface.h"
+#else
+    #include "bufr.interface.h"
+#endif
 #include "BufrParser/BufrCollectors/BufrCollectors.h"
 #include "BufrMnemonicSet.h"
 #include "DataContainer.h"


### PR DESCRIPTION
## Description

This PR adds in Ron's workaround for handling the two namings for the bufr interface include file. This has been tested on my iMac using the old and new versions of the NCEPLIBS-bufr library so this should enable developers to continue their work using either library while we get the test container issue sorted out.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

The develop version of the EMC bufr converter builds and tests pass with either of the old ore new version of the NCEPLIBS-bufr library.

## Dependencies

None

## Impact

None

## Test Data

None