### PR TITLE
Addition of avhrr3 naming for GSI ncdiag files

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -268,7 +268,6 @@ rad_sensors = [
     'ssmis',
     'abi',
     'ahi',
-    'avhrr',
     'avhrr3',
     'saphir',
     'gmi',

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -269,6 +269,7 @@ rad_sensors = [
     'abi',
     'ahi',
     'avhrr',
+    'avhrr3',
     'saphir',
     'gmi',
     'amsr2',

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -268,6 +268,7 @@ rad_sensors = [
     'ssmis',
     'abi',
     'ahi',
+    'avhrr',
     'avhrr3',
     'saphir',
     'gmi',


### PR DESCRIPTION
## Description

This PR adds the conversion of "avhrr3" named GSI ncdiag files into observation and geoval file.  

Provide a detailed description of what this PR does.

The "avhrr3" instrument has been added to the list of radiance sensors for GSI ncdiags input files, so that GSI-generated diag files "avhrr3" can be processed and "avhrr3" observation and geoval files can be created. 

What problem does it fix? What new capability does it add?

This solves the naming convention problem noticed in the JEDI GDAS experiments.

### Issue(s) addressed

https://github.com/JCSDA-internal/experiments/issues/15

## Acceptance Criteria (Definition of Done)

ioda-converters were tested with "avhrr" and "avhrr3" input files and generated the proper output file name and content. 

What does it mean for this PR to be finished?

## Dependencies

[GSI](https://github.com/JCSDA-internal/GSI) ncdiag scripts will have to use "avhrr3" naming from now.


## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

- [GSI](https://github.com/JCSDA-internal/GSI)
- [experiments](https://github.com/JCSDA-internal/experiments)
