### PR TITLE
Link to python libraries in "module" mode instead of "embed" mode

### DIFF
--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import ioda
+import ioda_obs_space as ioda_os
 import numpy as np
 
 # define vars
@@ -43,7 +43,7 @@ class IodaWriter(object):
         self._dim_dict = DimDict
         self._test_key_list = TestKeyList
         # open IODA obs backend
-        self.obsspace = ioda.ObsSpace(Fname, mode='w', dim_dict=DimDict)
+        self.obsspace = ioda_os.ObsSpace(Fname, mode='w', dim_dict=DimDict)
 
     def WriteObsVars(self, ObsVars, VarDims, VarMdata, VarUnits):
         # this method will create variables in the ouput obs group and


### PR DESCRIPTION
## Description

This is a companion PR to jcsda-internal/ioda/pull/500 that is necessary due to the reorganization of the ioda python modules.

### Issue(s) addressed

Accompanies changes in jcsda-internal/ioda/pull/500 that contribute to fixing the issue jcsda-internal/ioda/issues/463

## Acceptance Criteria (Definition of Done)

Pybind11 and miniconda successfully build together.

The issues with multiple versions of libraries (such as hdf5) at runtime are not completely addressed by this PR. If the library versions match between miniconda and jedi-stack, then there will be no issues at runtime. The piece in getting the library versions all sync'd up is outside the scope of the ioda-converters repo.

The homebrew python and jedi-stack have matching libraries on my MacBook so there are no runtime issues. Ie, the openssl and homebrew python have matching versions for openssl and hdf5. And this must be true also for the CI test containers.

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/500

## Impact

None