### PR TITLE
Upgrade hgodas_adt2ioda to use ioda-v2 and add tests

### DIFF
--- a/src/marine/hgodas_adt2ioda.py
+++ b/src/marine/hgodas_adt2ioda.py
@@ -19,11 +19,11 @@ if not IODA_CONV_PATH.is_dir():
     IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
 sys.path.append(str(IODA_CONV_PATH.resolve()))
 
-import ioda_conv_ncio as iconv
+import ioda_conv_engines as iconv
 from orddicts import DefaultOrderedDict
 
 
-vName = "obs_absolute_dynamic_topography",
+vName = "obs_absolute_dynamic_topography"
 
 locationKeyList = [
     ("latitude", "float"),
@@ -31,18 +31,24 @@ locationKeyList = [
     ("datetime", "string")
 ]
 
-AttrData = {
-    'odb_version': 1,
+GlobalAttrs = {
+}
+
+VarDims = {
+    vName: ['nlocs'],
+}
+
+DimDict = {
 }
 
 
 class Observation(object):
 
-    def __init__(self, filename, date, writer):
+    def __init__(self, filename, date):
         self.filename = filename
         self.date = date
         self.data = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
-        self.writer = writer
+        self.VarAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
         self._read()
 
     def _read(self):
@@ -58,9 +64,15 @@ class Observation(object):
 
         base_date = datetime(1970, 1, 1) + timedelta(seconds=int(time[0]))
 
-        valKey = vName, self.writer.OvalName()
-        errKey = vName, self.writer.OerrName()
-        qcKey = vName, self.writer.OqcName()
+        valKey = vName, iconv.OvalName()
+        errKey = vName, iconv.OerrName()
+        qcKey = vName, iconv.OqcName()
+        self.VarAttrs[vName, iconv.OvalName()]['_FillValue'] = -999.
+        self.VarAttrs[vName, iconv.OerrName()]['_FillValue'] = -999.
+        self.VarAttrs[vName, iconv.OqcName()]['_FillValue'] = -999
+        self.VarAttrs[vName, iconv.OvalName()]['units'] = 'm'
+        self.VarAttrs[vName, iconv.OerrName()]['units'] = 'm'
+        self.VarAttrs[vName, iconv.OqcName()]['units'] = 'unitless'
 
         for i in range(len(hrs)):
             # there shouldn't be any bad obs, but just in case remove them all
@@ -69,9 +81,9 @@ class Observation(object):
 
             dt = base_date + timedelta(hours=float(hrs[i]))
             locKey = lats[i], lons[i], dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-            self.data[0][locKey][valKey] = vals[i]
-            self.data[0][locKey][errKey] = errs[i]
-            self.data[0][locKey][qcKey] = qcs[i]
+            self.data[locKey][valKey] = vals[i]
+            self.data[locKey][errKey] = errs[i]
+            self.data[locKey][qcKey] = qcs[i]
 
 
 def main():
@@ -98,16 +110,20 @@ def main():
     args = parser.parse_args()
     fdate = datetime.strptime(args.date, '%Y%m%d%H')
 
-    writer = iconv.NcWriter(args.output, locationKeyList)
+    # Read in the adt
+    adt = Observation(args.input, fdate)
 
-    # Read in the profiles
-    prof = Observation(args.input, fdate, writer)
+    # Extract Obsdata
+    ObsVars, nlocs = iconv.ExtractObsData(adt.data, locationKeyList)
+
+    # Set attributes
+    DimDict['nlocs'] = nlocs
+
+    # Set up the IODA writer
+    writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)
 
     # write them out
-    AttrData['date_time_string'] = fdate.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    (ObsVars, LocMdata, VarMdata) = writer.ExtractObsData(prof.data)
-    writer.BuildNetcdf(ObsVars, LocMdata, VarMdata, AttrData)
+    writer.BuildIoda(ObsVars, VarDims, adt.VarAttrs, GlobalAttrs)
 
 
 if __name__ == '__main__':

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ list( APPEND test_input
   testinput/godae_trak.bin
   testinput/rads_adt.nc
   testinput/smap_sss_rss.nc
+  testinput/hgodas_adt.nc
   testinput/hgodas_insitu.nc
   testinput/hgodas_sst.nc
   testinput/marineglider_AOML.nc
@@ -63,6 +64,7 @@ list( APPEND test_output
   testoutput/godae_trak.nc
   testoutput/rads_adt.nc
   testoutput/smap_sss_rss.nc
+  testoutput/hgodas_adt.nc
   testoutput/hgodas_insitu.nc
   testoutput/hgodas_sst.nc
   testoutput/test_glider.nc
@@ -321,6 +323,17 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_trak
                           -o testrun/godae_trak.nc
                           -d 2004070812"
                           godae_trak.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_adt
+                  TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                  ARGS    netcdf
+                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/hgodas_adt2ioda.py
+                          -i testinput/hgodas_adt.nc
+                          -o testrun/hgodas_adt.nc
+                          -d 2018041512"
+                          hgodas_adt.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_insitu
                   TYPE    SCRIPT

--- a/test/testinput/hgodas_adt.nc
+++ b/test/testinput/hgodas_adt.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47d47194d27d90672c273372c3c1de007cb6471844d594b409fd9f63658fadd9
+size 3032764

--- a/test/testoutput/hgodas_adt.nc
+++ b/test/testoutput/hgodas_adt.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5141dd8e2de5f83712e9fd8403632f024091422679a8d8501e3af911cc5b437
+size 6161312


### PR DESCRIPTION
## Description

Upgrades the marine/hgodas_adt2ioda convert to use the new ioda v-2 interface and adds relevant tests and testdata.
### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #646 

