### PR TITLE
update gnssro fortran converters

### DIFF
--- a/src/gnssro/gnssro_bufr2ioda.f90
+++ b/src/gnssro/gnssro_bufr2ioda.f90
@@ -326,9 +326,6 @@ endif
 
 call check( nf90_create(trim(outfile), NF90_NETCDF4, ncid))
 call check( nf90_def_dim(ncid, 'nlocs', ndata,   nlocs_dimid) )
-call check( nf90_def_dim(ncid, 'nrecs', nrec,    nrecs_dimid) )
-call check( nf90_def_dim(ncid, 'nobs',  ndata*nvars,   nobs_dimid) )
-call check( nf90_def_dim(ncid, 'nvars', nvars,   nvars_dimid) )
 call check( nf90_def_dim(ncid, 'ndatetime', ndatetime,   ndatetime_dimid) )
 call check( nf90_put_att(ncid, NF90_GLOBAL, 'date_time', anatime_i) )
 call check( nf90_def_var(ncid, "latitude@MetaData",      NF90_FLOAT, nlocs_dimid, varid_lat) )

--- a/src/gnssro/gnssro_gsidiag2ioda.f90
+++ b/src/gnssro/gnssro_gsidiag2ioda.f90
@@ -285,8 +285,6 @@ end do
 call check( nf90_create(trim(obsname_out), nf90_clobber, ncid_out))
 call check( nf90_put_att(ncid_out, NF90_GLOBAL, 'date_time', anatime_i) )
 call check( nf90_def_dim(ncid_out, 'nlocs', nsub,  nlocs_dimid) )
-call check( nf90_def_dim(ncid_out, 'nvars', 1,     nvars_dimid) )
-call check( nf90_def_dim(ncid_out, 'nrecs', nrecs, nrecs_dimid) )
 call check( nf90_def_var(ncid_out, "latitude@MetaData",        NF90_FLOAT, nlocs_dimid, varid_lat) )
 call check( nf90_def_var(ncid_out, "longitude@MetaData",       NF90_FLOAT, nlocs_dimid, varid_lon) )
 call check( nf90_def_var(ncid_out, "time@MetaData",            NF90_FLOAT, nlocs_dimid, varid_time) )

--- a/test/testoutput/gnssro_kompsat5_2018041500.nc4
+++ b/test/testoutput/gnssro_kompsat5_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78173423b6d4579a40ed814224d6e30ea867e563ca57cca339637db19f3d4cc0
-size 530192
+oid sha256:d6bcf1e36fb501df76cafe67cc287957da6a869599a686549a8936fdc189ced9
+size 528737


### PR DESCRIPTION
## Description
This PR deletes extra dimensions in the output IODA file header because IODA2 can not handle dimensions other than "nlocs".

### Issue(s) addressed

- fixes https://github.com/JCSDA-internal/ufo/issues/1309
- fixes https://github.com/JCSDA-internal/ufo/issues/1310