### PR TITLE
Add ability to convert GNSSRO data in WMO-formatted BUFR to IODA (v2) output

### DIFF
--- a/doc/bufr_obs_samples/gnssro_bufr_sample.txt
+++ b/doc/bufr_obs_samples/gnssro_bufr_sample.txt
@@ -1,0 +1,226 @@
+
+Found BUFR message #      1
+  
+        Message length:       17278
+      Section 0 length:           8
+          BUFR edition:           4
+  
+      Section 1 length:          22
+          Master table:           0
+    Originating center:          60 (= United States National Centre for Atmospheric Research (NCAR))
+ Originating subcenter:           0
+ Update sequence numbr:           0
+    Section 2 present?: No
+         Data category:           3 (= Vertical soundings (satellite))
+     Local subcategory:          14
+ Internatl subcategory:          50 (= Radio occultation sounding)
+  Master table version:          12
+   Local table version:           0
+                  Year:        2020
+                 Month:          11
+                   Day:           1
+                  Hour:          23
+                Minute:          57
+                Second:          54
+  
+ Number of data subsets:           1
+     Data are observed?: Yes
+   Data are compressed?: No
+  Number of descriptors:           1
+        1: 310026
+
+BUFR message #      1 of type MSTTB001 and date 2020110123 contains      1 subsets:
+
+MESSAGE TYPE MSTTB001  
+
+001007  SAID                       755.0  CODE TABLE                    Satellite identifier                            
+                                    755 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+002019  SIID                       104.0  CODE TABLE                    Satellite instruments                           
+                                    104 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+001033  OGCE                        60.0  CODE TABLE                    Identification of originating/generating centre 
+                                     60 = United States National Centre for Atmospheric Research (NCAR)
+002172  PTAG                         2.0  CODE TABLE                    Product type for retrieved atmospheric gases    
+                                      2 = Retrieval from a limb sounding
+025060  SWID                      2019.0  NUMERIC                       Software identification                         
+008021  TSIG                        17.0  CODE TABLE                    Time significance                               
+                                     17 = Start of phenomenon
+004001  YEAR                      2020.0  YEAR                          Year                                            
+004002  MNTH                        11.0  MONTH                         Month                                           
+004003  DAYS                         1.0  DAY                           Day                                             
+004004  HOUR                        23.0  HOUR                          Hour                                            
+004005  MINU                        57.0  MINUTE                        Minute                                          
+004006  SECO                      54.000  S                             Second                                          
+033039  QFRO                     16448.0  FLAG TABLE(2,10)              Quality flags for radio occultation data        
+                                      2 = Offline product
+                                     10 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+033007  PCCF                       100.0  %                             Percent confidence                              
+027031  PD00                 -5902285.50  M                             In direction of 0 degrees longitude, distance fr
+028031  PD90                 -2733253.00  M                             In direction 90 degrees East, distance from the 
+010031  PDNP                 -2814368.50  M                             In direction of the North Pole, distance from th
+001041  PS00                  6698.77002  M S⁻¹                      Absolute platform velocity - first component    
+001042  PS90                 -3312.32837  M S⁻¹                      Absolute platform velocity - second component   
+001043  PSNP                   675.55377  M S⁻¹                      Absolute platform velocity - third component    
+002020  SCLF                       402.0  CODE TABLE                    Satellite classification                        
+                                    402 = GLONASS
+001050  PTID                         4.0  NUMERIC                       Platform transmitter ID number                  
+027031  PD00                  -2487281.5  M                             In direction of 0 degrees longitude, distance fr
+028031  PD90                  24843054.0  M                             In direction 90 degrees East, distance from the 
+010031  PDNP                  -5228890.0  M                             In direction of the North Pole, distance from th
+001041  PS00                 -1704.06152  M S⁻¹                      Absolute platform velocity - first component    
+001042  PS90                  -757.53845  M S⁻¹                      Absolute platform velocity - second component   
+001043  PSNP                  3485.48047  M S⁻¹                      Absolute platform velocity - third component    
+004016  TISE                      61.751  S                             Time increment                                  
+005001  CLATH                  -29.24269  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                  175.85043  DEGREE                        Longitude (high accuracy)                       
+027031  PD00                     -236.88  M                             In direction of 0 degrees longitude, distance fr
+028031  PD90                      235.89  M                             In direction 90 degrees East, distance from the 
+010031  PDNP                    20710.13  M                             In direction of the North Pole, distance from th
+010035  ELRC                   6382901.0  M                             Earth's local radius of curvature               
+005021  BEARAZ                     84.19  DEGREE TRUE                   Bearing or azimuth                              
+010036  GEODU                      47.03  M                             Geoid undulation                                
+           (RPSEQ001)   247 REPLICATIONS
+    ++++++  RPSEQ001  REPLICATION #     1  ++++++
+005001  CLATH                  -29.35406  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                  176.33571  DEGREE                        Longitude (high accuracy)                       
+005021  BEARAZ                     84.11  DEGREE TRUE                   Bearing or azimuth                              
+           {RPSEQ002}     3 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+002121  MEFR                1500000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385042.5  M                             Impact parameter                                
+015037  BNDA                  0.02446111  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00597962  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+002121  MEFR                1200000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385042.5  M                             Impact parameter                                
+015037  BNDA                     MISSING  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00597962  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+002121  MEFR                         0.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385042.5  M                             Impact parameter                                
+015037  BNDA                  0.02445192  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00597962  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        28.0  %                             Percent confidence                              
+    ++++++  RPSEQ001  REPLICATION #     2  ++++++
+005001  CLATH                  -29.34878  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                  176.31244  DEGREE                        Longitude (high accuracy)                       
+005021  BEARAZ                     84.11  DEGREE TRUE                   Bearing or azimuth                              
+           {RPSEQ002}     3 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+002121  MEFR                1500000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385160.0  M                             Impact parameter                                
+015037  BNDA                  0.02778937  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00583053  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+002121  MEFR                1200000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385160.0  M                             Impact parameter                                
+015037  BNDA                     MISSING  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00583053  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+002121  MEFR                         0.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385160.0  M                             Impact parameter                                
+015037  BNDA                  0.02778009  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00583053  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        37.0  %                             Percent confidence                              
+    ++++++  RPSEQ001  REPLICATION #     3  ++++++
+005001  CLATH                  -29.34353  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                  176.28925  DEGREE                        Longitude (high accuracy)                       
+005021  BEARAZ                     84.12  DEGREE TRUE                   Bearing or azimuth                              
+           {RPSEQ002}     3 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+002121  MEFR                1500000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385278.0  M                             Impact parameter                                
+015037  BNDA                  0.02977946  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00570416  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+002121  MEFR                1200000000.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385278.0  M                             Impact parameter                                
+015037  BNDA                     MISSING  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00570416  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+002121  MEFR                         0.0  HZ                            Mean frequency                                  
+007040  IMPP                   6385278.0  M                             Impact parameter                                
+015037  BNDA                  0.02977010  RAD                           Bending angle                                   
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015037  BNDA                  0.00570416  RAD                           Bending angle                                   
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        33.0  %                             Percent confidence                              
+
+
+           (RPSEQ003)   247 REPLICATIONS    [Showing only first 3]
+
+    ++++++  RPSEQ003  REPLICATION #     1  ++++++
+007007  HEIT                        27.0  M                             Height                                          
+015036  ARFR                     323.314  N UNITS                       Atmospheric refractivity                        
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015036  ARFR                     MISSING  N UNITS                       Atmospheric refractivity                        
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        28.0  %                             Percent confidence                              
+    ++++++  RPSEQ003  REPLICATION #     2  ++++++
+007007  HEIT                       147.0  M                             Height                                          
+015036  ARFR                     323.557  N UNITS                       Atmospheric refractivity                        
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015036  ARFR                     MISSING  N UNITS                       Atmospheric refractivity                        
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        37.0  %                             Percent confidence                              
+    ++++++  RPSEQ003  REPLICATION #     3  ++++++
+007007  HEIT                       294.0  M                             Height                                          
+015036  ARFR                     318.877  N UNITS                       Atmospheric refractivity                        
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+015036  ARFR                     MISSING  N UNITS                       Atmospheric refractivity                        
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                        33.0  %                             Percent confidence                              
+
+           (RPSEQ004)   386 REPLICATIONS    [Showing only first 3]
+
+    ++++++  RPSEQ004  REPLICATION #     1  ++++++
+007009  GPHTST                    1498.0  GPM                           Geopotential height                             
+010004  PRES                     85880.0  PA                            Pressure                                        
+012001  TMDBST                     287.1  K                             Temperature/dry-bulb temperature                
+013001  SPFH                     0.00179  KG KG⁻¹                    Specific humidity                               
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+010004  PRES                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+013001  SPFH                     MISSING  KG KG⁻¹                    Specific humidity                               
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                       100.0  %                             Percent confidence                              
+    ++++++  RPSEQ004  REPLICATION #     2  ++++++
+007009  GPHTST                    1597.0  GPM                           Geopotential height                             
+010004  PRES                     84870.0  PA                            Pressure                                        
+012001  TMDBST                     287.9  K                             Temperature/dry-bulb temperature                
+013001  SPFH                     0.00116  KG KG⁻¹                    Specific humidity                               
+008023  FOST                        13.0  CODE TABLE                    First-order statistics                          
+                                     13 = Root-mean-square
+010004  PRES                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+013001  SPFH                     MISSING  KG KG⁻¹                    Specific humidity                               
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+033007  PCCF                       100.0  %                             Percent confidence                              

--- a/doc/bufr_table_samples/gnssro_bufr_mnemonics.txt
+++ b/doc/bufr_table_samples/gnssro_bufr_mnemonics.txt
@@ -1,0 +1,139 @@
+
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| MSTTB001 | A54000 | TABLE A MNEMONIC MSTTB001                                |
+|          |        |                                                          |
+| RAOCSEQ  | 310026 | Satellite radio occultation data                         |
+| SIIDSEQ  | 310022 |                                                          |
+| YYMMDD   | 301011 |                                                          |
+| HHMM     | 301012 |                                                          |
+| LOCPLAT  | 304030 | Location of platform                                     |
+| SPDPLAT  | 304031 | Speed of platform                                        |
+| LTLONH   | 301021 |                                                          |
+| RPSEQ001 | 354001 | REPLICATION SEQUENCE 001                                 |
+| RPSEQ002 | 354002 | REPLICATION SEQUENCE 002                                 |
+| RPSEQ003 | 354003 | REPLICATION SEQUENCE 003                                 |
+| RPSEQ004 | 354004 | REPLICATION SEQUENCE 004                                 |
+|          |        |                                                          |
+| SAID     | 001007 | Satellite identifier                                     |
+| SIID     | 002019 | Satellite instruments                                    |
+| OGCE     | 001033 | Identification of originating/generating centre          |
+| PTAG     | 002172 | Product type for retrieved atmospheric gases             |
+| SWID     | 025060 | Software identification                                  |
+| TSIG     | 008021 | Time significance                                        |
+| YEAR     | 004001 | Year                                                     |
+| MNTH     | 004002 | Month                                                    |
+| DAYS     | 004003 | Day                                                      |
+| HOUR     | 004004 | Hour                                                     |
+| MINU     | 004005 | Minute                                                   |
+| SECO     | 004006 | Second                                                   |
+| QFRO     | 033039 | Quality flags for radio occultation data                 |
+| PCCF     | 033007 | Percent confidence                                       |
+| PD00     | 027031 | In direction of 0 degrees longitude, distance from the   |
+| PD90     | 028031 | In direction 90 degrees East, distance from the Earth's  |
+| PDNP     | 010031 | In direction of the North Pole, distance from the Earth  |
+| PS00     | 001041 | Absolute platform velocity - first component             |
+| PS90     | 001042 | Absolute platform velocity - second component            |
+| PSNP     | 001043 | Absolute platform velocity - third component             |
+| SCLF     | 002020 | Satellite classification                                 |
+| PTID     | 001050 | Platform transmitter ID number                           |
+| TISE     | 004016 | Time increment                                           |
+| CLATH    | 005001 | Latitude (high accuracy)                                 |
+| CLONH    | 006001 | Longitude (high accuracy)                                |
+| ELRC     | 010035 | Earth's local radius of curvature                        |
+| BEARAZ   | 005021 | Bearing or azimuth                                       |
+| GEODU    | 010036 | Geoid undulation                                         |
+| MEFR     | 002121 | Mean frequency                                           |
+| IMPP     | 007040 | Impact parameter                                         |
+| BNDA     | 015037 | Bending angle                                            |
+| FOST     | 008023 | First-order statistics                                   |
+| HEIT     | 007007 | Height                                                   |
+| ARFR     | 015036 | Atmospheric refractivity                                 |
+| GPHTST   | 007009 | Geopotential height                                      |
+| PRES     | 010004 | Pressure                                                 |
+| TMDBST   | 012001 | Temperature/dry-bulb temperature                         |
+| SPFH     | 013001 | Specific humidity                                        |
+| VSAT     | 008003 | Vertical significance (satellite observations)           |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| MSTTB001 | RAOCSEQ                                                           |
+|          |                                                                   |
+| RAOCSEQ  | SIIDSEQ  SWID  TSIG  YYMMDD  HHMM  201138  202131  SECO  202000   |
+| RAOCSEQ  | 201000  QFRO  PCCF  LOCPLAT  SPDPLAT  SCLF  PTID  202127  LOCPLAT |
+| RAOCSEQ  | 202000  SPDPLAT  201133  202131  TISE  202000  201000  LTLONH     |
+| RAOCSEQ  | LOCPLAT  ELRC  BEARAZ  GEODU  (RPSEQ001)  (RPSEQ003)  (RPSEQ004)  |
+| RAOCSEQ  | VSAT  GPHTST  PRES  FOST  201120  PRES  201000  FOST  PCCF        |
+|          |                                                                   |
+| SIIDSEQ  | SAID  SIID  OGCE  PTAG                                            |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| LOCPLAT  | PD00  PD90  PDNP                                                  |
+|          |                                                                   |
+| SPDPLAT  | PS00  PS90  PSNP                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| RPSEQ001 | LTLONH  BEARAZ  {RPSEQ002}  PCCF                                  |
+|          |                                                                   |
+| RPSEQ002 | MEFR  IMPP  BNDA  FOST  201125  BNDA  201000  FOST                |
+|          |                                                                   |
+| RPSEQ003 | HEIT  ARFR  FOST  201123  ARFR  201000  FOST  PCCF                |
+|          |                                                                   |
+| RPSEQ004 | GPHTST  PRES  TMDBST  SPFH  FOST  201120  PRES  201000  201122    |
+| RPSEQ004 | TMDBST  201000  201123  SPFH  201000  FOST  PCCF                  |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| SAID     |    0 |           0 |  10 | CODE TABLE               |-------------|
+| SIID     |    0 |           0 |  11 | CODE TABLE               |-------------|
+| OGCE     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| PTAG     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| SWID     |    0 |           0 |  14 | NUMERIC                  |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | S                        |-------------|
+| QFRO     |    0 |           0 |  16 | FLAG TABLE               |-------------|
+| PCCF     |    0 |           0 |   7 | %                        |-------------|
+| PD00     |    2 | -1073741824 |  31 | M                        |-------------|
+| PD90     |    2 | -1073741824 |  31 | M                        |-------------|
+| PDNP     |    2 | -1073741824 |  31 | M                        |-------------|
+| PS00     |    5 | -1073741824 |  31 | M S⁻¹                 |-------------|
+| PS90     |    5 | -1073741824 |  31 | M S⁻¹                 |-------------|
+| PSNP     |    5 | -1073741824 |  31 | M S⁻¹                 |-------------|
+| SCLF     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PTID     |    0 |           0 |  17 | NUMERIC                  |-------------|
+| TISE     |    0 |       -4096 |  13 | S                        |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE                   |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE                   |-------------|
+| ELRC     |    1 |    62000000 |  22 | M                        |-------------|
+| BEARAZ   |    2 |           0 |  16 | DEGREE TRUE              |-------------|
+| GEODU    |    2 |      -15000 |  15 | M                        |-------------|
+| MEFR     |   -8 |           0 |   7 | HZ                       |-------------|
+| IMPP     |    1 |    62000000 |  22 | M                        |-------------|
+| BNDA     |    8 |     -100000 |  23 | RAD                      |-------------|
+| FOST     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| HEIT     |    0 |       -1000 |  17 | M                        |-------------|
+| ARFR     |    3 |           0 |  19 | N UNITS                  |-------------|
+| GPHTST   |    0 |       -1000 |  17 | GPM                      |-------------|
+| PRES     |   -1 |           0 |  14 | PA                       |-------------|
+| TMDBST   |    1 |           0 |  12 | K                        |-------------|
+| SPFH     |    5 |           0 |  14 | KG KG⁻¹               |-------------|
+| VSAT     |    0 |           0 |   6 | CODE TABLE               |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,7 +154,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/NC005066.nc
     testoutput/airep_multi.nc
     testoutput/amdar_single.nc
-    testinput/gnssro_2020-306-2358C2E6.nc
+    testoutput/gnssro_2020-306-2358C2E6.nc
   )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,6 +136,8 @@ if( iodaconv_bufr_ENABLED )
     testinput/airep_wmo_multi.bufr
     testinput/amdar_wmoBUFR2ioda.yaml
     testinput/amdar_wmo_single.bufr
+    testinput/gnssro_wmoBUFR2ioda.yaml
+    testinput/gnssro_2020-306-2358C2E6.bufr
   )
 
   list( APPEND test_output
@@ -152,6 +154,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/NC005066.nc
     testoutput/airep_multi.nc
     testoutput/amdar_single.nc
+    testinput/gnssro_2020-306-2358C2E6.nc
   )
 endif()
 
@@ -777,6 +780,14 @@ if(iodaconv_bufr_ENABLED)
                     ARGS    netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/amdar_wmoBUFR2ioda.yaml"
                     amdar_single.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_gnssro_wmo_bufr
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/gnssro_wmoBUFR2ioda.yaml"
+                    gnssro_2020-306-2358C2E6.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 endif()
 

--- a/test/testinput/gnssro_2020-306-2358C2E6.bufr
+++ b/test/testinput/gnssro_2020-306-2358C2E6.bufr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f02fac525e3feae95bce3a83c0688da0b7dabf1f768d0d1d10e767087244a098
+size 17300

--- a/test/testinput/gnssro_wmoBUFR2ioda.yaml
+++ b/test/testinput/gnssro_wmoBUFR2ioda.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2021 UCAR
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,8 +6,7 @@
 observations:
   - obs space:
       name: bufr
-#     obsdatain: "./testinput/gnssro_2020-306-2358C2E6.bufr"
-      obsdatain: "/data/users/gthompsn/JEDI/src/ioda-bundle/iodaconv/test/testinput/gnssro_2020-306-2358C2E6.bufr"
+      obsdatain: "./testinput/gnssro_2020-306-2358C2E6.bufr"
       isWmoFormat: true
       tablepath: "./testinput/bufr_tables"
 
@@ -117,13 +116,6 @@ observations:
           longName: "Air pressure"
           units: "Pa"
 
-        - name: "MetaData/airPressure"
-          coordinates: "longitude latitude"
-          source: variables/airPressure
-          dimensions: [ "nlocs" ]
-          longName: "Air pressure"
-          units: "Pa"
-
         - name: "MetaData/gnss_sat_class
           coordinates: "longitude latitude"
           source: variables/satelliteClassification
@@ -145,7 +137,7 @@ observations:
           longName: "GNSS platform transmitter ID"
           units: "unitless"
 
-        - name: "MetaData/ascending_flag
+        - name: "MetaData/qualityFlags
           coordinates: "longitude latitude"
           source: variables/qualityFlags
           dimensions: [ "nlocs" ]
@@ -179,6 +171,13 @@ observations:
           dimensions: [ "nlocs" ]
           longName: "Sensor azimuth angle"
           units: "degrees"
+
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          dimensions: [ "nlocs" ]
+          longName: "Air temperature"
+          units: "K"
 
         - name: "ObsValue/specificHumidity"
           coordinates: "longitude latitude"

--- a/test/testinput/gnssro_wmoBUFR2ioda.yaml
+++ b/test/testinput/gnssro_wmoBUFR2ioda.yaml
@@ -14,7 +14,7 @@ observations:
         - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, SECO, CLATH, CLONH]
         - mnemonics: [HEIT]
         - mnemonics: [GPHTST, PRES, TMDBST, SPFH, PRES]
-        - mnemonics: [SAID, OGCE]
+        - mnemonics: [SAID, SIID, OGCE]
         - mnemonics: [IMPP, BNDA]
         - mnemonics: [QFRO, PCCF, SCLF, PTID, ELRC, BEARAZ, GEODU]
         - mnemonics: [ARFR]
@@ -46,6 +46,8 @@ observations:
 
           satelliteIdentifier:
             mnemonic: SAID
+          instrumentIdentifier:
+            mnemonic: SIID
           satelliteClassification:
             mnemonic: SCLF
           platformTransmitterId:
@@ -135,6 +137,13 @@ observations:
           source: variables/satelliteIdentifier
           dimensions: [ "nlocs" ]
           longName: "GNSS satellite ID"
+          units: "unitless"
+
+        - name: "MetaData/occulting_sat_is
+          coordinates: "longitude latitude"
+          source: variables/instrumentIdentifier
+          dimensions: [ "nlocs" ]
+          longName: "Instrument ID"
           units: "unitless"
 
         - name: "MetaData/occulting_sat_id

--- a/test/testinput/gnssro_wmoBUFR2ioda.yaml
+++ b/test/testinput/gnssro_wmoBUFR2ioda.yaml
@@ -1,0 +1,202 @@
+# (C) Copyright 2021 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+#     obsdatain: "./testinput/gnssro_2020-306-2358C2E6.bufr"
+      obsdatain: "/data/users/gthompsn/JEDI/src/ioda-bundle/iodaconv/test/testinput/gnssro_2020-306-2358C2E6.bufr"
+      isWmoFormat: true
+      tablepath: "./testinput/bufr_tables"
+
+      mnemonicSets:
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, SECO, CLATH, CLONH]
+        - mnemonics: [HEIT]
+        - mnemonics: [GPHTST, PRES, TMDBST, SPFH, PRES]
+        - mnemonics: [SAID, OGCE]
+        - mnemonics: [IMPP, BNDA]
+        - mnemonics: [QFRO, PCCF, SCLF, PTID, ELRC, BEARAZ, GEODU]
+        - mnemonics: [ARFR]
+
+      exports:
+        variables:
+          timestamp:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+              second: SECO
+          latitude:
+            mnemonic: CLATH
+          longitude:
+            mnemonic: CLONH
+          height:
+            mnemonic: HEIT
+          geopotentialHeight:
+            mnemonic: GPHTST
+          airPressure:
+            mnemonic: PRES
+          airTemperature:
+            mnemonic: TMDBST
+          specificHumidity:
+            mnemonic: SPFH
+
+          satelliteIdentifier:
+            mnemonic: SAID
+          satelliteClassification:
+            mnemonic: SCLF
+          platformTransmitterId:
+            mnemonic: PTID
+          originatingCenter:
+            mnemonic: OGCE
+          qualityFlags:
+            mnemonic: QFRO
+          percentConfidence:
+            mnemonic: PCCF
+          impactParameter:
+            mnemonic: IMPP
+          geoidUndulation:
+            mnemonic: GEODU
+          azimuth:
+            mnemonic: BEARAZ
+          earthRadiusCurvature:
+            mnemonic: ELRC
+
+          bendingAngle:
+            mnemonic: BNDA
+          refractivity:
+            mnemonic: ARFR
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/gnssro_2020-306-2358C2E6.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+
+      variables:
+        - name: "MetaData/datetime"
+          source: variables/timestamp
+          dimensions: [ "nlocs" ]
+          longName: "Datetime"
+          units: "datetime"
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          dimensions: [ "nlocs" ]
+          longName: "Latitude"
+          units: "degrees_north"
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          dimensions: [ "nlocs" ]
+          longName: "Longitude"
+          units: "degrees_east"
+
+        - name: "MetaData/height"
+          source: variables/height
+          dimensions: [ "nlocs" ]
+          longName: "Height"
+          units: "m"
+
+        - name: "MetaData/geopotentialHeight"
+          source: variables/geopotentialHeight
+          dimensions: [ "nlocs" ]
+          longName: "Geopotential height"
+          units: "m"
+
+        - name: "MetaData/airPressure"
+          coordinates: "longitude latitude"
+          source: variables/airPressure
+          dimensions: [ "nlocs" ]
+          longName: "Air pressure"
+          units: "Pa"
+
+        - name: "MetaData/airPressure"
+          coordinates: "longitude latitude"
+          source: variables/airPressure
+          dimensions: [ "nlocs" ]
+          longName: "Air pressure"
+          units: "Pa"
+
+        - name: "MetaData/gnss_sat_class
+          coordinates: "longitude latitude"
+          source: variables/satelliteClassification
+          dimensions: [ "nlocs" ]
+          longName: "GNSS satellite classification"
+          units: "unitless"
+
+        - name: "MetaData/reference_sat_id
+          coordinates: "longitude latitude"
+          source: variables/satelliteIdentifier
+          dimensions: [ "nlocs" ]
+          longName: "GNSS satellite ID"
+          units: "unitless"
+
+        - name: "MetaData/occulting_sat_id
+          coordinates: "longitude latitude"
+          source: variables/platformTransmitterId
+          dimensions: [ "nlocs" ]
+          longName: "GNSS platform transmitter ID"
+          units: "unitless"
+
+        - name: "MetaData/ascending_flag
+          coordinates: "longitude latitude"
+          source: variables/qualityFlags
+          dimensions: [ "nlocs" ]
+          longName: "Quality flags"
+          units: "unitless"
+
+        - name: "MetaData/earth_radius_of_curvature"
+          coordinates: "longitude latitude"
+          source: variables/earthRadiusCurvature
+          dimensions: [ "nlocs" ]
+          longName: "Earth local radius of curvature"
+          units: "m"
+
+        - name: "MetaData/geoid_height_above_reference_ellipsoid
+          coordinates: "longitude latitude"
+          source: variables/geoidUndulation
+          dimensions: [ "nlocs" ]
+          longName: "Geoid undulation"
+          units: "m"
+
+        - name: "MetaData/impact_parameter
+          coordinates: "longitude latitude"
+          source: variables/impactParameter
+          dimensions: [ "nlocs" ]
+          longName: "Impact parameter"
+          units: "m"
+
+        - name: "MetaData/sensor_azimuth_angle
+          coordinates: "longitude latitude"
+          source: variables/azimuth
+          dimensions: [ "nlocs" ]
+          longName: "Sensor azimuth angle"
+          units: "degrees"
+
+        - name: "ObsValue/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidity
+          dimensions: [ "nlocs" ]
+          longName: "Specific humidity"
+          units: "kg kg-1"
+
+        - name: "ObsValue/bending_angle"
+          coordinates: "longitude latitude"
+          source: variables/bendingAngle
+          dimensions: [ "nlocs" ]
+          longName: "Bending angle"
+          units: "radians"
+
+        - name: "ObsValue/refractivity"
+          coordinates: "longitude latitude"
+          source: variables/refractivity
+          dimensions: [ "nlocs" ]
+          longName: "Refractivity"
+          units: "N units"

--- a/test/testinput/gnssro_wmoBUFR2ioda.yaml
+++ b/test/testinput/gnssro_wmoBUFR2ioda.yaml
@@ -116,6 +116,13 @@ observations:
           longName: "Air pressure"
           units: "Pa"
 
+        - name: "MetaData/process_center
+          coordinates: "longitude latitude"
+          source: variables/originatingCenter
+          dimensions: [ "nlocs" ]
+          longName: "Originating center"
+          units: "unitless"
+
         - name: "MetaData/gnss_sat_class
           coordinates: "longitude latitude"
           source: variables/satelliteClassification

--- a/test/testoutput/gnssro_2020-306-2358C2E6.nc
+++ b/test/testoutput/gnssro_2020-306-2358C2E6.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f6c1098b11e94768d16c0e4bf4f21bd0dc1bdd9bb733e003234f44c7a375d4c
-size 59819
+oid sha256:f5500f28ec3599cb3ec1b2aa31eb90078dced2a69a532aa7329f275e5a75acac
+size 62620

--- a/test/testoutput/gnssro_2020-306-2358C2E6.nc
+++ b/test/testoutput/gnssro_2020-306-2358C2E6.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ceeda0f7893b37318ac48c151ba297ce954d0efa3e253b280eda6ccdd3a20a89
+oid sha256:5f6c1098b11e94768d16c0e4bf4f21bd0dc1bdd9bb733e003234f44c7a375d4c
 size 59819

--- a/test/testoutput/gnssro_2020-306-2358C2E6.nc
+++ b/test/testoutput/gnssro_2020-306-2358C2E6.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5500f28ec3599cb3ec1b2aa31eb90078dced2a69a532aa7329f275e5a75acac
-size 62620
+oid sha256:0461f822140186874c75394c86584266471973745c34b0378981f3e08bbdbfdc
+size 65140

--- a/test/testoutput/gnssro_2020-306-2358C2E6.nc
+++ b/test/testoutput/gnssro_2020-306-2358C2E6.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceeda0f7893b37318ac48c151ba297ce954d0efa3e253b280eda6ccdd3a20a89
+size 59819


### PR DESCRIPTION
## Description

Add capability to convert WMO BUFR formatted GNSSRO data to IODA directly with more flexible bufr2ioda application instead of fortran converter.  One problem is the Quality Flags remain a 16-bit integer whereas the existing IODA file does need the derived value of ascending and descending pass (bit position 3).  Therefore more processing of the quality flags will be needed within UFO.  This PR also adds documentation for BUFR mnemonics and sample obs into the doc subdirectory for additional data usage if needed.

### Issue(s) addressed

This item in particular does not have a corresponding issue number but moving towards BUFR-2-IODA in general needs to include as many data types as possible.

## Acceptance Criteria (Definition of Done)

Successful completion of ctest and useful IODA (v2) file for use within UFO (QC and subsequent steps).

## Dependencies

No dependencies.

## Impact

No impacts to other repos.
