### PR TITLE
ioda-converter for SMOS SSS L2 from ESA

### DIFF
--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND programs
   ndbc_hfradar2ioda.py
   rads_adt2ioda.py
   smap_sss2ioda.py
+  smos_sss2ioda.py
   argoClim2ioda.py
   viirs_modis_l2_oc2ioda.py
   viirs_modis_l3_oc2ioda.py

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -49,18 +49,18 @@ class Salinity(object):
         valKey = vName, self.writer.OvalName()
         errKey = vName, self.writer.OerrName()
         qcKey = vName, self.writer.OqcName()
-        
+
         for f in self.filenames:
-            print(" Reading file: ",f)
+            print(" Reading file: ", f)
             ncd = nc.Dataset(f, 'r')
 
             source_var_name = {
-                 'lat': 'Latitude',
-		 'lon': 'Longitude',
-		 'sss': 'SSS_corr',
-		 'sss_err':'Sigma_SSS_corr',
-		 'sss_qc': 'Dg_quality_SSS_corr',
-                }
+                'lat': 'Latitude',
+                'lon': 'Longitude',
+                'sss': 'SSS_corr',
+                'sss_err': 'Sigma_SSS_corr',
+                'sss_qc': 'Dg_quality_SSS_corr'
+            }
             lon = ncd.variables['Longitude'][:]
             lat = ncd.variables['Latitude'][:]
             sss = ncd.variables['SSS_corr'][:]
@@ -77,9 +77,9 @@ class Salinity(object):
 
             for i in range(len(lon)):
                 if sss_qc[i] <= 150:
-                   sss_qc[i] = 0
+                    sss_qc[i] = 0
                 else:
-                   sss_qc[i] = 1
+                    sss_qc[i] = 1
                 # get date from filename
                 n = f.find("SM_")
                 date1 = f[n+19:n+19+8]
@@ -87,16 +87,16 @@ class Salinity(object):
                 MM1 = f[n+19+11:n+19+13]
                 SS1 = f[n+19+13:n+19+15]
                 #
-                seconds = ( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
-                          datetime.strptime(date1,'%Y%m%d') ).total_seconds()
-                basetime = datetime.strptime(date1,'%Y%m%d')
+                seconds = (datetime.strptime(date1+HH1+MM1+SS1, '%Y%m%d%H%M%S') - datetime.strptime(
+                           date1, '%Y%m%d')).total_seconds()
+                basetime = datetime.strptime(date1, '%Y%m%d')
                 obs_date = basetime + timedelta(seconds=int(seconds))
                 locKey = lat[i], lon[i], obs_date.strftime("%Y-%m-%dT%H:%M:%SZ")
                 self.data[0][locKey][valKey] = sss[i]
                 self.data[0][locKey][errKey] = sss_err[i]
                 self.data[0][locKey][qcKey] = sss_qc[i]
-
             ncd.close()
+
 
 def main():
 
@@ -131,6 +131,7 @@ def main():
 #
     (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(sal.data)
     writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
+
 
 if __name__ == '__main__':
     main()

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2021 UCAR
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -57,9 +57,9 @@ class Salinity(object):
             source_var_name = {
                  'lat': 'Latitude',
 		 'lon': 'Longitude',
-                 'sss': 'SSS_corr',
+		 'sss': 'SSS_corr',
 		 'sss_err':'Sigma_SSS_corr',
-                 'sss_qc': 'Dg_quality_SSS_corr',
+		 'sss_qc': 'Dg_quality_SSS_corr',
                 }
             lon = ncd.variables['Longitude'][:]
             lat = ncd.variables['Latitude'][:]

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -85,13 +85,8 @@ class Salinity(object):
                 date1 = f[n+19:n+19+8]
                 HH1 = f[n+19+9:n+19+11]
                 MM1 = f[n+19+11:n+19+13]
-<<<<<<< HEAD
                 SS1 = f[n+19+13:n+19+15]
                 #
-=======
-                SS1 = f[n+19+13:n+19+15
-		# 
->>>>>>> 76a5690e92d3a6d199d6e22f92d5b43b19b51945
                 seconds = ( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
                           datetime.strptime(date1,'%Y%m%d') ).total_seconds()
                 basetime = datetime.strptime(date1,'%Y%m%d')

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -81,11 +81,12 @@ class Salinity(object):
                 else:
                    sss_qc[i] = 1
                 # get date from filename
-                I = f.find("SM_")
-                date1 = f[I+19:I+19+8]
-                HH1 = f[I+19+9:I+19+11]
-                MM1 = f[I+19+11:I+19+13]
-                SS1 = f[I+19+13:I+19+15]
+                n = f.find("SM_")
+                date1 = f[n+19:n+19+8]
+                HH1 = f[n+19+9:n+19+11]
+                MM1 = f[n+19+11:n+19+13]
+                SS1 = f[n+19+13:n+19+15]
+                #
                 seconds = ( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
                           datetime.strptime(date1,'%Y%m%d') ).total_seconds()
                 basetime = datetime.strptime(date1,'%Y%m%d')

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -52,8 +52,8 @@ class Salinity(object):
         
         for f in self.filenames:
             print(" Reading file: ",f)
-	    ncd = nc.Dataset(f, 'r')
-            
+            ncd = nc.Dataset(f, 'r')
+
             source_var_name = {
                  'lat': 'Latitude',
 		 'lon': 'Longitude',
@@ -68,7 +68,7 @@ class Salinity(object):
             sss_qc = ncd.variables['Dg_quality_SSS_corr'][:]
             sss_qc = sss_qc.astype(int)
 
-	    mask = np.logical_not(sss.mask)
+            mask = np.logical_not(sss.mask)
             lon = lon[mask]
             lat = lat[mask]
             sss = sss[mask]

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -7,14 +7,11 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
 
-from __future__ import print_function
 import sys
 import argparse
 import numpy as np
 from datetime import datetime, timedelta
 import netCDF4 as nc
-import re
-import dateutil.parser
 from pathlib import Path
 
 IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
@@ -55,23 +52,23 @@ class Salinity(object):
         
         for f in self.filenames:
             print(" Reading file: ",f)
-            ncd = nc.Dataset(f, 'r')
+	    ncd = nc.Dataset(f, 'r')
             
             source_var_name = {
                  'lat': 'Latitude',
-                 'lon': 'Longitude',
+		 'lon': 'Longitude',
                  'sss': 'SSS_corr',
-                 'sss_err':'Sigma_SSS_corr',
+		 'sss_err':'Sigma_SSS_corr',
                  'sss_qc': 'Dg_quality_SSS_corr',
                 }
-            lon     = ncd.variables['Longitude'][:]
-            lat     = ncd.variables['Latitude'][:]
-            sss     = ncd.variables['SSS_corr'][:]
+            lon = ncd.variables['Longitude'][:]
+            lat = ncd.variables['Latitude'][:]
+            sss = ncd.variables['SSS_corr'][:]
             sss_err = ncd.variables['Sigma_SSS_corr'][:]
-            sss_qc  = ncd.variables['Dg_quality_SSS_corr'][:]
+            sss_qc = ncd.variables['Dg_quality_SSS_corr'][:]
             sss_qc = sss_qc.astype(int)
 
-            mask = np.logical_not(sss.mask)
+	    mask = np.logical_not(sss.mask)
             lon = lon[mask]
             lat = lat[mask]
             sss = sss[mask]
@@ -83,23 +80,22 @@ class Salinity(object):
                    sss_qc[i] = 0
                 else:
                    sss_qc[i] = 1
-                I=f.find("SM_")
-                date1=f[I+19:I+19+8]
-                HH1=f[I+19+9:I+19+11]
-                MM1=f[I+19+11:I+19+13]
-                SS1=f[I+19+13:I+19+15]
-                seconds=( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
+                # get date from filename
+                I = f.find("SM_")
+                date1 = f[I+19:I+19+8]
+                HH1 = f[I+19+9:I+19+11]
+                MM1 = f[I+19+11:I+19+13]
+                SS1 = f[I+19+13:I+19+15]
+                seconds = ( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
                           datetime.strptime(date1,'%Y%m%d') ).total_seconds()
-                basetime=datetime.strptime(date1,'%Y%m%d')
+                basetime = datetime.strptime(date1,'%Y%m%d')
                 obs_date = basetime + timedelta(seconds=int(seconds))
                 locKey = lat[i], lon[i], obs_date.strftime("%Y-%m-%dT%H:%M:%SZ")
                 self.data[0][locKey][valKey] = sss[i]
                 self.data[0][locKey][errKey] = sss_err[i]
                 self.data[0][locKey][qcKey] = sss_qc[i]
-                               
 
             ncd.close()
-
 
 def main():
 
@@ -123,7 +119,6 @@ def main():
         metavar="YYYYMMDDHH", type=str, required=True)
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
-        
 #
     writer = iconv.NcWriter(args.output, locationKeyList)
 #

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+#
+# (C) Copyright 2019 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+
+from __future__ import print_function
+import sys
+import argparse
+import numpy as np
+from datetime import datetime, timedelta
+import netCDF4 as nc
+import re
+import dateutil.parser
+from pathlib import Path
+
+IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
+if not IODA_CONV_PATH.is_dir():
+    IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
+sys.path.append(str(IODA_CONV_PATH.resolve()))
+
+import ioda_conv_ncio as iconv
+from orddicts import DefaultOrderedDict
+
+
+vName = "sea_surface_salinity"
+
+locationKeyList = [
+    ("latitude", "float"),
+    ("longitude", "float"),
+    ("datetime", "string")
+]
+
+AttrData = {
+    'odb_version': 1,
+}
+
+
+class Salinity(object):
+    def __init__(self, filenames, date, writer):
+        self.filenames = filenames
+        self.date = date
+        self.data = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
+        self.writer = writer
+        self._read()
+
+    # Open obs file and read/load relevant info
+    def _read(self):
+        valKey = vName, self.writer.OvalName()
+        errKey = vName, self.writer.OerrName()
+        qcKey = vName, self.writer.OqcName()
+        
+        for f in self.filenames:
+            print(" Reading file: ",f)
+            ncd = nc.Dataset(f, 'r')
+            
+            source_var_name = {
+                 'lat': 'Latitude',
+                 'lon': 'Longitude',
+                 'sss': 'SSS_corr',
+                 'sss_err':'Sigma_SSS_corr',
+                 'sss_qc': 'Dg_quality_SSS_corr',
+                }
+            lon     = ncd.variables['Longitude'][:]
+            lat     = ncd.variables['Latitude'][:]
+            sss     = ncd.variables['SSS_corr'][:]
+            sss_err = ncd.variables['Sigma_SSS_corr'][:]
+            sss_qc  = ncd.variables['Dg_quality_SSS_corr'][:]
+            sss_qc = sss_qc.astype(int)
+
+            mask = np.logical_not(sss.mask)
+            lon = lon[mask]
+            lat = lat[mask]
+            sss = sss[mask]
+            sss_err = sss_err[mask]
+            sss_qc = sss_qc[mask]
+
+            for i in range(len(lon)):
+                if sss_qc[i] <= 150:
+                   sss_qc[i] = 0
+                else:
+                   sss_qc[i] = 1
+                I=f.find("SM_")
+                date1=f[I+19:I+19+8]
+                HH1=f[I+19+9:I+19+11]
+                MM1=f[I+19+11:I+19+13]
+                SS1=f[I+19+13:I+19+15]
+                seconds=( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
+                          datetime.strptime(date1,'%Y%m%d') ).total_seconds()
+                basetime=datetime.strptime(date1,'%Y%m%d')
+                obs_date = basetime + timedelta(seconds=int(seconds))
+                locKey = lat[i], lon[i], obs_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                self.data[0][locKey][valKey] = sss[i]
+                self.data[0][locKey][errKey] = sss_err[i]
+                self.data[0][locKey][qcKey] = sss_qc[i]
+                               
+
+            ncd.close()
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description=(
+            'Read JPL/RSS SMOS sea surface salinity (SSS) file(s) and convert'
+            ' to a concatenated IODA formatted output file.')
+    )
+    required = parser.add_argument_group(title='required arguments')
+    required.add_argument(
+        '-i', '--input',
+        help="name of sss input file(s)",
+        type=str, nargs='+', required=True)
+    required.add_argument(
+        '-o', '--output',
+        help="name of ioda output file",
+        type=str, required=True)
+    required.add_argument(
+        '-d', '--date',
+        help="base date for the center of the window",
+        metavar="YYYYMMDDHH", type=str, required=True)
+    args = parser.parse_args()
+    fdate = datetime.strptime(args.date, '%Y%m%d%H')
+        
+#
+    writer = iconv.NcWriter(args.output, locationKeyList)
+#
+#    # Read in the salinity
+    sal = Salinity(args.input, fdate, writer)
+#
+#    # write them out
+    AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
+#
+    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(sal.data)
+    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
+
+if __name__ == '__main__':
+    main()

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -85,8 +85,13 @@ class Salinity(object):
                 date1 = f[n+19:n+19+8]
                 HH1 = f[n+19+9:n+19+11]
                 MM1 = f[n+19+11:n+19+13]
+<<<<<<< HEAD
                 SS1 = f[n+19+13:n+19+15]
                 #
+=======
+                SS1 = f[n+19+13:n+19+15
+		# 
+>>>>>>> 76a5690e92d3a6d199d6e22f92d5b43b19b51945
                 seconds = ( datetime.strptime(date1+HH1+MM1+SS1,'%Y%m%d%H%M%S') - 
                           datetime.strptime(date1,'%Y%m%d') ).total_seconds()
                 basetime = datetime.strptime(date1,'%Y%m%d')

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ list( APPEND test_input
   testinput/SMAP_L2_SM_P_NRT_24342_A_20190822T224858_N16023_002.h5
   testinput/smos_l2nrt_ssm.nc
   testinput/ascat_ssm.nc
+  testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
 )
 
 list( APPEND test_output
@@ -79,6 +80,7 @@ list( APPEND test_output
   testoutput/smap_ssm.nc
   testoutput/smos_ssm.nc
   testoutput/ascat_ssm.nc
+  testoutput/smos_sss_l2.nc
 )
 
 if( iodaconv_gnssro_ENABLED )
@@ -325,6 +327,16 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_cryosat2
                           -o testrun/cryosat2_L2.nc
                           -d 2019092112"
                           cryosat2_L2.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smos_sss
+                  TYPE    SCRIPT
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                  ARGS    netcdf
+                          "${CMAKE_BINARY_DIR}/bin/smos_sss2ioda.py
+                          -i testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
+                          -o testrun/smos_sss_l2.nc
+                          -d 2010060100"
+                          smos_sss_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 #===============================================================================
 # Conventional data, surface Obs - METAR converter

--- a/test/testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
+++ b/test/testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f43378a471c545c9b607839863167c5ce488984925a8ff056bfb9304776b3a35
+size 1779165

--- a/test/testoutput/smos_sss_l2.nc
+++ b/test/testoutput/smos_sss_l2.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec7237cb90ab7df209fa8c80954d0982d4790ca3f5a6283e7f0541ce82d31b5
+size 50464


### PR DESCRIPTION
## Description

This PR adds a ioda-converter for SSS SMOS L2 data from ESA (smos_sss2ioda.py)
The ioda-converter reads the date from each data (nc) file per day since there is no "time" variable provided.
The SMOS ESA data is available from 20100601

What problem does it fix? What new capability does it add?
Adds capability to use SMOS SSS data

[See the JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html) for further information.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #489 >

