### PR TITLE
Replaced function in ioda-v2

### DIFF
--- a/src/bufr/IodaEncoder/IodaEncoder.cpp
+++ b/src/bufr/IodaEncoder/IodaEncoder.cpp
@@ -101,10 +101,10 @@ namespace Ingester
                     }
                 }
 
-                auto newDim = std::make_shared<ioda::NewDimensionScale<int>>(scale.name,
-                                                                             size,
-                                                                             size,
-                                                                             size);
+                auto newDim = ioda::NewDimensionScale<int>(scale.name,
+                                                           size,
+                                                           size,
+                                                           size);
                 newDims.push_back(newDim);
 
                 if (size <= 0) { foundInvalidDim = true; }

--- a/src/satbias/SatBiasConverter.cpp
+++ b/src/satbias/SatBiasConverter.cpp
@@ -44,9 +44,9 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
 
   // Creating dimensions: npredictors & nchannels
   ioda::NewDimensionScales_t newDims;
-  newDims.push_back(std::make_shared<ioda::NewDimensionScale<int>>("npredictors",
+  newDims.push_back(ioda::NewDimensionScale<int>("npredictors",
                     numPreds, numPreds, numPreds));
-  newDims.push_back(std::make_shared<ioda::NewDimensionScale<int>>("nchannels",
+  newDims.push_back(ioda::NewDimensionScale<int>("nchannels",
                     numChans, numChans, numChans));
 
   // Construct an ObsGroup object, with 2 dimensions npred, nchans


### PR DESCRIPTION
This PR fixes the bufr converter code so that it can build again ioda-v2. A function was rewritten quite a while ago and somehow escaped CI detection.
