### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Use this template to report bugs
+title: "[Bug]"
+labels: 'bug'
+assignees: ''
+
+---
+
+## Current behavior (describe the bug)
+>[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
+
+## To Reproduce
+
+> What computer are you running on?
+
+> What compilers/modules are you using?
+
+> Steps to reproduce the behavior
+
+1.
+2.
+3.
+...
+
+## Expected behavior
+
+## Additional information (optional)

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: JCSDA
+    url: https://jcsda.org/
+    about: JCSDA web site
+  - name: Forums
+    url: https://forums.jcsda.org/
+    about: JCSDA user/developer forums

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,26 @@
+---
+name: General issue template
+about: Use this template for general issues
+title: "[New issue]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+>Provide a detailed description of this issue.
+>What problem needs to be fixed? What new capability needs to be added?
+>If this is a bug, describe the current behavior (or use the bug template).
+>[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
+
+## Requirements
+
+>If this is a new feature: What does the new code need to accomplish? Does it require new software dependencies (e.g. new jedi-stack components or new python modules?)
+>If this is a bugfix: What is the expected behavior?
+
+## Acceptance Criteria (Definition of Done)
+>What does it mean for this to be finished?
+
+## Dependencies
+>What must be done before this can be done? Add issue dependencies in ZenHub as appropriate
+>Does this block progress on other issues? Add this issue as a dependency to other ZenHub issues as appropriate


### PR DESCRIPTION
## Description

I remembered this morning that the organization-level github issue templates were not working with ZenHub.  So, to implement the issue templates in ZenHub, I believe we have to do it in each repository.

So, this implements the issue templates for ioda-converters.

### Issue(s) addressed

N/A

## Acceptance Criteria (Definition of Done)

When a user opens an issue in the ioda-converters repo using ZenHub, he or she will be able to use a general or bug template.

## Dependencies

None

## Impact

None

## Test Data

None