### PR TITLE
upgrade airnow2ioda converter

### DIFF
--- a/src/chem/airnow2ioda-nc.py
+++ b/src/chem/airnow2ioda-nc.py
@@ -108,11 +108,11 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     print('infile=', args.input, args.sitefile)
-    f = add_data(args.input, args.sitefile).drop_duplicates(subset=['PM2.5','OZONE','siteid','latitude','longitude'])
+    f = add_data(args.input, args.sitefile).drop_duplicates(subset=['PM2.5', 'OZONE', 'siteid', 'latitude', 'longitude'])
 
     f3 = f.dropna(subset=['PM2.5'], how='any').reset_index()
     nlocs, columns = f3.shape
-    
+
     obsvars = {'pm25': 'pm25', 'o3': 'o3', }
     AttrData = {'converter': os.path.basename(__file__), }
 

--- a/src/chem/airnow2ioda-nc.py
+++ b/src/chem/airnow2ioda-nc.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
     outdata[varDict['o3']['valKey']] = np.array((f3['OZONE']/1000).fillna(nc.default_fillvals['f4']))
     for i in ['pm25', 'o3']:
         outdata[varDict[i]['errKey']] = np.full((nlocs), 0.1)
-        outdata[varDict[i]['qcKey']] = np.full((nlocs), 1)
+        outdata[varDict[i]['qcKey']] = np.full((nlocs), 0)
 
     writer._nvars = 2
     writer._nlocs = nlocs

--- a/src/chem/airnow2ioda-nc.py
+++ b/src/chem/airnow2ioda-nc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # read airnow data and convert to netcdf
 import netCDF4 as nc
 import numpy as np
@@ -7,7 +7,7 @@ import pandas as pd
 from datetime import datetime
 from pathlib import Path
 
-IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
+IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"
 if not IODA_CONV_PATH.is_dir():
     IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
 sys.path.append(str(IODA_CONV_PATH.resolve()))

--- a/test/testoutput/airnow_2020081306.nc
+++ b/test/testoutput/airnow_2020081306.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f97dcd95b03c0cc1ef3e67a7ffdce3d1e3fb9c6050e346b6e3a7b764095e208b
+oid sha256:b1b2d8e178d3c24266c88ded97b38a6a1f20e252222bb5eef34ab9aee206b82f
 size 138122

--- a/test/testoutput/airnow_2020081306.nc
+++ b/test/testoutput/airnow_2020081306.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b17932aea53a6021b7a4261f42db4f5a0ab1877aab6b66c3c8e891e957218b14
-size 768204
+oid sha256:f97dcd95b03c0cc1ef3e67a7ffdce3d1e3fb9c6050e346b6e3a7b764095e208b
+size 138122


### PR DESCRIPTION

## Description

*(Instructions: replace text in this and all sections with your own text)*

Provide a detailed description of what this PR does.

remove the duplicated observation records
change variable name of pm25_tot to pm25
add real station_elevation (meter) in place (the existing one uses dummy value)

What problem does it fix? What new capability does it add?
remove the duplicated record,  add the real station_elevation. The variable name change is for the new AIRNow UFO 
https://github.com/JCSDA-internal/ufo/pull/1666

[See the JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html) for further information.

### Issue(s) addressed

Link the issues to be closed with this PR
N/A
If this does not close an existing issue, then [be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)

## Acceptance Criteria (Definition of Done)

What does it mean for this PR to be finished?
It can pass the regression test and convert the data to the desired format

## Dependencies
N/A

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- [ ] waiting on JCSDA/eckit/pull/<pr_number>
- [ ] waiting on JCSDA/atlas/pull/<pr_number>

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)
This PR is the upstream change for implementing https://github.com/JCSDA-internal/ufo/pull/1666
- [ ] saber
- [ ] ufo
- [ ] ...
