### PR TITLE
Bug fix for certain sensors on Orion

### DIFF
--- a/src/satbias/GsiSatBiasReader.cpp
+++ b/src/satbias/GsiSatBiasReader.cpp
@@ -61,8 +61,8 @@ void findSensorsChannels(const std::string & filename, std::vector<std::string> 
         nchannels.push_back(1);
       }
     }
+    infile.close();
   }
-  infile.close();
 }
 
 //---------------------------------------------------------------------------------------
@@ -103,8 +103,8 @@ void readObsBiasCoefficients(const std::string & filename, const std::string & s
         }
       }
     }
+    infile.close();
   }
-  infile.close();
 }
 
 //---------------------------------------------------------------------------------------
@@ -125,8 +125,9 @@ void readObsBiasCoeffErrors(const std::string & filename, const std::string & se
     {
       infile >> nusis;
       infile >> nuchan;
-      infile >> nobs(jchan);
+      infile >> par;
       if (nusis == sensor) {
+        nobs(jchan) = par;
         /// it's the sensor we're interested in; read in coefficients and channel
         /// indices
         for (size_t jpred = 0; jpred < gsi_npredictors; ++jpred) {
@@ -142,6 +143,6 @@ void readObsBiasCoeffErrors(const std::string & filename, const std::string & se
         }
       }
     }
+    infile.close();
   }
-  infile.close();
 }


### PR DESCRIPTION
## Description

Certain sensors/platforms would fail on Orion when trying to generate satbias IODA files (atms for example).

Two bugs were found:

- file close was located outside of the if that checks if the file is open
- nobs(jchan) was outside of an if statement, and thus, for all lines in the input file after the sensor of interest, the value of jchan would be greater than the size of nobs, on some machines I guess this isn't a problem, but it is (I think) overwriting unallocated memory, which led to downstream problems in the code on Orion. 
 
These changes should fix these bugs. Thanks to @fabiolrdiniz for tag teaming this debugging effort and testing the fix.

### Issue(s) addressed

I do no think this was associated with an issue but was found as part of JEDI-GDAS data preparation testing.

