### PR TITLE
Add GsiEffectiveQC variable

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -782,6 +782,12 @@ class Conv(BaseGSI):
                             else:
                                 tmp[tmp > 4e8] = self.FLOAT_FILL
                             outdata[gvname] = tmp
+                    # create a GSI effective QC variable
+                    gsiqcname = outvars[o], 'GsiEffectiveQC'
+                    errname = outvars[o], 'GsiFinalObsError'
+                    gsiqc = np.zeros_like(obsdata)
+                    gsiqc[outdata[errname] == self.FLOAT_FILL] = 1
+                    outdata[gsiqcname] = gsiqc
                     # store values in output data dictionary
                     outdata[varDict[outvars[o]]['valKey']] = obsdata
                     outdata[varDict[outvars[o]]['errKey']] = obserr
@@ -1306,6 +1312,12 @@ class Radiances(BaseGSI):
             outdata[varDict[value]['valKey']] = obsdatasub
             outdata[varDict[value]['errKey']] = obserrsub
             outdata[varDict[value]['qcKey']] = obsqcsub.astype(int)
+            # create a GSI effective QC variable
+            gsiqcname = value, 'GsiEffectiveQC'
+            errname = value, 'GsiFinalObsError'
+            gsiqc = np.zeros_like(obsdatasub)
+            gsiqc[outdata[errname] == self.FLOAT_FILL] = 1
+            outdata[gsiqcname] = gsiqc
             if (ObsBias):
                 valuebc = [
                     "constant_{:d}".format(chanlist[c]),

--- a/test/testoutput/amsua_aqua_obs_2018041500.nc4
+++ b/test/testoutput/amsua_aqua_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:269801067216b3da5c8a064dce88e8bc5c5e1cb3fb75235d63e884d47a8a573c
-size 135958
+oid sha256:909057dc00d687a1209195c2dc504d69c846974ce78a2fbea0887c085f8f5c41
+size 148568

--- a/test/testoutput/satwind_obs_2018041500.nc4
+++ b/test/testoutput/satwind_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01f2791ede347e45c3361d319f2036e82f67f1de009d0e479e0ecf98ba28da21
-size 42528
+oid sha256:aaab18bb7d67fff47dd7cd78e1ed5f28c1928272be5ca22681961e354bedc85d
+size 42692

--- a/test/testoutput/sfc_tv_obs_2018041500.nc4
+++ b/test/testoutput/sfc_tv_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:548d4e2c31a6c6e0fcc726f359f3e7d88355f5c0c2e5ccbc8e7b33a0ba495839
-size 24184
+oid sha256:9ba8b9538a5302124ec2c6718a7ed0c05763d9797a5775b18af012398b0007b7
+size 24248


### PR DESCRIPTION
## Description

Adds a new variable, GsiEffectiveQC, to the GSI ncdiag output.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #633 

## Acceptance Criteria (Definition of Done)

Once Obs team and EMC can verify through a spot check that the 'good' obs have a value of 0, and all else, 1.

## Dependencies
None

## Impact

None
