### PR TITLE
Move new dimension declarations to new ioda-v2 syntax

### DIFF
--- a/src/bufr/IodaEncoder/IodaEncoder.cpp
+++ b/src/bufr/IodaEncoder/IodaEncoder.cpp
@@ -101,10 +101,7 @@ namespace Ingester
                     }
                 }
 
-                auto newDim = std::make_shared<ioda::NewDimensionScale<int>>(scale.name,
-                                                                             size,
-                                                                             size,
-                                                                             size);
+                auto newDim = ioda::NewDimensionScale<int>(scale.name, size);
                 newDims.push_back(newDim);
 
                 if (size <= 0) { foundInvalidDim = true; }

--- a/src/satbias/SatBiasConverter.cpp
+++ b/src/satbias/SatBiasConverter.cpp
@@ -43,11 +43,10 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
   ASSERT(channels == channels_in_errorfile);
 
   // Creating dimensions: npredictors & nchannels
-  ioda::NewDimensionScales_t newDims;
-  newDims.push_back(std::make_shared<ioda::NewDimensionScale<int>>("npredictors",
-                    numPreds, numPreds, numPreds));
-  newDims.push_back(std::make_shared<ioda::NewDimensionScale<int>>("nchannels",
-                    numChans, numChans, numChans));
+  ioda::NewDimensionScales_t newDims {
+      ioda::NewDimensionScale<int>("npredictors", numPreds),
+      ioda::NewDimensionScale<int>("nchannels", numChans)
+  };
 
   // Construct an ObsGroup object, with 2 dimensions npred, nchans
   ioda::ObsGroup ogrp = ioda::ObsGroup::generate(empty_base_object, newDims);


### PR DESCRIPTION
## Description

This PR replaces the syntax for declaring new dimensions in develop (shared_ptr method) with the new syntax in feature/ioda-v2 (no shared_ptr, simpler interface).

### Issue(s) addressed

- fixes #505

## Acceptance Criteria (Definition of Done)

The feature/ioda-v2 branch in ioda-converters compiles successfully. Note that you need to use the feature/ioda-v2 branch in ioda for this to work properly.

## Dependencies

None

## Impact

None

## Test Data

None