### PR TITLE
Add bufr_version as global attribute to bufr2ioda output (for AMVs only)

### DIFF
--- a/tools/run_satwnds/satwnds_new_subset_template.yaml
+++ b/tools/run_satwnds/satwnds_new_subset_template.yaml
@@ -73,9 +73,9 @@ observations:
           size: variables/percent_confidence.ncols
 
       globals:
-        - name: "bufr_version@MetaData"
+        - name: "bufr_seq_version"
           type: string
-          value: "310077"    
+          value: "3-10-077"    
 
       variables:
         - name: "satellite@MetaData"

--- a/tools/run_satwnds/satwnds_new_subset_template.yaml
+++ b/tools/run_satwnds/satwnds_new_subset_template.yaml
@@ -72,6 +72,11 @@ observations:
         - name: "ncols_conf"
           size: variables/percent_confidence.ncols
 
+      globals:
+        - name: "bufr_version@MetaData"
+          type: string
+          value: "310077"    
+
       variables:
         - name: "satellite@MetaData"
           source: variables/satellite

--- a/tools/run_satwnds/satwnds_old_subset_template.yaml
+++ b/tools/run_satwnds/satwnds_old_subset_template.yaml
@@ -68,9 +68,9 @@ observations:
           size: variables/percent_confidence.ncols
 
       globals:
-        - name: "bufr_version@MetaData"
+        - name: "bufr_seq_version"
           type: string
-          value: "310014"     
+          value: "3-10-014"     
 
       variables:
         - name: "satellite@MetaData"

--- a/tools/run_satwnds/satwnds_old_subset_template.yaml
+++ b/tools/run_satwnds/satwnds_old_subset_template.yaml
@@ -67,6 +67,11 @@ observations:
         - name: "ncols_conf"
           size: variables/percent_confidence.ncols
 
+      globals:
+        - name: "bufr_version@MetaData"
+          type: string
+          value: "310014"     
+
       variables:
         - name: "satellite@MetaData"
           source: variables/satellite


### PR DESCRIPTION
## Description
See Issue [#587](https://github.com/JCSDA-internal/ioda-converters/issues/587)

We are adding global attribute _bufr_verson_ (BUFR sequence version) to the ioda output from bufr2ioda, allowing us to distinguish between two BUFR versions used for AMVs (satellite winds).
Later, UFO filters could read  bufr_verson and make quality control decisions.

This PR adds code to:
ioda-bundle/iodaconv/tools/run_satwnds/satwnds_old_subset_template.yaml
ioda-bundle/iodaconv/tools/run_satwnds/satwnds_new_subset_template.yaml
to add the global attribute.

Link the issues to be closed with this PR
- fixes #<587>

## Acceptance Criteria (Definition of Done)
The ioda output will show bufr_version:

// global attributes:
		string :_ioda_layout = “ObsGroup” ;
		:_ioda_layout_version = 0 ;
		string :bufr_version@MetaData = “310077" ;  
 
(or "310014")

## Dependencies
None

## Impact
- [iodaconv] iodaconv in ioda-bundle
