### PR TITLE
Fix to get working with ecbuild 3.6.1

### DIFF
--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -76,7 +76,6 @@ ecbuild_add_library( TARGET   ingester
 
 target_include_directories(ingester PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/BufrParser>
   $<INSTALL_INTERFACE:bufr>  # <prefix>/bufr
 )
 

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -74,6 +74,12 @@ ecbuild_add_library( TARGET   ingester
                      LINKER_LANGUAGE CXX
                     )
 
+target_include_directories(ingester PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/BufrParser>
+  $<INSTALL_INTERFACE:bufr>  # <prefix>/bufr
+)
+
 add_library( ${PROJECT_NAME}::ingester ALIAS ingester )
 
 ecbuild_add_executable( TARGET  bufr2ioda.x

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -68,11 +68,12 @@ list(APPEND _ingester_deps
 
 ecbuild_add_library( TARGET   ingester
                      SOURCES  ${_ingester_srcs}
-                     LIBS     ${_ingester_deps}
                      INSTALL_HEADERS LISTED
                      HEADER_DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bufr
                      LINKER_LANGUAGE CXX
                     )
+
+target_link_libraries(ingester PUBLIC ${_ingester_deps})
 
 target_include_directories(ingester PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
## Description

This PR adds code to make sure the include paths are set properly for building the BUFR converter. This change was necessary to get the build to work properly in the new ecbuild 3.6.1 environment. I have tested both in the current (ecbuild 3.3.2) environment and the new ecbuild 3.6.1 environment with these changes on my Macs and the build completes successfully and all tests pass in both cases.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

Tests pass in both ecbuild 3.3.2 and ecbuild 3.6.1 environments.

## Dependencies

None

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

None

## Test Data

None