### PR TITLE
add adpsfc and aircft individual bufr tables to ioda-coverters

### DIFF
--- a/doc/bufr_table_samples/adpsfc.nc000000.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000000.bufr.table.txt
@@ -1,0 +1,273 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000000 | A51001 | MTYP 000-000 SYNOPTIC-LAND, RESTRICTED (WMO RES 40)      |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LALOLV   | 301024 | LOCATION -- LATITUDE, LONGITUDE, ELEVATION               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| RPSEC1   | 361036 | SYNOPTIC REPORT WMO FM 12/13 SECTION 1 DATA              |
+| TMPSQ1   | 361037 | SYNOPTIC REPORT TEMPERATURE DATA                         |
+| CTMPS5   | 361040 | SYNOPTIC REPORT CITY TEMPERATURE DATA                    |
+| CLDSQ1   | 361041 | SYNOPTIC REPORT CLOUD DATA                               |
+| WNDSQ1   | 361042 | SYNOPTIC REPORT WIND DATA                                |
+| PRSSQ1   | 361045 | SYNOPTIC REPORT PRESSURE DATA                            |
+| PRSSQ2   | 361046 | SYNOPTIC REPORT GEOPOTENTAL DATA                         |
+| PRSSQ3   | 361047 | SYNOPTIC REPORT 24 HOUR PRESSURE CHANGE DATA             |
+| PCPSQ1   | 361048 | SYNOPTIC REPORT PRECIPITATION DATA 1                     |
+| WAVSQ1   | 361051 | SYNOPTIC REPORT INSTRUMENT WAVE DATA                     |
+| WAVSQ2   | 361052 | SYNOPTIC REPORT WIND WAVE DATA                           |
+| WAVSQ3   | 361053 | SYNOPTIC REPORT SWELL WAVE DATA                          |
+| PPWSQ1   | 361054 | SYNOPTIC REPORT PRESENT AND PAST WEATHER DATA            |
+| SNWSQ1   | 361055 | SYNOPTIC REPORT DEPTH OF SNOW DATA                       |
+| GRDSQ1   | 361056 | SYNOPTIC REPORT STATE OF THE GROUND DATA                 |
+| ICESQ1   | 361057 | SYNOPTIC REPORT SHIP ICE DATA                            |
+| RPSEC3   | 361089 | SYNOPTIC REPORT WMO FM 12 SECTION 3 DATA                 |
+|          |        |                                                          |
+| WMOB     | 001001 | WMO BLOCK NUMBER                                         |
+| WMOS     | 001002 | WMO STATION NUMBER                                       |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MSST     | 002038 | METHOD OF SEA SURFACE TEMPERATURE MEASUREMENT            |
+| MWBT     | 002039 | METHOD OF WET BULB TEMPERATURE MEASUREMENT               |
+| ITSO     | 002193 | IND TYPE OF STN OPERATION PAST/P                         |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| PRLC     | 007004 | PRESSURE                                                 |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GP10     | 010008 | GEOPOTENTIAL                                             |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| CTTP     | 012193 | CITY TEMPERATURE                                         |
+| CTMX     | 012194 | CITY MAXIMUM TEMPERATURE                                 |
+| CTMN     | 012195 | CITY MINIMUM TEMPERATURE                                 |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| INPC     | 013194 | INDIC INCLUSION/OMISSION OF PREC                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| IDTH     | 020031 | ICE DEPOSIT (THICKNESS)                                  |
+| ROIA     | 020032 | RATE OF ICE ACCRETION                                    |
+| COIA     | 020033 | CAUSE OF ICE ACCRETION                                   |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| HBLCS    | 020201 | HEIGHT ABOVE SURFACE OF BASE OF LOWEST CLOUD SEEN        |
+| DOSW     | 022003 | DIRECTION OF SWELL WAVES                                 |
+| POWV     | 022011 | PERIOD OF WAVES                                          |
+| POWW     | 022012 | PERIOD OF WIND WAVES                                     |
+| POSW     | 022013 | PERIOD OF SWELL WAVES                                    |
+| HOWV     | 022021 | HEIGHT OF WAVES                                          |
+| HOWW     | 022022 | HEIGHT OF WIND WAVES                                     |
+| HOSW     | 022023 | HEIGHT OF SWELL WAVES                                    |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMST     | 033218 | SDMEDIT QUALITY MARK FOR SEA SURFACE TEMPERATURE         |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000000 | YYMMDD  HHMM  RPID  WMOB  WMOS  LALOLV  CORN  RSRD  EXPRSRD  BID  |
+| NC000000 | RCPTIM  RPSEC1  WNDSQ1  TMPSQ1  PRSSQ1  <PRSSQ2>  <PRSSQ3>        |
+| NC000000 | PCPSQ1  TOCC  HBLCS  {CLDSQ1}  <PPWSQ1>  <WAVSQ1>  <WAVSQ2>       |
+| NC000000 | {WAVSQ3}  <SNWSQ1>  <ICESQ1>  <GRDSQ1>  <CTMPS5>  <RPSEC3>        |
+| NC000000 | {RAWRPT}                                                          |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LALOLV   | CLAT  CLON  SELV                                                  |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| RPSEC1   | ITSO  TOST  INPC  HOVI                                            |
+|          |                                                                   |
+| TMPSQ1   | QMAT  TMDB  QMDD  TMDP  MSST  QMST  SST1  <TMPSQ2>  <TMPSQ3>      |
+|          |                                                                   |
+| CTMPS5   | CTTP  CTMX  CTMN                                                  |
+|          |                                                                   |
+| CLDSQ1   | VSSO  CLAM  CLTP  HOCB  <CLDSQ2>                                  |
+|          |                                                                   |
+| WNDSQ1   | TIWM  QMWN  WDIR  WSPD  <WNDSQ2>                                  |
+|          |                                                                   |
+| PRSSQ1   | QMPR  PRES  PMSL  CHPT  3HPC                                      |
+|          |                                                                   |
+| PRSSQ2   | PRLC  GP10                                                        |
+|          |                                                                   |
+| PRSSQ3   | 24PC                                                              |
+|          |                                                                   |
+| PCPSQ1   | TP06  <PCPSQ2>  <PCPSQ3>                                          |
+|          |                                                                   |
+| WAVSQ1   | POWV  HOWV                                                        |
+|          |                                                                   |
+| WAVSQ2   | POWW  HOWW                                                        |
+|          |                                                                   |
+| WAVSQ3   | DOSW  POSW  HOSW                                                  |
+|          |                                                                   |
+| PPWSQ1   | PRWE  PSW1  PSW2                                                  |
+|          |                                                                   |
+| SNWSQ1   | .DTHDOFS  DOFS  TOSD                                              |
+|          |                                                                   |
+| GRDSQ1   | SOGR                                                              |
+|          |                                                                   |
+| ICESQ1   | COIA  IDTH  ROIA                                                  |
+|          |                                                                   |
+| RPSEC3   | VTVI                                                              |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| WMOB     |    0 |           0 |   7 | NUMERIC                  |-------------|
+| WMOS     |    0 |           0 |  10 | NUMERIC                  |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MSST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MWBT     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| ITSO     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GP10     |    0 |      -10000 |  20 | (METERS/SECOND)**2       |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTTP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMX     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMN     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| INPC     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| IDTH     |    2 |           0 |   7 | METERS                   |-------------|
+| ROIA     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| COIA     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| HBLCS    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| DOSW     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| POWV     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POWW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POSW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| HOWV     |    1 |           0 |  10 | METERS                   |-------------|
+| HOWW     |    1 |           0 |  10 | METERS                   |-------------|
+| HOSW     |    1 |           0 |  10 | METERS                   |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000001.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000001.bufr.table.txt
@@ -1,0 +1,268 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000001 | A63200 | MTYP 000-001 SYNOPTIC - FIXED LAND                       |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LALOLV   | 301024 | LOCATION -- LATITUDE, LONGITUDE, ELEVATION               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| RPSEC1   | 361036 | SYNOPTIC REPORT WMO FM 12/13 SECTION 1 DATA              |
+| TMPSQ1   | 361037 | SYNOPTIC REPORT TEMPERATURE DATA                         |
+| CTMPS5   | 361040 | SYNOPTIC REPORT CITY TEMPERATURE DATA                    |
+| CLDSQ1   | 361041 | SYNOPTIC REPORT CLOUD DATA                               |
+| WNDSQ1   | 361042 | SYNOPTIC REPORT WIND DATA                                |
+| PRSSQ1   | 361045 | SYNOPTIC REPORT PRESSURE DATA                            |
+| PRSSQ2   | 361046 | SYNOPTIC REPORT GEOPOTENTAL DATA                         |
+| PRSSQ3   | 361047 | SYNOPTIC REPORT 24 HOUR PRESSURE CHANGE DATA             |
+| PCPSQ1   | 361048 | SYNOPTIC REPORT PRECIPITATION DATA 1                     |
+| WAVSQ1   | 361051 | SYNOPTIC REPORT INSTRUMENT WAVE DATA                     |
+| WAVSQ2   | 361052 | SYNOPTIC REPORT WIND WAVE DATA                           |
+| WAVSQ3   | 361053 | SYNOPTIC REPORT SWELL WAVE DATA                          |
+| PPWSQ1   | 361054 | SYNOPTIC REPORT PRESENT AND PAST WEATHER DATA            |
+| SNWSQ1   | 361055 | SYNOPTIC REPORT DEPTH OF SNOW DATA                       |
+| GRDSQ1   | 361056 | SYNOPTIC REPORT STATE OF THE GROUND DATA                 |
+| ICESQ1   | 361057 | SYNOPTIC REPORT SHIP ICE DATA                            |
+| RPSEC3   | 361089 | SYNOPTIC REPORT WMO FM 12 SECTION 3 DATA                 |
+|          |        |                                                          |
+| WMOB     | 001001 | WMO BLOCK NUMBER                                         |
+| WMOS     | 001002 | WMO STATION NUMBER                                       |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MSST     | 002038 | METHOD OF SEA SURFACE TEMPERATURE MEASUREMENT            |
+| MWBT     | 002039 | METHOD OF WET BULB TEMPERATURE MEASUREMENT               |
+| ITSO     | 002193 | IND TYPE OF STN OPERATION PAST/P                         |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| PRLC     | 007004 | PRESSURE                                                 |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GP10     | 010008 | GEOPOTENTIAL                                             |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| CTTP     | 012193 | CITY TEMPERATURE                                         |
+| CTMX     | 012194 | CITY MAXIMUM TEMPERATURE                                 |
+| CTMN     | 012195 | CITY MINIMUM TEMPERATURE                                 |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| INPC     | 013194 | INDIC INCLUSION/OMISSION OF PREC                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| IDTH     | 020031 | ICE DEPOSIT (THICKNESS)                                  |
+| ROIA     | 020032 | RATE OF ICE ACCRETION                                    |
+| COIA     | 020033 | CAUSE OF ICE ACCRETION                                   |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| HBLCS    | 020201 | HEIGHT ABOVE SURFACE OF BASE OF LOWEST CLOUD SEEN        |
+| DOSW     | 022003 | DIRECTION OF SWELL WAVES                                 |
+| POWV     | 022011 | PERIOD OF WAVES                                          |
+| POWW     | 022012 | PERIOD OF WIND WAVES                                     |
+| POSW     | 022013 | PERIOD OF SWELL WAVES                                    |
+| HOWV     | 022021 | HEIGHT OF WAVES                                          |
+| HOWW     | 022022 | HEIGHT OF WIND WAVES                                     |
+| HOSW     | 022023 | HEIGHT OF SWELL WAVES                                    |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMST     | 033218 | SDMEDIT QUALITY MARK FOR SEA SURFACE TEMPERATURE         |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000001 | YYMMDD  HHMM  RPID  WMOB  WMOS  LALOLV  CORN  BID  RCPTIM  RPSEC1 |
+| NC000001 | WNDSQ1  TMPSQ1  PRSSQ1  <PRSSQ2>  <PRSSQ3>  PCPSQ1  TOCC  HBLCS   |
+| NC000001 | {CLDSQ1}  <PPWSQ1>  <WAVSQ1>  <WAVSQ2>  {WAVSQ3}  <SNWSQ1>        |
+| NC000001 | <ICESQ1>  <GRDSQ1>  <CTMPS5>  <RPSEC3>  {RAWRPT}                  |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LALOLV   | CLAT  CLON  SELV                                                  |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| RPSEC1   | ITSO  TOST  INPC  HOVI                                            |
+|          |                                                                   |
+| TMPSQ1   | QMAT  TMDB  QMDD  TMDP  MSST  QMST  SST1  <TMPSQ2>  <TMPSQ3>      |
+|          |                                                                   |
+| CTMPS5   | CTTP  CTMX  CTMN                                                  |
+|          |                                                                   |
+| CLDSQ1   | VSSO  CLAM  CLTP  HOCB  <CLDSQ2>                                  |
+|          |                                                                   |
+| WNDSQ1   | TIWM  QMWN  WDIR  WSPD  <WNDSQ2>                                  |
+|          |                                                                   |
+| PRSSQ1   | QMPR  PRES  PMSL  CHPT  3HPC                                      |
+|          |                                                                   |
+| PRSSQ2   | PRLC  GP10                                                        |
+|          |                                                                   |
+| PRSSQ3   | 24PC                                                              |
+|          |                                                                   |
+| PCPSQ1   | TP06  <PCPSQ2>  <PCPSQ3>                                          |
+|          |                                                                   |
+| WAVSQ1   | POWV  HOWV                                                        |
+|          |                                                                   |
+| WAVSQ2   | POWW  HOWW                                                        |
+|          |                                                                   |
+| WAVSQ3   | DOSW  POSW  HOSW                                                  |
+|          |                                                                   |
+| PPWSQ1   | PRWE  PSW1  PSW2                                                  |
+|          |                                                                   |
+| SNWSQ1   | .DTHDOFS  DOFS  TOSD                                              |
+|          |                                                                   |
+| GRDSQ1   | SOGR                                                              |
+|          |                                                                   |
+| ICESQ1   | COIA  IDTH  ROIA                                                  |
+|          |                                                                   |
+| RPSEC3   | VTVI                                                              |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| WMOB     |    0 |           0 |   7 | NUMERIC                  |-------------|
+| WMOS     |    0 |           0 |  10 | NUMERIC                  |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MSST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MWBT     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| ITSO     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GP10     |    0 |      -10000 |  20 | (METERS/SECOND)**2       |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTTP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMX     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMN     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| INPC     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| IDTH     |    2 |           0 |   7 | METERS                   |-------------|
+| ROIA     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| COIA     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| HBLCS    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| DOSW     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| POWV     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POWW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POSW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| HOWV     |    1 |           0 |  10 | METERS                   |-------------|
+| HOWW     |    1 |           0 |  10 | METERS                   |-------------|
+| HOSW     |    1 |           0 |  10 | METERS                   |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000002.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000002.bufr.table.txt
@@ -1,0 +1,230 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000002 | A61192 | MTYP 000-002 SYNOPTIC - MOBIL LAND                       |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LALOLV   | 301024 | LOCATION -- LATITUDE, LONGITUDE, ELEVATION               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| RPSEC1   | 361036 | SYNOPTIC REPORT WMO FM 12/13 SECTION 1 DATA              |
+| TMPSQ1   | 361037 | SYNOPTIC REPORT TEMPERATURE DATA                         |
+| TMPSQ2   | 361038 | SYNOPTIC REPORT WET BULB TEMPERATURE DATA                |
+| TMPSQ3   | 361039 | SYNOPTIC REPORT MAXIMUM AND MINIMUM TEMPERATURE DATA     |
+| CLDSQ1   | 361041 | SYNOPTIC REPORT CLOUD DATA                               |
+| WNDSQ1   | 361042 | SYNOPTIC REPORT WIND DATA                                |
+| WNDSQ2   | 361043 | SYNOPTIC REPORT HIGHEST WIND GUST DATA                   |
+| PRSSQ1   | 361045 | SYNOPTIC REPORT PRESSURE DATA                            |
+| PRSSQ2   | 361046 | SYNOPTIC REPORT GEOPOTENTAL DATA                         |
+| PRSSQ3   | 361047 | SYNOPTIC REPORT 24 HOUR PRESSURE CHANGE DATA             |
+| PCPSQ1   | 361048 | SYNOPTIC REPORT PRECIPITATION DATA 1                     |
+| PCPSQ2   | 361049 | SYNOPTIC REPORT PRECIPITATION DATA 2                     |
+| PCPSQ3   | 361050 | SYNOPTIC REPORT PRECIPITATION DATA 3                     |
+| PPWSQ1   | 361054 | SYNOPTIC REPORT PRESENT AND PAST WEATHER DATA            |
+| RPSEC3   | 361089 | SYNOPTIC REPORT WMO FM 12 SECTION 3 DATA                 |
+| CLDSQ2   | 361092 | SYNOPTIC REPORT SECTION 4 CLOUD DATA                     |
+|          |        |                                                          |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MSST     | 002038 | METHOD OF SEA SURFACE TEMPERATURE MEASUREMENT            |
+| MWBT     | 002039 | METHOD OF WET BULB TEMPERATURE MEASUREMENT               |
+| ITSO     | 002193 | IND TYPE OF STN OPERATION PAST/P                         |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| PRLC     | 007004 | PRESSURE                                                 |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GP10     | 010008 | GEOPOTENTIAL                                             |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| INPC     | 013194 | INDIC INCLUSION/OMISSION OF PREC                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| HBLCS    | 020201 | HEIGHT ABOVE SURFACE OF BASE OF LOWEST CLOUD SEEN        |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| QCEVR    | 033024 | STATION ELEVATION QUALITY MARK (FOR MOBIL STATIONS)      |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMST     | 033218 | SDMEDIT QUALITY MARK FOR SEA SURFACE TEMPERATURE         |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000002 | YYMMDD  HHMM  RPID  LALOLV  QCEVR  CORN  BID  RCPTIM  RPSEC1      |
+| NC000002 | WNDSQ1  TMPSQ1  PRSSQ1  <PRSSQ2>  <PRSSQ3>  PCPSQ1  TOCC  HBLCS   |
+| NC000002 | {CLDSQ1}  <PPWSQ1>  <RPSEC3>  {RAWRPT}                            |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LALOLV   | CLAT  CLON  SELV                                                  |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| RPSEC1   | ITSO  TOST  INPC  HOVI                                            |
+|          |                                                                   |
+| TMPSQ1   | QMAT  TMDB  QMDD  TMDP  MSST  QMST  SST1  <TMPSQ2>  <TMPSQ3>      |
+|          |                                                                   |
+| TMPSQ2   | MWBT  TMWB  REHU                                                  |
+|          |                                                                   |
+| TMPSQ3   | .DTHMXTM  MXTM  .DTHMITM  MITM                                    |
+|          |                                                                   |
+| CLDSQ1   | VSSO  CLAM  CLTP  HOCB  <CLDSQ2>                                  |
+|          |                                                                   |
+| WNDSQ1   | TIWM  QMWN  WDIR  WSPD  <WNDSQ2>                                  |
+|          |                                                                   |
+| WNDSQ2   | .DTMMXGS  MXGS                                                    |
+|          |                                                                   |
+| PRSSQ1   | QMPR  PRES  PMSL  CHPT  3HPC                                      |
+|          |                                                                   |
+| PRSSQ2   | PRLC  GP10                                                        |
+|          |                                                                   |
+| PRSSQ3   | 24PC                                                              |
+|          |                                                                   |
+| PCPSQ1   | TP06  <PCPSQ2>  <PCPSQ3>                                          |
+|          |                                                                   |
+| PCPSQ2   | TP01  TP03  TP12  TP24                                            |
+|          |                                                                   |
+| PCPSQ3   | .DTHTOPC  TOPC                                                    |
+|          |                                                                   |
+| PPWSQ1   | PRWE  PSW1  PSW2                                                  |
+|          |                                                                   |
+| RPSEC3   | VTVI                                                              |
+|          |                                                                   |
+| CLDSQ2   | HOCT  CTDS                                                        |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MSST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MWBT     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| ITSO     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GP10     |    0 |      -10000 |  20 | (METERS/SECOND)**2       |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| INPC     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| HBLCS    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| QCEVR    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000007.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000007.bufr.table.txt
@@ -1,0 +1,222 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000007 | A63206 | MTYP 000-007 AVIATION - METAR / SPECI                    |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| MTRID    | 361011 | METAR REPORT ID DATA                                     |
+| MTAUTO   | 361012 | METAR REPORT AUTOMATED STATION DATA                      |
+| MTRWND   | 361014 | METAR WIND DATA                                          |
+| MTGUST   | 361015 | METAR GUST DATA                                          |
+| MTVWND   | 361016 | METAR VARIABLE WIND DATA                                 |
+| MTWSHF   | 361017 | METAR WIND SHIFT DATA                                    |
+| MTRTMP   | 361018 | METAR TEMPERATURE DATA                                   |
+| MTTPSQ   | 361019 | METAR MAXIMUM MINIMUM TEMPERATURE DATA                   |
+| MTRPRS   | 361020 | METAR PRESSURE DATA                                      |
+| MTRVSB   | 361021 | METAR VISIBILITY DATA                                    |
+| MTRWVR   | 361022 | METAR RUNWAY DATA                                        |
+| MTRPRW   | 361023 | METAR PRESENT WEATHER DATA                               |
+| MTRCLD   | 361024 | METAR CLOUD DATA                                         |
+| MTRPRC   | 361025 | METAR HYDROLOGICAL DATA                                  |
+| MTRPKW   | 361026 | METAR PEAK WIND DATA                                     |
+| MTTPCT   | 361027 | METAR CITY TEMPERATURE DATA                              |
+| MTRPR3   | 361028 | METAR 3, 6, 24 HOUR PRECIP DATA                          |
+| MTRMSC   | 361029 | METAR MISC HYDRO AND RADIANCE DATA                       |
+|          |        |                                                          |
+| ICLX     | 001062 | SHORT ICAO LOCATION INDICATOR                            |
+| RWID     | 001064 | RUNWAY IDENTIFIER                                        |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| THRPT    | 001199 | TYPE OF HOURLY REPORT                                    |
+| AUTO     | 002194 | AUTOMATED STATION TYPE                                   |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| WSHFTH   | 004212 | TIME OF OCCURENCE OF WIND SHIFT (HOURS)                  |
+| WSHFTM   | 004213 | TIME OF OCCURENCE OF WIND SHIFT (MINUTES)                |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| ALSE     | 010052 | ALTIMETER SETTING                                        |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DRC1     | 011016 | EXTREME CCW WIND DIRECTION OF VARIABLE WIND              |
+| DRC2     | 011017 | EXTREME CW WIND DIRECTION OF VARIABLE WIND               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| PKWDDR   | 011202 | PEAK WIND DIRECTION                                      |
+| PKWDSP   | 011203 | PEAK WIND SPEED                                          |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| CTTP     | 012193 | CITY TEMPERATURE                                         |
+| CTMX     | 012194 | CITY MAXIMUM TEMPERATURE                                 |
+| CTMN     | 012195 | CITY MINIMUM TEMPERATURE                                 |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| TOSS     | 014031 | TOTAL SUNSHINE                                           |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| RWYT     | 020018 | RUNWAY VISUAL RANGE TENDENCY                             |
+| V1RIM    | 020061 | FIRST RUNWAY VISUAL RANGE                                |
+| V2RIM    | 020193 | SECOND RUNWAY VISUAL RANGE                               |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| SEST     | 022061 | STATE OF THE SEA                                         |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000007 | YYMMDD  HHMM  {BID}  MTRID  {RCPTIM}  MTRWND  MTRTMP  MTRPRS      |
+| NC000007 | MTRVSB  {MTRPRW}  {MTRCLD}  MTRPRC  {RAWRPT}  MTRPKW  SST1  SEST  |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| MTRID    | RPID  ICLX  CLAT  CLON  SELV  CORN  THRPT  <MTAUTO>               |
+|          |                                                                   |
+| MTAUTO   | AUTO                                                              |
+|          |                                                                   |
+| MTRWND   | QMWN  WDIR  WSPD  <MTGUST>  <MTVWND>  <MTWSHF>                    |
+|          |                                                                   |
+| MTGUST   | .DTMMXGS  MXGS                                                    |
+|          |                                                                   |
+| MTVWND   | DRC1  DRC2                                                        |
+|          |                                                                   |
+| MTWSHF   | WSHFTH  WSHFTM                                                    |
+|          |                                                                   |
+| MTRTMP   | QMAT  TMDB  QMDD  TMDP  {MTTPSQ}  <MTTPCT>                        |
+|          |                                                                   |
+| MTTPSQ   | .DTHMXTM  MXTM  .DTHMITM  MITM                                    |
+|          |                                                                   |
+| MTRPRS   | ALSE  QMPR  PMSL  CHPT  3HPC                                      |
+|          |                                                                   |
+| MTRVSB   | .REHOVI  HOVI  VTVI  {MTRWVR}                                     |
+|          |                                                                   |
+| MTRWVR   | RWID  .REV1RI  V1RIM  .REV2RI  V2RIM  RWYT                        |
+|          |                                                                   |
+| MTRPRW   | PRWE                                                              |
+|          |                                                                   |
+| MTRCLD   | VSSO  CLAM  CLTP  HOCB                                            |
+|          |                                                                   |
+| MTRPRC   | TP01  <MTRPR3>  <MTRMSC>                                          |
+|          |                                                                   |
+| MTRPKW   | YYMMDD  HHMM  PKWDDR  PKWDSP                                      |
+|          |                                                                   |
+| MTTPCT   | CTTP  CTMX  CTMN                                                  |
+|          |                                                                   |
+| MTRPR3   | TP03  TP06  TP24                                                  |
+|          |                                                                   |
+| MTRMSC   | TOSD  DOFS  TOPC  TOSS                                            |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ICLX     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RWID     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| THRPT    |    0 |           0 |   2 | CODE TABLE               |-------------|
+| AUTO     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| WSHFTH   |    0 |           0 |   5 | HOUR                     |-------------|
+| WSHFTM   |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| ALSE     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DRC1     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| DRC2     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| PKWDDR   |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| PKWDSP   |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTTP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMX     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMN     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TOSS     |    0 |           0 |  11 | MINUTE                   |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| RWYT     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| V1RIM    |    0 |           0 |  12 | METERS                   |-------------|
+| V2RIM    |    0 |           0 |  12 | METERS                   |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| SEST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000010.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000010.bufr.table.txt
@@ -1,0 +1,280 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000010 | A56100 | MTYP 000-010 PRODUCTS (SHEF) NOT IN ANY OTHER TANK       |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| SHTPMOSQ | 356101 | SHEF TIME PERIOD SEQUENCE (MONTHS)                       |
+| SHTPHRSQ | 356102 | SHEF TIME PERIOD SEQUENCE (HOURS)                        |
+| SHTPMISQ | 356103 | SHEF TIME PERIOD SEQUENCE (MINUTES)                      |
+| SHPRESSQ | 356104 | SHEF PRESSURE SEQUENCE                                   |
+| SHPMSLSQ | 356105 | SHEF PRESSURE (MSL) SEQUENCE                             |
+| SHTOPCSQ | 356106 | SHEF TOTAL PRECIPITATION SEQUENCE                        |
+| SHPRTPSQ | 356107 | SHEF TYPE OF PRECIPITATION SEQUENCE                      |
+| SHDOFSSQ | 356108 | SHEF DEPTH OF FRESH SNOW SEQUENCE                        |
+| SHTOSDSQ | 356109 | SHEF TOTAL SNOW DEPTH SEQUENCE                           |
+| SHSWEMSQ | 356110 | SHEF SNOW WATER EQUIVALENT SEQUENCE                      |
+| SHTMDBSQ | 356111 | SHEF TEMPERATURE SEQUENCE                                |
+| SHMXTMSQ | 356112 | SHEF MAXIMUM TEMPERATURE SEQUENCE                        |
+| SHMITMSQ | 356113 | SHEF MINIMUM TEMPERATURE SEQUENCE                        |
+| SHWATMSQ | 356114 | SHEF WATER TEMPERATURE SEQUENCE                          |
+| SHTMWBSQ | 356115 | SHEF WET BULB TEMPERATURE SEQUENCE                       |
+| SHREHUSQ | 356116 | SHEF RELATIVE HUMIDITY SEQUENCE                          |
+| SHMXRHSQ | 356117 | SHEF MAXIMUM RELATIVE HUMIDITY SEQUENCE                  |
+| SHMIRHSQ | 356118 | SHEF MINIMUM RELATIVE HUMIDITY SEQUENCE                  |
+| SHTMDPSQ | 356119 | SHEF DEW POINT TEMPERATURE SEQUENCE                      |
+| SHWDIRSQ | 356120 | SHEF WIND DIRECTION SEQUENCE                             |
+| SHWSPDSQ | 356121 | SHEF WIND SPEED SEQUENCE                                 |
+| SHMXGSSQ | 356122 | SHEF WIND SPEED (GUSTS) SEQUENCE                         |
+| SHPKWDSQ | 356123 | SHEF PEAK WIND DIRECTION SEQUENCE                        |
+| SHPKWSSQ | 356124 | SHEF PEAK WIND SPEED SEQUENCE                            |
+| SHPRWESQ | 356125 | SHEF PRESENT WEATHER SEQUENCE                            |
+| SHPSW1SQ | 356126 | SHEF PAST WEATHER (1) SEQUENCE                           |
+| SHCLAMSQ | 356127 | SHEF CLOUD AMOUNT SEQUENCE                               |
+| SHHOVISQ | 356128 | SHEF HORIZONTAL VISIBILITY SEQUENCE                      |
+| SHALBDSQ | 356129 | SHEF ALBEDO SEQUENCE                                     |
+| SHTOSHSQ | 356130 | SHEF TOTAL SUNSHINE SEQUENCE                             |
+| SHSOGRSQ | 356131 | SHEF STATE OF THE GROUND SEQUENCE                        |
+| SHRSHMSQ | 356132 | SHEF RIVER STAGE HEIGHT SEQUENCE                         |
+| SHSTM1SQ | 356133 | SHEF SOIL TEMPERATURE (DEPTH #1) SEQUENCE                |
+| SHSTM2SQ | 356134 | SHEF SOIL TEMPERATURE (DEPTH #2) SEQUENCE                |
+| SHXST1SQ | 356135 | SHEF MAXIMUM SOIL TEMPERATURE (DEPTH #1) SEQUENCE        |
+| SHXST2SQ | 356136 | SHEF MAXIMUM SOIL TEMPERATURE (DEPTH #2) SEQUENCE        |
+| SHIST1SQ | 356137 | SHEF MINIMUM SOIL TEMPERATURE (DEPTH #1) SEQUENCE        |
+| SHIST2SQ | 356138 | SHEF MINIMUM SOIL TEMPERATURE (DEPTH #2) SEQUENCE        |
+| SHWACNSQ | 356139 | SHEF WATER CONDUCTIVITY SEQUENCE                         |
+| SHTLLWSQ | 356140 | SHEF TIDE HEIGHT SEQUENCE                                |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+|          |        |                                                          |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| TPMO     | 004022 | TIME PERIOD OR DISPLACEMENT                              |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| HSMSL    | 007030 | HEIGHT OF STATION GROUND ABOVE MSL                       |
+| DBLS     | 007061 | DEPTH BELOW LAND SURFACE                                 |
+| RSHM     | 007198 | RIVER STAGE HEIGHT                                       |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| PKWDDR   | 011202 | PEAK WIND DIRECTION                                      |
+| PKWDSP   | 011203 | PEAK WIND SPEED                                          |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| STEMH    | 012130 | SOIL TEMPERATURE                                         |
+| MISTH    | 012212 | MINIMUM SOIL TEMPERATURE                                 |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| MIRH     | 013007 | MINIMUM RELATIVE HUMIDITY                                |
+| MXRH     | 013008 | MAXIMUM RELATIVE HUMIDITY                                |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| WACN     | 013081 | WATER CONDUCTIVITY                                       |
+| WATM     | 013082 | WATER TEMPERATURE                                        |
+| SWEM     | 013210 | SNOW WATER EQUIVALENT                                    |
+| ALBD     | 014027 | ALBEDO                                                   |
+| TOSH     | 014032 | TOTAL SUNSHINE                                           |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| PRTP     | 020021 | TYPE OF PRECIPITATION                                    |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| TLLW     | 022226 | TIDE ELEV. WITH RESPECT TO MEAN LOWER LOW WATER          |
+| SHRV     | 033230 | SHEF DATA REVISION FLAG                                  |
+| SHQL     | 033231 | SHEF DATA QUALIFIER FLAG                                 |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000010 | YYMMDD  HHMM  <SHTPMOSQ>  <SHTPHRSQ>  <SHTPMISQ>  BID  RCPTIM     |
+| NC000010 | RPID  CLAT  CLON  HSMSL  <SHPRESSQ>  <SHPMSLSQ>  <SHTOPCSQ>       |
+| NC000010 | <SHPRTPSQ>  <SHDOFSSQ>  <SHTOSDSQ>  <SHSWEMSQ>  <SHTMDBSQ>        |
+| NC000010 | <SHMXTMSQ>  <SHMITMSQ>  <SHWATMSQ>  <SHTMWBSQ>  <SHREHUSQ>        |
+| NC000010 | <SHMXRHSQ>  <SHMIRHSQ>  <SHTMDPSQ>  <SHWACNSQ>  <SHWDIRSQ>        |
+| NC000010 | <SHWSPDSQ>  <SHMXGSSQ>  <SHPKWDSQ>  <SHPKWSSQ>  <SHPRWESQ>        |
+| NC000010 | <SHPSW1SQ>  <SHCLAMSQ>  <SHHOVISQ>  <SHALBDSQ>  <SHTOSHSQ>        |
+| NC000010 | <SHSOGRSQ>  <SHRSHMSQ>  <SHTLLWSQ>  <SHSTM1SQ>  <SHSTM2SQ>        |
+| NC000010 | <SHXST1SQ>  <SHXST2SQ>  <SHIST1SQ>  <SHIST2SQ>                    |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| SHTPMOSQ | TPMO                                                              |
+|          |                                                                   |
+| SHTPHRSQ | TPHR                                                              |
+|          |                                                                   |
+| SHTPMISQ | TPMI                                                              |
+|          |                                                                   |
+| SHPRESSQ | PRES  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPMSLSQ | PMSL  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOPCSQ | TOPC  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPRTPSQ | PRTP  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHDOFSSQ | DOFS  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOSDSQ | TOSD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSWEMSQ | SWEM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMDBSQ | TMDB  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXTMSQ | MXTM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMITMSQ | MITM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWATMSQ | WATM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMWBSQ | TMWB  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHREHUSQ | REHU  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXRHSQ | MXRH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMIRHSQ | MIRH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMDPSQ | TMDP  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWDIRSQ | WDIR  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWSPDSQ | WSPD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXGSSQ | MXGS  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPKWDSQ | PKWDDR  SHRV  SHQL                                                |
+|          |                                                                   |
+| SHPKWSSQ | PKWDSP  SHRV  SHQL                                                |
+|          |                                                                   |
+| SHPRWESQ | PRWE  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPSW1SQ | PSW1  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHCLAMSQ | CLAM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHHOVISQ | HOVI  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHALBDSQ | ALBD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOSHSQ | TOSH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSOGRSQ | SOGR  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHRSHMSQ | RSHM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSTM1SQ | DBLS  STEMH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHSTM2SQ | DBLS  STEMH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHXST1SQ | DBLS  MXSTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHXST2SQ | DBLS  MXSTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHIST1SQ | DBLS  MISTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHIST2SQ | DBLS  MISTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHWACNSQ | 207001  WACN  207000  SHRV  SHQL                                  |
+|          |                                                                   |
+| SHTLLWSQ | TLLW  SHRV  SHQL                                                  |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| TPMO     |    0 |       -1024 |  11 | MONTH                    |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| HSMSL    |    1 |       -4000 |  17 | METERS                   |-------------|
+| DBLS     |    2 |           0 |  14 | METERS                   |-------------|
+| RSHM     |    3 |           0 |  15 | METERS                   |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| PKWDDR   |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| PKWDSP   |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| STEMH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MISTH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| MIRH     |    0 |           0 |   7 | %                        |-------------|
+| MXRH     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| WACN     |    3 |           0 |  14 | SIEMENS/M                |-------------|
+| WATM     |    1 |           0 |  12 | DEGREES KELVIN           |-------------|
+| SWEM     |    2 |           0 |  18 | KG/METER**2              |-------------|
+| ALBD     |    0 |           0 |   7 | %                        |-------------|
+| TOSH     |    0 |           0 |  10 | HOUR                     |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| PRTP     |    0 |           0 |  30 | FLAG TABLE               |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TLLW     |    3 |       -9999 |  15 | METERS                   |-------------|
+| SHRV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| SHQL     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000011.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000011.bufr.table.txt
@@ -1,0 +1,407 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000011 | A63214 | MTYP 000-011 AFOS PRODUCTS (PRECIP) (SHEF)               |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| SHEFID   | 362091 | SHEF REPORT ID DATA                                      |
+| SHEFPRC  | 362092 | SHEF PRECIP DATA                                         |
+| SHEFTPA  | 362093 | SHEF MAXIMUM MINIMUM AIR TEMPERATURE DATA                |
+| SHEFSNW  | 362094 | SHEF SNOW DATA                                           |
+| SHEFSOG  | 362095 | SHEF STATE OF THE GROUND                                 |
+| SHEFP01  | 362096 | SHEF PRECIP DATA FOR  1 HOUR                             |
+| SHEFP03  | 362097 | SHEF PRECIP DATA FOR  3 HOURS                            |
+| SHEFP06  | 362098 | SHEF PRECIP DATA FOR  6 HOURS                            |
+| SHEFP12  | 362099 | SHEF PRECIP DATA FOR 12 HOURS                            |
+| SHEFP24  | 362100 | SHEF PRECIP DATA FOR 24 HOURS                            |
+| SHEFTPX  | 362111 | SHEF MAX AIR TEMPERATURE DATA                            |
+| SHEFTPN  | 362112 | SHEF MIN AIR TEMPERATURE DATA                            |
+| SHEFSDP  | 362113 | SHEF SNOW DEPTH ON GROUND DATA                           |
+| SHEFSWE  | 362114 | SHEF SNOW WATER EQUIVALENT DATA                          |
+| SHEFSFL  | 362115 | SHEF SNOW FALL DATA                                      |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+|          |        |                                                          |
+| WMOB     | 001001 | WMO BLOCK NUMBER                                         |
+| WMOS     | 001002 | WMO STATION NUMBER                                       |
+| WMOR     | 001003 | WMO REGION NUMBER/GEOGRAPHICAL AREA                      |
+| SMID     | 001011 | SHIP OR MOBILE LAND STATION IDENTIFIER                   |
+| STSN     | 001015 | STATION OR SITE NAME                                     |
+| SSTN     | 001018 | SHORT STATION NAME                                       |
+| ICLX     | 001062 | SHORT ICAO LOCATION INDICATOR                            |
+| RWID     | 001064 | RUNWAY IDENTIFIER                                        |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| THRPT    | 001199 | TYPE OF HOURLY REPORT                                    |
+| WEPRV    | 001220 | WIND ENERGY PROVIDER                                     |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MSST     | 002038 | METHOD OF SEA SURFACE TEMPERATURE MEASUREMENT            |
+| MWBT     | 002039 | METHOD OF WET BULB TEMPERATURE MEASUREMENT               |
+| MOPM     | 002175 | METHOD OF PRECIPITATION MEASUREMENT                      |
+| MSGM     | 002176 | METHOD OF STATE OF GROUND MEASUREMENT                    |
+| MODM     | 002177 | METHOD OF SNOW DEPTH MEASUREMENT                         |
+| MLMP     | 002178 | METHOD OF LIQUID CONTENT MEASUREMENT OF PRECIPITATION    |
+| ITSO     | 002193 | IND TYPE OF STN OPERATION PAST/P                         |
+| AUTO     | 002194 | AUTOMATED STATION TYPE                                   |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| SECO     | 004006 | SECOND                                                   |
+| TPMO     | 004022 | TIME PERIOD OR DISPLACEMENT                              |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| TPSE     | 004026 | TIME PERIOD OR DISPLACEMENT                              |
+| .DTH.... | 004031 | DUR OF TIME IN HOURS RELATED TO FOLLOWING VALUE          |
+| .DTM.... | 004032 | DUR OF TIME IN MINS RELATED TO FOLLOWING VALUE           |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| WSHFTH   | 004212 | TIME OF OCCURENCE OF WIND SHIFT (HOURS)                  |
+| WSHFTM   | 004213 | TIME OF OCCURENCE OF WIND SHIFT (MINUTES)                |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| PRLC     | 007004 | PRESSURE                                                 |
+| HSMSL    | 007030 | HEIGHT OF STATION GROUND ABOVE MSL                       |
+| HBMSL    | 007031 | HEIGHT OF BAROMETER ABOVE MEAN SEA LEVEL                 |
+| HSALG    | 007032 | HEIGHT OF SENSOR ABOVE LOCAL GROUND                      |
+| HSAWS    | 007033 | HEIGHT OF SENSOR ABOVE WATER SURFACE                     |
+| DBLS     | 007061 | DEPTH BELOW LAND SURFACE                                 |
+| RSHM     | 007198 | RIVER STAGE HEIGHT                                       |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| TSIG     | 008021 | TIME SIGNIFICANCE                                        |
+| .RE....  | 008201 | RELATIONSHIP TO THE FOLLOWING VALUE                      |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GP10     | 010008 | GEOPOTENTIAL                                             |
+| GPH10    | 010009 | GEOPOTENTIAL HEIGHT                                      |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| ALSE     | 010052 | ALTIMETER SETTING                                        |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DRC1     | 011016 | EXTREME CCW WIND DIRECTION OF VARIABLE WIND              |
+| DRC2     | 011017 | EXTREME CW WIND DIRECTION OF VARIABLE WIND               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| MXGD     | 011043 | MAXIMUM WIND GUST DIRECTION                              |
+| SDWD     | 011049 | STANDARD DEVIATION OF WIND DIRECTION                     |
+| SDHS     | 011050 | STANDARD DEVIATION OF HORIZONTAL WIND SPEED              |
+| PKWDDR   | 011202 | PEAK WIND DIRECTION                                      |
+| PKWDSP   | 011203 | PEAK WIND SPEED                                          |
+| WDRC     | 011227 | CONTINUOUS WIND DIRECTION IN DEGREES                     |
+| WDSC     | 011228 | CONTINUOUS WIND SPEED IN M/SEC                           |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| GMITH    | 012113 | GROUND MINIMUM TEMPERATURE, PAST 12 HOURS                |
+| STEMH    | 012130 | SOIL TEMPERATURE                                         |
+| CTTP     | 012193 | CITY TEMPERATURE                                         |
+| CTMX     | 012194 | CITY MAXIMUM TEMPERATURE                                 |
+| CTMN     | 012195 | CITY MINIMUM TEMPERATURE                                 |
+| MXSTH    | 012211 | MAXIMUM SOIL TEMPERATURE                                 |
+| MISTH    | 012212 | MINIMUM SOIL TEMPERATURE                                 |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| MIRH     | 013007 | MINIMUM RELATIVE HUMIDITY                                |
+| MXRH     | 013008 | MAXIMUM RELATIVE HUMIDITY                                |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| REQV     | 013014 | RAINFALL/WATER EQUIVALENT OF SNOW (AVERAGED RATE)        |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| WACN     | 013081 | WATER CONDUCTIVITY                                       |
+| WATM     | 013082 | WATER TEMPERATURE                                        |
+| INPC     | 013194 | INDIC INCLUSION/OMISSION OF PREC                         |
+| SWEM     | 013210 | SNOW WATER EQUIVALENT                                    |
+| CTP24    | 013227 | CITY TOTAL PRECIPITATION PAST 24 HOURS                   |
+| ALBD     | 014027 | ALBEDO                                                   |
+| TOSS     | 014031 | TOTAL SUNSHINE                                           |
+| TOSH     | 014032 | TOTAL SUNSHINE                                           |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| RWYT     | 020018 | RUNWAY VISUAL RANGE TENDENCY                             |
+| PRTP     | 020021 | TYPE OF PRECIPITATION                                    |
+| IDTH     | 020031 | ICE DEPOSIT (THICKNESS)                                  |
+| ROIA     | 020032 | RATE OF ICE ACCRETION                                    |
+| COIA     | 020033 | CAUSE OF ICE ACCRETION                                   |
+| TDCM     | 020054 | TRUE DIRECTION FROM WHICH CLOUDS ARE MOVING              |
+| V1RIM    | 020061 | FIRST RUNWAY VISUAL RANGE                                |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| V2RIM    | 020193 | SECOND RUNWAY VISUAL RANGE                               |
+| HBLCS    | 020201 | HEIGHT ABOVE SURFACE OF BASE OF LOWEST CLOUD SEEN        |
+| DOSW     | 022003 | DIRECTION OF SWELL WAVES                                 |
+| POWV     | 022011 | PERIOD OF WAVES                                          |
+| POWW     | 022012 | PERIOD OF WIND WAVES                                     |
+| POSW     | 022013 | PERIOD OF SWELL WAVES                                    |
+| HOWV     | 022021 | HEIGHT OF WAVES                                          |
+| HOWW     | 022022 | HEIGHT OF WIND WAVES                                     |
+| HOSW     | 022023 | HEIGHT OF SWELL WAVES                                    |
+| TERC     | 022038 | TIDAL ELEV WITH RESPECT TO CHART                         |
+| TIDER    | 022040 | METEORLOGICAL RESIDUAL TIDAL EVLEVATION                  |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| SEST     | 022061 | STATE OF THE SEA                                         |
+| TLLW     | 022226 | TIDE ELEV. WITH RESPECT TO MEAN LOWER LOW WATER          |
+| IMSI     | 033006 | INTERNAL MEASUREMENT STATUS INFORMATION (AWS)            |
+| QCEVR    | 033024 | STATION ELEVATION QUALITY MARK (FOR MOBIL STATIONS)      |
+| AOFV     | 033041 | ATTRIBUTE OF FOLLOWING VALUE                             |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMST     | 033218 | SDMEDIT QUALITY MARK FOR SEA SURFACE TEMPERATURE         |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| SHRV     | 033230 | SHEF DATA REVISION FLAG                                  |
+| SHQL     | 033231 | SHEF DATA QUALIFIER FLAG                                 |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000011 | YYMMDD  HHMM  SHEFID  <SHEFPRC>  <SHEFTPA>  <SHEFSNW>  <SHEFSOG>  |
+| NC000011 | BID                                                               |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| SHEFID   | RPID  CLAT  CLON                                                  |
+|          |                                                                   |
+| SHEFPRC  | <SHEFP01>  <SHEFP03>  <SHEFP06>  <SHEFP12>  <SHEFP24>             |
+|          |                                                                   |
+| SHEFTPA  | <SHEFTPX>  <SHEFTPN>                                              |
+|          |                                                                   |
+| SHEFSNW  | <SHEFSDP>  <SHEFSWE>  <SHEFSFL>                                   |
+|          |                                                                   |
+| SHEFSOG  | SOGR                                                              |
+|          |                                                                   |
+| SHEFP01  | TP01                                                              |
+|          |                                                                   |
+| SHEFP03  | TP03                                                              |
+|          |                                                                   |
+| SHEFP06  | TP06                                                              |
+|          |                                                                   |
+| SHEFP12  | TP12                                                              |
+|          |                                                                   |
+| SHEFP24  | TP24                                                              |
+|          |                                                                   |
+| SHEFTPX  | .DTHMXTM  MXTM                                                    |
+|          |                                                                   |
+| SHEFTPN  | .DTHMITM  MITM                                                    |
+|          |                                                                   |
+| SHEFSDP  | TOSD                                                              |
+|          |                                                                   |
+| SHEFSWE  | TOPC                                                              |
+|          |                                                                   |
+| SHEFSFL  | DOFS                                                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| WMOB     |    0 |           0 |   7 | NUMERIC                  |-------------|
+| WMOS     |    0 |           0 |  10 | NUMERIC                  |-------------|
+| WMOR     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| SMID     |    0 |           0 |  72 | CCITT IA5                |-------------|
+| STSN     |    0 |           0 | 160 | CCITT IA5                |-------------|
+| SSTN     |    0 |           0 |  40 | CCITT IA5                |-------------|
+| ICLX     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RWID     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| THRPT    |    0 |           0 |   2 | CODE TABLE               |-------------|
+| WEPRV    |    0 |           0 | 128 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MSST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MWBT     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| MOPM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MSGM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MODM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MLMP     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| ITSO     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| AUTO     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| TPMO     |    0 |       -1024 |  11 | MONTH                    |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| TPSE     |    0 |       -4096 |  13 | SECONDS                  |-------------|
+| .DTH.... |    0 |           0 |   8 | HOUR                     |-------------|
+| .DTM.... |    0 |           0 |   6 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| WSHFTH   |    0 |           0 |   5 | HOUR                     |-------------|
+| WSHFTM   |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE(N+,S-)            |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE(E+,W-)            |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| HSMSL    |    1 |       -4000 |  17 | METERS                   |-------------|
+| HBMSL    |    1 |       -4000 |  17 | M                        |-------------|
+| HSALG    |    2 |           0 |  16 | M                        |-------------|
+| HSAWS    |    1 |           0 |  12 | M                        |-------------|
+| DBLS     |    2 |           0 |  14 | METERS                   |-------------|
+| RSHM     |    3 |           0 |  15 | METERS                   |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| .RE....  |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GP10     |    0 |      -10000 |  20 | (METERS/SECOND)**2       |-------------|
+| GPH10    |    0 |       -1000 |  17 | GPM                      |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| ALSE     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DRC1     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| DRC2     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGD     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| SDWD     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| SDHS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| PKWDDR   |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| PKWDSP   |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| WDRC     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WDSC     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| GMITH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| STEMH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTTP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMX     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| CTMN     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXSTH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MISTH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| MIRH     |    0 |           0 |   7 | %                        |-------------|
+| MXRH     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| REQV     |    4 |           0 |  12 | KG M**-2 S**-1           |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| WACN     |    3 |           0 |  14 | SIEMENS/M                |-------------|
+| WATM     |    1 |           0 |  12 | DEGREES KELVIN           |-------------|
+| INPC     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| SWEM     |    2 |           0 |  18 | KG/METER**2              |-------------|
+| CTP24    |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| ALBD     |    0 |           0 |   7 | %                        |-------------|
+| TOSS     |    0 |           0 |  11 | MINUTE                   |-------------|
+| TOSH     |    0 |           0 |  10 | HOUR                     |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| RWYT     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| PRTP     |    0 |           0 |  30 | FLAG TABLE               |-------------|
+| IDTH     |    2 |           0 |   7 | METERS                   |-------------|
+| ROIA     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| COIA     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| TDCM     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| V1RIM    |    0 |           0 |  12 | METERS                   |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| V2RIM    |    0 |           0 |  12 | METERS                   |-------------|
+| HBLCS    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| DOSW     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| POWV     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POWW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| POSW     |    0 |           0 |   6 | SECONDS                  |-------------|
+| HOWV     |    1 |           0 |  10 | METERS                   |-------------|
+| HOWW     |    1 |           0 |  10 | METERS                   |-------------|
+| HOSW     |    1 |           0 |  10 | METERS                   |-------------|
+| TERC     |    3 |      -10000 |  15 | METERS                   |-------------|
+| TIDER    |    3 |       -5000 |  14 | METERS                   |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| SEST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TLLW     |    3 |       -9999 |  15 | METERS                   |-------------|
+| IMSI     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| QCEVR    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| AOFV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| SHRV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| SHQL     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000100.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000100.bufr.table.txt
@@ -1,0 +1,257 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000100 | A51050 | MTYP 000-100 SYNOPTIC - FIXED LAND (BUFR) (WMO RES 40)   |
+|          |        |                                                          |
+| SFCSTNID | 301004 | SURFACE STATION IDENTIFICATION                           |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LTLONH   | 301021 | LOCATION -- LATITUDE, LONGITUDE (HIGH ACCURACY)          |
+| SFIDTIME | 301090 | SURFACE STATION IDENTIFICATION, TIME AND LOCATION        |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| PRESSQ03 | 302001 |                                                          |
+| GENCLOUD | 302004 | GENERAL CLOUD INFORMATION                                |
+| PRESDATA | 302031 | PRESSURE INFORMATION                                     |
+| PWEATHER | 302038 | PRESENT AND PAST WEATHER                                 |
+| DIRCLDFT | 302047 | DIRECTION OF CLOUD DRIFT                                 |
+| VISBSEQN | 302069 | VISIBILITY DATA                                          |
+| TEMHUMDA | 302072 | TEMPERATURE AND HUMIDITY DATA                            |
+| STGDSNDM | 302078 | STATE OF GROUND AND SNOW DEPTH MEASUREMENT               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| BSYWND1  | 361066 | SYNOPTIC REPORT WIND DATA 1 (BUFR)                       |
+| BSYWND2  | 361067 | SYNOPTIC REPORT WIND DATA 2 (BUFR)                       |
+| BSYPCP1  | 361068 | SYNOPTIC REPORT PRECIPITATION DATA 1 (BUFR)              |
+| BSYPCP2  | 361069 | SYNOPTIC REPORT PRECIPITATION DATA 2 (BUFR)              |
+| BSYEXTM  | 361070 | SYNOPTIC REPORT EXTREME TEMPERATURE DATA (BUFR)          |
+| BSYSCLD  | 361071 | SYNOPTIC REPORT SUPPLEMENTAL CLOUD LAYER DATA (BUFR)     |
+| BSYBCLD  | 361072 | SYNOPTIC REPORT CLOUD BASES BELOW STN LEVEL DATA (BUFR)  |
+| BSYDCLD  | 361073 | SYNOPTIC REPORT CLOUD DRIFT DATA (BUFR)                  |
+|          |        |                                                          |
+| WMOB     | 001001 | WMO BLOCK NUMBER                                         |
+| WMOS     | 001002 | WMO STATION NUMBER                                       |
+| STSN     | 001015 | STATION OR SITE NAME                                     |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MOPM     | 002175 | METHOD OF PRECIPITATION MEASUREMENT                      |
+| MSGM     | 002176 | METHOD OF STATE OF GROUND MEASUREMENT                    |
+| MODM     | 002177 | METHOD OF SNOW DEPTH MEASUREMENT                         |
+| MLMP     | 002178 | METHOD OF LIQUID CONTENT MEASUREMENT OF PRECIPITATION    |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| PRLC     | 007004 | PRESSURE                                                 |
+| HSMSL    | 007030 | HEIGHT OF STATION GROUND ABOVE MSL                       |
+| HBMSL    | 007031 | HEIGHT OF BAROMETER ABOVE MEAN SEA LEVEL                 |
+| HSALG    | 007032 | HEIGHT OF SENSOR ABOVE LOCAL GROUND                      |
+| HSAWS    | 007033 | HEIGHT OF SENSOR ABOVE WATER SURFACE                     |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| TSIG     | 008021 | TIME SIGNIFICANCE                                        |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GPH10    | 010009 | GEOPOTENTIAL HEIGHT                                      |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| MXGD     | 011043 | MAXIMUM WIND GUST DIRECTION                              |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| GMITH    | 012113 | GROUND MINIMUM TEMPERATURE, PAST 12 HOURS                |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| TDCM     | 020054 | TRUE DIRECTION FROM WHICH CLOUDS ARE MOVING              |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| AOFV     | 033041 | ATTRIBUTE OF FOLLOWING VALUE                             |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000100 | SFIDTIME  WIGOSID  RPID  PRESDATA  QMPR  TEMHUMDA  QMAT  QMDD     |
+| NC000100 | <BSYEXTM>  VISBSEQN  BSYWND1  QMWN  {BSYWND2}  TPMI  BSYPCP1      |
+| NC000100 | {BSYPCP2}  HSALG  HSAWS  GENCLOUD  {BSYSCLD}  {BSYBCLD}           |
+| NC000100 | <DIRCLDFT>  VSSO  <PWEATHER>  <STGDSNDM>  GMITH  BID  RCPTIM      |
+| NC000100 | CORN  RSRD  EXPRSRD                                               |
+|          |                                                                   |
+| SFCSTNID | WMOB  WMOS  STSN  TOST                                            |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| SFIDTIME | SFCSTNID  YYMMDD  HHMM  LTLONH  HSMSL  HBMSL                      |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| PRESSQ03 | PRES  PMSL  3HPC  CHPT                                            |
+|          |                                                                   |
+| GENCLOUD | TOCC  VSSO  CLAM  HOCB  CLTP  CLTP  CLTP                          |
+|          |                                                                   |
+| PRESDATA | PRESSQ03  24PC  PRLC  GPH10                                       |
+|          |                                                                   |
+| PWEATHER | PRWE  TPHR  PSW1  PSW2                                            |
+|          |                                                                   |
+| DIRCLDFT | "BSYDCLD"3                                                        |
+|          |                                                                   |
+| VISBSEQN | HSALG  HSAWS  AOFV  HOVI                                          |
+|          |                                                                   |
+| TEMHUMDA | HSALG  HSAWS  TMDB  TMDP  REHU                                    |
+|          |                                                                   |
+| STGDSNDM | MSGM  SOGR  MODM  TOSD                                            |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| BSYWND1  | HSALG  HSAWS  TIWM  TSIG  TPMI  WDIR  WSPD  TSIG                  |
+|          |                                                                   |
+| BSYWND2  | TPMI  MXGD  MXGS                                                  |
+|          |                                                                   |
+| BSYPCP1  | HSALG  HSAWS  MOPM  MLMP                                          |
+|          |                                                                   |
+| BSYPCP2  | TPHR  TOPC                                                        |
+|          |                                                                   |
+| BSYEXTM  | HSALG  HSAWS  TPHR  TPHR  MXTM  TPHR  TPHR  MITM  HSALG  HSAWS    |
+| BSYEXTM  | TPMI  MITM                                                        |
+|          |                                                                   |
+| BSYSCLD  | VSSO  CLAM  CLTP  AOFV  HOCB                                      |
+|          |                                                                   |
+| BSYBCLD  | VSSO  CLAM  CLTP  HOCT  CTDS                                      |
+|          |                                                                   |
+| BSYDCLD  | VSSO  TDCM                                                        |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| WMOB     |    0 |           0 |   7 | NUMERIC                  |-------------|
+| WMOS     |    0 |           0 |  10 | NUMERIC                  |-------------|
+| STSN     |    0 |           0 | 160 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MOPM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MSGM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MODM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MLMP     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE(N+,S-)            |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE(E+,W-)            |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| HSMSL    |    1 |       -4000 |  17 | METERS                   |-------------|
+| HBMSL    |    1 |       -4000 |  17 | M                        |-------------|
+| HSALG    |    2 |           0 |  16 | M                        |-------------|
+| HSAWS    |    1 |           0 |  12 | M                        |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GPH10    |    0 |       -1000 |  17 | GPM                      |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGD     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| GMITH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TDCM     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| AOFV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000101.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000101.bufr.table.txt
@@ -1,0 +1,252 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+| NC000101 | A51051 | MTYP 000-101 SYNOPTIC - FIXED LAND (BUFR)                |
+|          |        |                                                          |
+| SFCSTNID | 301004 | SURFACE STATION IDENTIFICATION                           |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LTLONH   | 301021 | LOCATION -- LATITUDE, LONGITUDE (HIGH ACCURACY)          |
+| SFIDTIME | 301090 | SURFACE STATION IDENTIFICATION, TIME AND LOCATION        |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| PRESSQ03 | 302001 |                                                          |
+| GENCLOUD | 302004 | GENERAL CLOUD INFORMATION                                |
+| PRESDATA | 302031 | PRESSURE INFORMATION                                     |
+| PWEATHER | 302038 | PRESENT AND PAST WEATHER                                 |
+| DIRCLDFT | 302047 | DIRECTION OF CLOUD DRIFT                                 |
+| VISBSEQN | 302069 | VISIBILITY DATA                                          |
+| TEMHUMDA | 302072 | TEMPERATURE AND HUMIDITY DATA                            |
+| STGDSNDM | 302078 | STATE OF GROUND AND SNOW DEPTH MEASUREMENT               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| BSYWND1  | 361066 | SYNOPTIC REPORT WIND DATA 1 (BUFR)                       |
+| BSYWND2  | 361067 | SYNOPTIC REPORT WIND DATA 2 (BUFR)                       |
+| BSYPCP1  | 361068 | SYNOPTIC REPORT PRECIPITATION DATA 1 (BUFR)              |
+| BSYPCP2  | 361069 | SYNOPTIC REPORT PRECIPITATION DATA 2 (BUFR)              |
+| BSYEXTM  | 361070 | SYNOPTIC REPORT EXTREME TEMPERATURE DATA (BUFR)          |
+| BSYSCLD  | 361071 | SYNOPTIC REPORT SUPPLEMENTAL CLOUD LAYER DATA (BUFR)     |
+| BSYBCLD  | 361072 | SYNOPTIC REPORT CLOUD BASES BELOW STN LEVEL DATA (BUFR)  |
+| BSYDCLD  | 361073 | SYNOPTIC REPORT CLOUD DRIFT DATA (BUFR)                  |
+|          |        |                                                          |
+| WMOB     | 001001 | WMO BLOCK NUMBER                                         |
+| WMOS     | 001002 | WMO STATION NUMBER                                       |
+| STSN     | 001015 | STATION OR SITE NAME                                     |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MOPM     | 002175 | METHOD OF PRECIPITATION MEASUREMENT                      |
+| MSGM     | 002176 | METHOD OF STATE OF GROUND MEASUREMENT                    |
+| MODM     | 002177 | METHOD OF SNOW DEPTH MEASUREMENT                         |
+| MLMP     | 002178 | METHOD OF LIQUID CONTENT MEASUREMENT OF PRECIPITATION    |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| PRLC     | 007004 | PRESSURE                                                 |
+| HSMSL    | 007030 | HEIGHT OF STATION GROUND ABOVE MSL                       |
+| HBMSL    | 007031 | HEIGHT OF BAROMETER ABOVE MEAN SEA LEVEL                 |
+| HSALG    | 007032 | HEIGHT OF SENSOR ABOVE LOCAL GROUND                      |
+| HSAWS    | 007033 | HEIGHT OF SENSOR ABOVE WATER SURFACE                     |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| TSIG     | 008021 | TIME SIGNIFICANCE                                        |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GPH10    | 010009 | GEOPOTENTIAL HEIGHT                                      |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| MXGD     | 011043 | MAXIMUM WIND GUST DIRECTION                              |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| GMITH    | 012113 | GROUND MINIMUM TEMPERATURE, PAST 12 HOURS                |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| TDCM     | 020054 | TRUE DIRECTION FROM WHICH CLOUDS ARE MOVING              |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| AOFV     | 033041 | ATTRIBUTE OF FOLLOWING VALUE                             |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000101 | SFIDTIME  WIGOSID  RPID  PRESDATA  QMPR  TEMHUMDA  QMAT  QMDD     |
+| NC000101 | <BSYEXTM>  VISBSEQN  BSYWND1  QMWN  {BSYWND2}  TPMI  BSYPCP1      |
+| NC000101 | {BSYPCP2}  HSALG  HSAWS  GENCLOUD  {BSYSCLD}  {BSYBCLD}           |
+| NC000101 | <DIRCLDFT>  VSSO  <PWEATHER>  <STGDSNDM>  GMITH  BID  RCPTIM      |
+| NC000101 | CORN                                                              |
+|          |                                                                   |
+| SFCSTNID | WMOB  WMOS  STSN  TOST                                            |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| SFIDTIME | SFCSTNID  YYMMDD  HHMM  LTLONH  HSMSL  HBMSL                      |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| PRESSQ03 | PRES  PMSL  3HPC  CHPT                                            |
+|          |                                                                   |
+| GENCLOUD | TOCC  VSSO  CLAM  HOCB  CLTP  CLTP  CLTP                          |
+|          |                                                                   |
+| PRESDATA | PRESSQ03  24PC  PRLC  GPH10                                       |
+|          |                                                                   |
+| PWEATHER | PRWE  TPHR  PSW1  PSW2                                            |
+|          |                                                                   |
+| DIRCLDFT | "BSYDCLD"3                                                        |
+|          |                                                                   |
+| VISBSEQN | HSALG  HSAWS  AOFV  HOVI                                          |
+|          |                                                                   |
+| TEMHUMDA | HSALG  HSAWS  TMDB  TMDP  REHU                                    |
+|          |                                                                   |
+| STGDSNDM | MSGM  SOGR  MODM  TOSD                                            |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| BSYWND1  | HSALG  HSAWS  TIWM  TSIG  TPMI  WDIR  WSPD  TSIG                  |
+|          |                                                                   |
+| BSYWND2  | TPMI  MXGD  MXGS                                                  |
+|          |                                                                   |
+| BSYPCP1  | HSALG  HSAWS  MOPM  MLMP                                          |
+|          |                                                                   |
+| BSYPCP2  | TPHR  TOPC                                                        |
+|          |                                                                   |
+| BSYEXTM  | HSALG  HSAWS  TPHR  TPHR  MXTM  TPHR  TPHR  MITM  HSALG  HSAWS    |
+| BSYEXTM  | TPMI  MITM                                                        |
+|          |                                                                   |
+| BSYSCLD  | VSSO  CLAM  CLTP  AOFV  HOCB                                      |
+|          |                                                                   |
+| BSYBCLD  | VSSO  CLAM  CLTP  HOCT  CTDS                                      |
+|          |                                                                   |
+| BSYDCLD  | VSSO  TDCM                                                        |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| WMOB     |    0 |           0 |   7 | NUMERIC                  |-------------|
+| WMOS     |    0 |           0 |  10 | NUMERIC                  |-------------|
+| STSN     |    0 |           0 | 160 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MOPM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MSGM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MODM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MLMP     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE(N+,S-)            |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE(E+,W-)            |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| HSMSL    |    1 |       -4000 |  17 | METERS                   |-------------|
+| HBMSL    |    1 |       -4000 |  17 | M                        |-------------|
+| HSALG    |    2 |           0 |  16 | M                        |-------------|
+| HSAWS    |    1 |           0 |  12 | M                        |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GPH10    |    0 |       -1000 |  17 | GPM                      |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGD     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| GMITH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TDCM     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| AOFV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/adpsfc.nc000102.bufr.table.txt
+++ b/doc/bufr_table_samples/adpsfc.nc000102.bufr.table.txt
@@ -1,0 +1,236 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC000102 | A51052 | MTYP 000-102 SYNOPTIC - MOBIL LAND (BUFR)                |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| LTLONH   | 301021 | LOCATION -- LATITUDE, LONGITUDE (HIGH ACCURACY)          |
+| MOBIDENT | 301092 | MOBILE SURFACE STATION IDENTIFICATION, DATE/TIME, HORIZ  |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| PRESSQ03 | 302001 |                                                          |
+| GENCLOUD | 302004 | GENERAL CLOUD INFORMATION                                |
+| PRESDATA | 302031 | PRESSURE INFORMATION                                     |
+| PWEATHER | 302038 | PRESENT AND PAST WEATHER                                 |
+| DIRCLDFT | 302047 | DIRECTION OF CLOUD DRIFT                                 |
+| VISBSEQN | 302069 | VISIBILITY DATA                                          |
+| TEMHUMDA | 302072 | TEMPERATURE AND HUMIDITY DATA                            |
+| STGDSNDM | 302078 | STATE OF GROUND AND SNOW DEPTH MEASUREMENT               |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| BSYWND1  | 361066 | SYNOPTIC REPORT WIND DATA 1 (BUFR)                       |
+| BSYWND2  | 361067 | SYNOPTIC REPORT WIND DATA 2 (BUFR)                       |
+| BSYPCP1  | 361068 | SYNOPTIC REPORT PRECIPITATION DATA 1 (BUFR)              |
+| BSYPCP2  | 361069 | SYNOPTIC REPORT PRECIPITATION DATA 2 (BUFR)              |
+| BSYEXTM  | 361070 | SYNOPTIC REPORT EXTREME TEMPERATURE DATA (BUFR)          |
+| BSYSCLD  | 361071 | SYNOPTIC REPORT SUPPLEMENTAL CLOUD LAYER DATA (BUFR)     |
+| BSYBCLD  | 361072 | SYNOPTIC REPORT CLOUD BASES BELOW STN LEVEL DATA (BUFR)  |
+| BSYDCLD  | 361073 | SYNOPTIC REPORT CLOUD DRIFT DATA (BUFR)                  |
+|          |        |                                                          |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| MSST     | 002038 | METHOD OF SEA SURFACE TEMPERATURE MEASUREMENT            |
+| MWBT     | 002039 | METHOD OF WET BULB TEMPERATURE MEASUREMENT               |
+| ITSO     | 002193 | IND TYPE OF STN OPERATION PAST/P                         |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| PRLC     | 007004 | PRESSURE                                                 |
+| VSSO     | 008002 | VERT. SIGNIFICANCE (SFC OBSERVATION)                     |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| GP10     | 010008 | GEOPOTENTIAL                                             |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| 3HPC     | 010061 | 3 HOUR PRESSURE CHANGE                                   |
+| 24PC     | 010062 | 24 HOUR PRESSURE CHANGE                                  |
+| CHPT     | 010063 | CHARACTERISTIC OF PRESSURE TENDENCY                      |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAXIMUM WIND GUST SPEED                                  |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| INPC     | 013194 | INDIC INCLUSION/OMISSION OF PREC                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| VTVI     | 020002 | VERTICAL VISIBILITY                                      |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| PSW2     | 020005 | PAST WEATHER (2)                                         |
+| TOCC     | 020010 | CLOUD COVER (TOTAL)                                      |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| CTDS     | 020017 | CLOUD TOP DESCRIPTION                                    |
+| HBLCS    | 020201 | HEIGHT ABOVE SURFACE OF BASE OF LOWEST CLOUD SEEN        |
+| SST1     | 022043 | SEA TEMPERATURE                                          |
+| QCEVR    | 033024 | STATION ELEVATION QUALITY MARK (FOR MOBIL STATIONS)      |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMST     | 033218 | SDMEDIT QUALITY MARK FOR SEA SURFACE TEMPERATURE         |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC000102 | MOBIDENT  WIGOSID  RPID  PRESDATA  QMPR  TEMHUMDA  QMAT  QMDD     |
+| NC000102 | <BSYEXTM>  VISBSEQN  BSYWND1  QMWN  {BSYWND2}  TPMI  BSYPCP1      |
+| NC000102 | {BSYPCP2}  HSALG  HSAWS  GENCLOUD  {BSYSCLD}  {BSYBCLD}           |
+| NC000102 | <DIRCLDFT>  VSSO  <PWEATHER>  <STGDSNDM>  GMITH  BID  RCPTIM      |
+| NC000102 | CORN                                                              |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| MOBIDENT | SMID  WMOR  TOST  YYMMDD  HHMM  LTLONH  HSMSL  HBMSL  QCEVR       |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| PRESSQ03 | PRES  PMSL  3HPC  CHPT                                            |
+|          |                                                                   |
+| GENCLOUD | TOCC  VSSO  CLAM  HOCB  CLTP  CLTP  CLTP                          |
+|          |                                                                   |
+| PRESDATA | PRESSQ03  24PC  PRLC  GPH10                                       |
+|          |                                                                   |
+| PWEATHER | PRWE  TPHR  PSW1  PSW2                                            |
+|          |                                                                   |
+| DIRCLDFT | "BSYDCLD"3                                                        |
+|          |                                                                   |
+| VISBSEQN | HSALG  HSAWS  AOFV  HOVI                                          |
+|          |                                                                   |
+| TEMHUMDA | HSALG  HSAWS  TMDB  TMDP  REHU                                    |
+|          |                                                                   |
+| STGDSNDM | MSGM  SOGR  MODM  TOSD                                            |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| BSYWND1  | HSALG  HSAWS  TIWM  TSIG  TPMI  WDIR  WSPD  TSIG                  |
+|          |                                                                   |
+| BSYWND2  | TPMI  MXGD  MXGS                                                  |
+|          |                                                                   |
+| BSYPCP1  | HSALG  HSAWS  MOPM  MLMP                                          |
+|          |                                                                   |
+| BSYPCP2  | TPHR  TOPC                                                        |
+|          |                                                                   |
+| BSYEXTM  | HSALG  HSAWS  TPHR  TPHR  MXTM  TPHR  TPHR  MITM  HSALG  HSAWS    |
+| BSYEXTM  | TPMI  MITM                                                        |
+|          |                                                                   |
+| BSYSCLD  | VSSO  CLAM  CLTP  AOFV  HOCB                                      |
+|          |                                                                   |
+| BSYBCLD  | VSSO  CLAM  CLTP  HOCT  CTDS                                      |
+|          |                                                                   |
+| BSYDCLD  | VSSO  TDCM                                                        |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| MSST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MWBT     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| ITSO     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| VSSO     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| GP10     |    0 |      -10000 |  20 | (METERS/SECOND)**2       |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| 3HPC     |   -1 |        -500 |  10 | PASCALS                  |-------------|
+| 24PC     |   -1 |       -1000 |  11 | PASCALS                  |-------------|
+| CHPT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| INPC     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| VTVI     |   -1 |           0 |   7 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| PSW2     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TOCC     |    0 |           0 |   7 | %                        |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| CTDS     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| HBLCS    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| SST1     |    2 |           0 |  15 | DEGREES KELVIN           |-------------|
+| QCEVR    |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMST     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004001.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004001.bufr.table.txt
@@ -1,0 +1,107 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004001 | A63231 | MTYP 004-001  Manual AIREP & ADS (AIREP)                 |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| AFRID    | 362030 | AIRCRAFT REPORT ID DATA                                  |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| PSAL     | 007196 | PRESSURE ALTITUDE RELATIVE TO MEAN SEA LEVEL             |
+| FLVL     | 007197 | FLIGHT LEVEL                                             |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DGOT     | 011031 | DEGREE OF TURBULENCE                                     |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004001 | YYMMDD  HHMM  RCPTIM  BID  AFRID  {RAWRPT}  AFTMP  AFWND  ACID    |
+| NC004001 | DGOT                                                              |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| AFRID    | RPID  CORN  CLAT  CLON  FLVL  PSAL                                |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| PSAL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| FLVL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DGOT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004002.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004002.bufr.table.txt
@@ -1,0 +1,145 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004002 | A63232 | MTYP 004-002  Manual PIREP (PIREP)                       |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| AFRID    | 362030 | AIRCRAFT REPORT ID DATA                                  |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+| AFICG    | 362035 | AIRCRAFT ICING DATA                                      |
+| AFCLD    | 362036 | AIRCRAFT CLOUD DATA                                      |
+| APTRB    | 362037 | PIREP TURBULENCE DATA                                    |
+| APPWX    | 362038 | PIREP PRESENT WEATHER DATA                               |
+|          |        |                                                          |
+| ACTP     | 001009 | TYPE OF COMMERCIAL AIRCRAFT                              |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| PSAL     | 007196 | PRESSURE ALTITUDE RELATIVE TO MEAN SEA LEVEL             |
+| FLVL     | 007197 | FLIGHT LEVEL                                             |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| TRBX10   | 011236 | TURBULENCE INDEX FOR PERIOD (TOB-1 MIN) -> TOB           |
+| TRBX21   | 011237 | TURBULENCE INDEX FOR PERIOD (TOB-2 MIN) -> (TOB-1 MIN)   |
+| TRBX32   | 011238 | TURBULENCE INDEX FOR PERIOD (TOB-3 MIN) -> (TOB-2 MIN)   |
+| TRBX43   | 011239 | TURBULENCE INDEX FOR PERIOD (TOB-4 MIN) -> (TOB-3 MIN)   |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| CLTP     | 020012 | CLOUD TYPE                                               |
+| HOCB     | 020013 | HEIGHT OF BASE OF CLOUD                                  |
+| HOCT     | 020014 | HEIGHT OF TOP OF CLOUD                                   |
+| AFIC     | 020041 | AIRFRAME ICING                                           |
+| HBOI     | 020194 | HEIGHT OF BASE OF ICING                                  |
+| HTOI     | 020195 | HEIGHT OF TOP OF ICING                                   |
+| HBWX     | 020196 | HEIGHT OF BASE OF PRESENT WEATHER                        |
+| HTWX     | 020197 | HEIGHT OF TOP OF PRESENT WEATHER                         |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004002 | YYMMDD  HHMM  RCPTIM  BID  AFRID  {RAWRPT}  AFTMP  AFWND  {AFCLD} |
+| NC004002 | {AFICG}  {APTRB}  {APPWX}  ACTP  HOVI                             |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| AFRID    | RPID  CORN  CLAT  CLON  FLVL  PSAL                                |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+| AFICG    | AFIC  HBOI  HTOI                                                  |
+|          |                                                                   |
+| AFCLD    | CLAM  CLTP  HOCB  HOCT                                            |
+|          |                                                                   |
+| APTRB    | DGOT  HBOT  HTOT                                                  |
+|          |                                                                   |
+| APPWX    | PRWE  HBWX  HTWX                                                  |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACTP     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| PSAL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| FLVL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TRBX10   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX21   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX32   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX43   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HOCB     |   -1 |         -40 |  11 | METERS                   |-------------|
+| HOCT     |   -1 |         -40 |  11 | METERS                   |-------------|
+| AFIC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| HBOI     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HTOI     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HBWX     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HTWX     |   -1 |         -40 |  16 | METERS                   |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004003.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004003.bufr.table.txt
@@ -1,0 +1,129 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004003 | A63233 | MTYP 004-003  Automated AMDAR (FM-42 AMDAR)              |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RAWRPT   | 352002 | RAW REPORT                                               |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| AFRID    | 362030 | AIRCRAFT REPORT ID DATA                                  |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+| AFMST    | 362034 | AIRCRAFT MOISTURE DATA                                   |
+| ADSUP    | 362041 | AMDAR SUPPLEMENTARY DATA                                 |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| PCAT     | 002005 | PRECISION OF TEMPERATURE OBSERVATION                     |
+| ACNS     | 002061 | AIRCRAFT NAVIGATION SYSTEM                               |
+| TADR     | 002062 | TYPE OF AIRCRAFT DATA RELAY SYSTEM                       |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| PSAL     | 007196 | PRESSURE ALTITUDE RELATIVE TO MEAN SEA LEVEL             |
+| FLVL     | 007197 | FLIGHT LEVEL                                             |
+| POAF     | 008004 | PHASE OF AIRCRAFT FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DGOT     | 011031 | DEGREE OF TURBULENCE                                     |
+| MDEVG    | 011036 | MAXIMUM DERIVED EQUIVALENT VERTICAL GUST SPEED           |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RRSTG    | 058008 | RAW REPORT STRING                                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004003 | YYMMDD  HHMM  RCPTIM  RSRD  EXPRSRD  BID  AFRID  {RAWRPT}  AFTMP  |
+| NC004003 | AFWND  <AFMST>  ADSUP  ACID  DGOT                                 |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RAWRPT   | RRSTG                                                             |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| AFRID    | RPID  CORN  CLAT  CLON  FLVL  PSAL                                |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+| AFMST    | QMDD  TMDP  REHU                                                  |
+|          |                                                                   |
+| ADSUP    | POAF  ACNS  TADR  PCAT  MDEVG                                     |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PCAT     |    2 |           0 |   7 | DEGREES KELVIN           |-------------|
+| ACNS     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| TADR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| PSAL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| FLVL     |    1 |       -4000 |  20 | METERS                   |-------------|
+| POAF     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DGOT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MDEVG    |    1 |           0 |  10 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RRSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004004.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004004.bufr.table.txt
@@ -1,0 +1,170 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004004 | A63234 | MTYP 004-004  Automated MDCRS (ARINC to NCEP) (BUFR)     |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| ACTRB    | 362017 | ACARS TURBULENCE DATA                                    |
+| ACMST2   | 362019 | ACARS MOISTURE DATA                                      |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| OAPT     | 001111 | ORIGINATION AIRPORT                                      |
+| DAPT     | 001112 | DESTINATION AIRPORT                                      |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| TOST     | 002001 | TYPE OF STATION                                          |
+| TIWM     | 002002 | TYPE OF INSTRUMENTATION FOR WIND MEASUREMENT             |
+| PCAT     | 002005 | PRECISION OF TEMPERATURE OBSERVATION                     |
+| TADR     | 002062 | TYPE OF AIRCRAFT DATA RELAY SYSTEM                       |
+| ROLQ     | 002064 | AIRCRAFT ROLL ANGLE QUALITY                              |
+| ARST     | 002065 | ARINC GROUND RECEIVING STATION                           |
+| OSLL     | 002070 | ORIGINAL SPECIFICATION OF LAT/LON                        |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| SECO     | 004006 | SECOND                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| PRLC     | 007004 | PRESSURE                                                 |
+| POAF     | 008004 | PHASE OF AIRCRAFT FLIGHT                                 |
+| DPOF     | 008009 | DETAILED PHASE OF FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| IALT     | 010070 | INDICATED AIRCRAFT ALTITUDE                              |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| TASP     | 011100 | AIRCRAFT TRUE AIRSPEED                                   |
+| AVLU     | 011101 | AIRCRAFT GROUND SPEED U-COMPONENT                        |
+| AVLV     | 011102 | AIRCRAFT GROUND SPEED V-COMPONENT                        |
+| ACTH     | 011104 | TRUE HEADING OF AIRCRAFT, SHIP OR OTHER MOBILE PLATFORM  |
+| TRBX10   | 011236 | TURBULENCE INDEX FOR PERIOD (TOB-1 MIN) -> TOB           |
+| TRBX21   | 011237 | TURBULENCE INDEX FOR PERIOD (TOB-2 MIN) -> (TOB-1 MIN)   |
+| TRBX32   | 011238 | TURBULENCE INDEX FOR PERIOD (TOB-3 MIN) -> (TOB-2 MIN)   |
+| TRBX43   | 011239 | TURBULENCE INDEX FOR PERIOD (TOB-4 MIN) -> (TOB-3 MIN)   |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| MIXR     | 013002 | MIXING RATIO                                             |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| INTV     | 033025 | ACARS INTERPOLATED VALUES                                |
+| MSTQ     | 033026 | MOISTURE QUALITY                                         |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004004 | YYMMDD  HHMM  SECO  RCPTIM  RSRD  EXPRSRD  BID  CORN  OAPT  DAPT  |
+| NC004004 | WIGOSID  ACID  ACRN  ARST  207003  CLAT  CLON  207000  PRLC  IALT |
+| NC004004 | OSLL  PCAT  TIWM  DPOF  POAF  TADR  TOST  ROLQ  <ACMST2>  MSTQ    |
+| NC004004 | INTV  <ACTRB>  AFTMP  AFWND  TASP  AVLU  AVLV  ACTH               |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| ACTRB    | TRBX10  TRBX21  TRBX32  TRBX43                                    |
+|          |                                                                   |
+| ACMST2   | QMDD  207005  MIXR  207000  REHU                                  |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| OAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| DAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| TOST     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| TIWM     |    0 |           0 |   4 | FLAG TABLE               |-------------|
+| PCAT     |    2 |           0 |   7 | DEGREES KELVIN           |-------------|
+| TADR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| ROLQ     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| ARST     |    0 |           0 |  40 | CCITT IA5                |-------------|
+| OSLL     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| PRLC     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| POAF     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| DPOF     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| IALT     |    0 |        -400 |  16 | METERS                   |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TASP     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| AVLU     |    1 |       -4096 |  13 | METERS/SECOND            |-------------|
+| AVLV     |    1 |       -4096 |  13 | METERS/SECOND            |-------------|
+| ACTH     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| TRBX10   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX21   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX32   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TRBX43   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MIXR     |    5 |           0 |  14 | KG/KG                    |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| INTV     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| MSTQ     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004006.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004006.bufr.table.txt
@@ -1,0 +1,149 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004006 | A55200 | MTYP 004-006  Automated European AMDAR (BUFR)            |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+| ADSUP    | 362041 | AMDAR SUPPLEMENTARY DATA                                 |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| OAPT     | 001111 | ORIGINATION AIRPORT                                      |
+| DAPT     | 001112 | DESTINATION AIRPORT                                      |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| PCAT     | 002005 | PRECISION OF TEMPERATURE OBSERVATION                     |
+| ACNS     | 002061 | AIRCRAFT NAVIGATION SYSTEM                               |
+| TADR     | 002062 | TYPE OF AIRCRAFT DATA RELAY SYSTEM                       |
+| ROLQ     | 002064 | AIRCRAFT ROLL ANGLE QUALITY                              |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| SECO     | 004006 | SECOND                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| HMSL     | 007002 | HEIGHT OR ALTITUDE                                       |
+| HEIT     | 007007 | HEIGHT                                                   |
+| POAF     | 008004 | PHASE OF AIRCRAFT FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DGOT     | 011031 | DEGREE OF TURBULENCE                                     |
+| HBOT     | 011032 | HEIGHT OF BASE OF TURBULENCE                             |
+| HTOT     | 011033 | HEIGHT OF TOP OF TURBULENCE                              |
+| MDEVG    | 011036 | MAXIMUM DERIVED EQUIVALENT VERTICAL GUST SPEED           |
+| PTRB     | 011076 | PEAK TURBULENCE INTENSITY                                |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| MIXR     | 013002 | MIXING RATIO                                             |
+| AFIC     | 020041 | AIRFRAME ICING                                           |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004006 | YYMMDD  HHMM  SECO  RCPTIM  RSRD  EXPRSRD  BID  CORN  OAPT  DAPT  |
+| NC004006 | WIGOSID  ACID  ACRN  CLATH  CLONH  HMSL  AFTMP  AFWND  ADSUP      |
+| NC004006 | HEIT  DGOT  HBOT  HTOT  PTRB  AFIC  ROLQ  207005  MIXR  207000    |
+| NC004006 | QMDD                                                              |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+| ADSUP    | POAF  ACNS  TADR  PCAT  MDEVG                                     |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| OAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| DAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| PCAT     |    2 |           0 |   7 | DEGREES KELVIN           |-------------|
+| ACNS     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| TADR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| ROLQ     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| HMSL     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HEIT     |    0 |       -1000 |  17 | METERS                   |-------------|
+| POAF     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DGOT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| HBOT     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HTOT     |   -1 |         -40 |  16 | METERS                   |-------------|
+| MDEVG    |    1 |           0 |  10 | METERS/SECOND            |-------------|
+| PTRB     |    2 |           0 |   8 | (M**2/3)(S**-1)          |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MIXR     |    5 |           0 |  14 | KG/KG                    |-------------|
+| AFIC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004009.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004009.bufr.table.txt
@@ -1,0 +1,140 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004009 | A55203 | MTYP 004-009  Automated Canadian AMDAR (BUFR)            |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| AFTMP    | 362032 | AIRCRAFT TEMPERATURE DATA                                |
+| AFWND    | 362033 | AIRCRAFT WIND DATA                                       |
+| ADSUP    | 362041 | AMDAR SUPPLEMENTARY DATA                                 |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| PCAT     | 002005 | PRECISION OF TEMPERATURE OBSERVATION                     |
+| ACNS     | 002061 | AIRCRAFT NAVIGATION SYSTEM                               |
+| TADR     | 002062 | TYPE OF AIRCRAFT DATA RELAY SYSTEM                       |
+| ROLQ     | 002064 | AIRCRAFT ROLL ANGLE QUALITY                              |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| SECO     | 004006 | SECOND                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| HMSL     | 007002 | HEIGHT OR ALTITUDE                                       |
+| HEIT     | 007007 | HEIGHT                                                   |
+| POAF     | 008004 | PHASE OF AIRCRAFT FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DGOT     | 011031 | DEGREE OF TURBULENCE                                     |
+| HBOT     | 011032 | HEIGHT OF BASE OF TURBULENCE                             |
+| HTOT     | 011033 | HEIGHT OF TOP OF TURBULENCE                              |
+| MDEVG    | 011036 | MAXIMUM DERIVED EQUIVALENT VERTICAL GUST SPEED           |
+| PTRB     | 011076 | PEAK TURBULENCE INTENSITY                                |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| AFIC     | 020041 | AIRFRAME ICING                                           |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004009 | YYMMDD  HHMM  SECO  RCPTIM  RSRD  EXPRSRD  BID  CORN  ACID  ACRN  |
+| NC004009 | WIGOSID  CLATH  CLONH  HMSL  AFTMP  AFWND  ADSUP  HEIT  DGOT      |
+| NC004009 | HBOT  HTOT  PTRB  AFIC  ROLQ                                      |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| AFTMP    | QMAT  TMDB                                                        |
+|          |                                                                   |
+| AFWND    | QMWN  WDIR  WSPD                                                  |
+|          |                                                                   |
+| ADSUP    | POAF  ACNS  TADR  PCAT  MDEVG                                     |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| PCAT     |    2 |           0 |   7 | DEGREES KELVIN           |-------------|
+| ACNS     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| TADR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| ROLQ     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| HMSL     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HEIT     |    0 |       -1000 |  17 | METERS                   |-------------|
+| POAF     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DGOT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| HBOT     |   -1 |         -40 |  16 | METERS                   |-------------|
+| HTOT     |   -1 |         -40 |  16 | METERS                   |-------------|
+| MDEVG    |    1 |           0 |  10 | METERS/SECOND            |-------------|
+| PTRB     |    2 |           0 |   8 | (M**2/3)(S**-1)          |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| AFIC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004010.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004010.bufr.table.txt
@@ -1,0 +1,104 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004010 | A55204 | MTYP 004-010  TAMDAR from Panasonic (BUFR)               |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMMSS   | 301013 | TIME -- HOUR, MINUTE, SECOND                             |
+| LTLONH   | 301021 | HIGH ACCURACY LATITUDE/LONGITUDE POSITION                |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+|          |        |                                                          |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| ACTP     | 001009 | TYPE OF COMMERCIAL AIRCRAFT                              |
+| SMMO     | 001013 | SPEED OF MOTION OF MOVING OBSERVING PLATFORM             |
+| OBSVR    | 001095 | OBSERVER IDENTIFICATION                                  |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| SECO     | 004006 | SECOND                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| HMSL     | 007002 | HEIGHT OR ALTITUDE                                       |
+| FLVLST   | 007010 | FLIGHT LEVEL                                             |
+| POAF     | 008004 | PHASE OF AIRCRAFT FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| IALR     | 010082 | INSTANTANEOUS ALTITUDE RATE                              |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| TMDBST   | 012001 | TEMPERATURE/DRY-BULB TEMPERATURE                         |
+| RAWHU    | 013009 | RAW RELATIVE HUMIDITY                                    |
+| QMRKH    | 033003 | QUALITY INFORMATION                                      |
+| PCCF     | 033007 | PERCENT CONFIDENCE                                       |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004010 | YYMMDD  HHMMSS  RCPTIM  RSRD  EXPRSRD  LTLONH  CORN  OBSVR  ACTP  |
+| NC004010 | HMSL  FLVLST  ACRN  POAF  IALR  QMRKH  SMMO  QMRKH  TMDBST  QMAT  |
+| NC004010 | QMRKH  WDIR  QMRKH  WSPD  QMWN  PCCF  RAWHU  QMDD                 |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMMSS   | HOUR  MINU  SECO                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| ACTP     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| SMMO     |    0 |           0 |  10 | METERS/SECOND            |-------------|
+| OBSVR    |    0 |           0 |  32 | CCITT IA5                |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| HMSL     |   -1 |         -40 |  16 | METERS                   |-------------|
+| FLVLST   |    0 |       -1024 |  16 | METERS                   |-------------|
+| POAF     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| IALR     |    3 |      -65536 |  17 | METERS/SECOND            |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDBST   |    1 |           0 |  12 | DEGREES KELVIN           |-------------|
+| RAWHU    |    1 |       -1000 |  12 | %                        |-------------|
+| QMRKH    |    0 |           0 |   3 | CODE TABLE               |-------------|
+| PCCF     |    0 |           0 |   7 | PERCENT                  |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004011.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004011.bufr.table.txt
@@ -1,0 +1,120 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004011 | A55205 | MTYP 004-011  Automated Korean AMDAR (BUFR)              |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMMSS   | 301013 | TIME -- HOUR, MINUTE, SECOND                             |
+| LTLONH   | 301021 | HIGH ACCURACY LATITUDE/LONGITUDE POSITION                |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+|          |        |                                                          |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| OSQN     | 001023 | OBSERVATION SEQUENCE NUMBER                              |
+| WGOSIDS  | 001125 | WIGOS IDENTIFIER SERIES                                  |
+| WGOSISID | 001126 | WIGOS ISSUER OF IDENTIFIER                               |
+| WGOSISNM | 001127 | WIGOS ISSUE NUMBER                                       |
+| WGOSLID  | 001128 | WIGOS LOCAL IDENTIFIER (CHARACTER)                       |
+| ROLQ     | 002064 | AIRCRAFT ROLL ANGLE QUALITY                              |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTE                                                   |
+| SECO     | 004006 | SECOND                                                   |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| FLVLST   | 007010 | FLIGHT LEVEL                                             |
+| DPOF     | 008009 | DETAILED PHASE OF FLIGHT                                 |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DGOT     | 011031 | DEGREE OF TURBULENCE                                     |
+| MDEVG    | 011036 | MAXIMUM DERIVED EQUIVALENT VERTICAL GUST SPEED           |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| INTV     | 033025 | ACARS INTERPOLATED VALUES                                |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004011 | YYMMDD  HHMMSS  RCPTIM  BID  RSRD  EXPRSRD  LTLONH  CORN  FLVLST  |
+| NC004011 | WIGOSID  ACRN  OSQN  DPOF  QMWN  WDIR  WSPD  DGOT  MDEVG  QMAT    |
+| NC004011 | TMDB  INTV  ROLQ                                                  |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMMSS   | HOUR  MINU  SECO                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| OSQN     |    0 |           0 |   9 | NUMERIC                  |-------------|
+| WGOSIDS  |    0 |           0 |   4 | NUMERIC                  |-------------|
+| WGOSISID |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSISNM |    0 |           0 |  16 | NUMERIC                  |-------------|
+| WGOSLID  |    0 |           0 | 128 | CCITT IA5                |-------------|
+| ROLQ     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | SECOND                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| FLVLST   |    0 |       -1024 |  16 | METERS                   |-------------|
+| DPOF     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DGOT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MDEVG    |    1 |           0 |  10 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| INTV     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/aircft.nc004103.bufr.table.txt
+++ b/doc/bufr_table_samples/aircft.nc004103.bufr.table.txt
@@ -1,0 +1,94 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC004103 | A55210 | MTYP 004-103  All other automated AMDAR (BUFR)           |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMMSS   | 301013 | TIME -- HOUR, MINUTE, SECOND                             |
+| LTLONH   | 301021 | HIGH ACCURACY LATITUDE/LONGITUDE POSITION                |
+| WIGOSID  | 301150 | WIGOS IDENTIFIER                                         |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| APTRB    | 362037 | PIREP TURBULENCE DATA                                    |
+| ADRBLSEQ | 362042 | AMDAR BUFR LEVEL SEQUENCE                                |
+|          |        |                                                          |
+| ACID     | 001006 | AIRCRAFT FLIGHT NUMBER                                   |
+| ACRN     | 001008 | AIRCRAFT REGISTRATION NUMBER (TAIL NUMBER)               |
+| OSQN     | 001023 | OBSERVATION SEQUENCE NUMBER                              |
+| OAPT     | 001111 | ORIGINATION AIRPORT                                      |
+| DAPT     | 001112 | DESTINATION AIRPORT                                      |
+| PCAT     | 002005 | PRECISION OF TEMPERATURE OBSERVATION                     |
+| ACNS     | 002061 | AIRCRAFT NAVIGATION SYSTEM                               |
+| TADR     | 002062 | TYPE OF AIRCRAFT DATA RELAY SYSTEM                       |
+| DPOF     | 008009 | DETAILED PHASE OF FLIGHT                                 |
+| MDEVG    | 011036 | MAXIMUM DERIVED EQUIVALENT VERTICAL GUST SPEED           |
+| TASP     | 011100 | AIRCRAFT TRUE AIRSPEED                                   |
+| AVLU     | 011101 | AIRCRAFT GROUND SPEED U-COMPONENT                        |
+| AVLV     | 011102 | AIRCRAFT GROUND SPEED V-COMPONENT                        |
+| ACTH     | 011104 | TRUE HEADING OF AIRCRAFT, SHIP OR OTHER MOBILE PLATFORM  |
+| AFIC     | 020041 | AIRFRAME ICING                                           |
+| INTV     | 033025 | ACARS INTERPOLATED VALUES                                |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| CORN     | 033215 | CORRECTED REPORT INDICATOR                               |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC004103 | YYMMDD  HHMMSS  OAPT  DAPT  ACID  ACRN  DPOF  LTLONH  OSQN  ACNS  |
+| NC004103 | WIGOSID  TADR  PCAT  {ADRBLSEQ}  APTRB  AFIC  MDEVG  INTV  RCPTIM |
+| NC004103 | BID  CORN  QMAT  QMWN  QMDD  RSRD  EXPRSRD  TASP  AVLU  AVLV      |
+| NC004103 | ACTH                                                              |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMMSS   | HOUR  MINU  SECO                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| WIGOSID  | WGOSIDS  WGOSISID  WGOSISNM  WGOSLID                              |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| APTRB    | DGOT  HBOT  HTOT                                                  |
+|          |                                                                   |
+| ADRBLSEQ | FLVLST  LTLONH  WDIR  WSPD  ROLQ  TMDB  TMDP  207005  MIXR        |
+| ADRBLSEQ | 207000                                                            |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| ACID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| ACRN     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| OSQN     |    0 |           0 |   9 | NUMERIC                  |-------------|
+| OAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| DAPT     |    0 |           0 |  24 | CCITT IA5                |-------------|
+| PCAT     |    2 |           0 |   7 | DEGREES KELVIN           |-------------|
+| ACNS     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| TADR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| DPOF     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| MDEVG    |    1 |           0 |  10 | METERS/SECOND            |-------------|
+| TASP     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| AVLU     |    1 |       -4096 |  13 | METERS/SECOND            |-------------|
+| AVLV     |    1 |       -4096 |  13 | METERS/SECOND            |-------------|
+| ACTH     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| AFIC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| INTV     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| CORN     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'


### PR DESCRIPTION
## Description

There are 9 different subtypes of AIRCFT and ADPSFC data. Each has their own unique sequence of mnemonics. These 18 bufr tables document the sequences and mnemonics.

The bufr tables may now be easily accessible to those that need them.

### Issue(s) addressed

Link the issues to be closed with this PR
A number of issues were written to gather information and write these bufr tables. The tables are documented as text files and as text in the following issues
For adpsfc: #549 #548 #547 #546 #545 #544 #543 #542 #541 #540 
For aircft: #572 #571 #570 #569 #568 #567 #566 #565 #564 #563 

## Acceptance Criteria (Definition of Done)

None

## Dependencies

None

## Impact

None

## Test Data