### PR TITLE
use python3 explicitly

### DIFF
--- a/src/chem/airnow2ioda-nc.py
+++ b/src/chem/airnow2ioda-nc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # read airnow data and convert to netcdf
 import netCDF4 as nc
 import numpy as np

--- a/src/chem/tropomi_no2_nc2ioda.py
+++ b/src/chem/tropomi_no2_nc2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2020 UCAR

--- a/src/chem/viirs_aod2ioda.py
+++ b/src/chem/viirs_aod2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # (C) Copyright 2020 UCAR
 #

--- a/src/gsi-ncdiag/combine_files.py
+++ b/src/gsi-ncdiag/combine_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # combine_files.py
 # combine conventional obs and GOESIR (currently ahi_himawari8) from IODA format into
 # one output file with matching corresponding locations

--- a/src/gsi-ncdiag/proc_gsi_ncdiag.py
+++ b/src/gsi-ncdiag/proc_gsi_ncdiag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import os
 import sys

--- a/src/gsi-ncdiag/subset_files.py
+++ b/src/gsi-ncdiag/subset_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 from multiprocessing import Pool
 import glob

--- a/src/gsi-ncdiag/test_gsidiag.py
+++ b/src/gsi-ncdiag/test_gsidiag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # script to run to test if the GSI ncdiag converters are still working
 import sys
 import argparse

--- a/src/land/smos_ssm2ioda.py
+++ b/src/land/smos_ssm2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # (C) Copyright 2021 NOAA/NWS/NCEP/EMC
 #

--- a/src/lib-python/collect_sources.py
+++ b/src/lib-python/collect_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import path
 

--- a/src/lib-python/ioda_conv_ncio.py
+++ b/src/lib-python/ioda_conv_ncio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime as dt
 import math

--- a/src/lib-python/meteo_utils.py
+++ b/src/lib-python/meteo_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2020 UCAR

--- a/src/lib-python/run-mccabe.py
+++ b/src/lib-python/run-mccabe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import ast

--- a/src/lib-python/run-pyflakes.py
+++ b/src/lib-python/run-pyflakes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import subprocess

--- a/src/marine/argoClim2ioda.py
+++ b/src/marine/argoClim2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019-2019 UCAR

--- a/src/marine/cryosat_ice2ioda.py
+++ b/src/marine/cryosat_ice2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/emc_ice2ioda.py
+++ b/src/marine/emc_ice2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/gds2_sst2ioda.py
+++ b/src/marine/gds2_sst2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/glider2ioda.py
+++ b/src/marine/glider2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/gmao_obs2ioda.py
+++ b/src/marine/gmao_obs2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (C) Copyright 2019 UCAR
 #

--- a/src/marine/godae_profile2ioda.py
+++ b/src/marine/godae_profile2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/godae_ship2ioda.py
+++ b/src/marine/godae_ship2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/godae_trak2ioda.py
+++ b/src/marine/godae_trak2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/hgodas_adt2ioda.py
+++ b/src/marine/hgodas_adt2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/hgodas_insitu2ioda.py
+++ b/src/marine/hgodas_insitu2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/hgodas_sst2ioda.py
+++ b/src/marine/hgodas_sst2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/ndbc_hfradar2ioda.py
+++ b/src/marine/ndbc_hfradar2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ioda-converter for National Data Buoy Center High Frequency Radar radial velocity
 # Script modified by Ling Liu (IMSG@NOAA/NCEP/EMC)

--- a/src/marine/rads_adt2ioda.py
+++ b/src/marine/rads_adt2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/smap_sss2ioda.py
+++ b/src/marine/smap_sss2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/marine/smos_sss2ioda.py
+++ b/src/marine/smos_sss2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2021 UCAR

--- a/src/marine/viirs_modis_l2_oc2ioda.py
+++ b/src/marine/viirs_modis_l2_oc2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2020 UCAR

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2021 UCAR

--- a/src/ncep/bufr2nc.py
+++ b/src/ncep/bufr2nc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import ncepbufr

--- a/src/ncep/bufr2ncCommon.py
+++ b/src/ncep/bufr2ncCommon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/src/ncep/bufr2ncObsTypes.py
+++ b/src/ncep/bufr2ncObsTypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import numpy as np

--- a/src/ncep/ncep_classes.py
+++ b/src/ncep/ncep_classes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import ncepbufr
 from netCDF4 import Dataset

--- a/src/orig/JEDI_amsu_bufr2nc.v8.py
+++ b/src/orig/JEDI_amsu_bufr2nc.v8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """convert amsubufr file to netCDF"""
 from __future__ import print_function
 import ncepbufr

--- a/src/orig/JEDI_conv_bufr2nc_2D.py
+++ b/src/orig/JEDI_conv_bufr2nc_2D.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """convert prepbufr file to netCDF
 cdraper, Nov, 2017"""
 

--- a/src/orig/prepbufr2ncSG.py
+++ b/src/orig/prepbufr2ncSG.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """convert prepbufr file to netCDF"""
 from __future__ import print_function
 import ncepbufr

--- a/src/ssec/Experimental/giirs_lw2ioda_bt_v1.py
+++ b/src/ssec/Experimental/giirs_lw2ioda_bt_v1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/ssec/Experimental/giirs_lw2ioda_bt_v2.py
+++ b/src/ssec/Experimental/giirs_lw2ioda_bt_v2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/ssec/giirs_lw2ioda.py
+++ b/src/ssec/giirs_lw2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/ssec/giirs_ssec2ioda.py
+++ b/src/ssec/giirs_ssec2ioda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (C) Copyright 2019 UCAR

--- a/src/wrfda-ncdiag/proc_wrfda_ncdiag.py
+++ b/src/wrfda-ncdiag/proc_wrfda_ncdiag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import os
 import sys

--- a/src/wrfda-ncdiag/test_wrfdadiag.py
+++ b/src/wrfda-ncdiag/test_wrfdadiag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # script to run to test if the WRFDA ncdiag converters are still working
 import sys
 import argparse

--- a/tools/bufrtest.py
+++ b/tools/bufrtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import ncepbufr

--- a/tools/iodaconv_cpplint.py
+++ b/tools/iodaconv_cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
## Description

I was having problems with [this bug](https://github.com/JCSDA-internal/ioda-converters/issues/583) - namely the ioda-converters python scripts were using `#! /usr/bin/env python` which on my Mac invokes python 2.7.  This fixed the problem.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #583

## Acceptance Criteria (Definition of Done)

python3 is invoked by tests and scripts instead of python2

## Dependencies

None

## Impact

None
