### PR TITLE
Add BUFR conversion to IODA format for IASI, EARS AMSU-A and EARS MHS in NCAR-BUFR2NC utility

### DIFF
--- a/src/ncar-bufr2nc-fortran/define_mod.f90
+++ b/src/ncar-bufr2nc-fortran/define_mod.f90
@@ -19,8 +19,7 @@ integer(i_kind), parameter :: n_ncdim           = 5  ! total numner of nc dimens
 integer(i_kind), parameter :: nvar_met          = 6
 integer(i_kind), parameter :: nvar_info         = 9  ! number of metadata
 integer(i_kind), parameter :: nsen_info         = 7  ! number of sensor metadata
-integer(i_kind), parameter :: ninst             = 12
-!integer(i_kind), parameter :: ninst             = 13 ! including airs
+integer(i_kind), parameter :: ninst             = 15 ! including airs
 integer(i_kind), parameter :: write_nc_conv     = 1
 integer(i_kind), parameter :: write_nc_radiance = 2
 
@@ -81,7 +80,10 @@ character(len=nstring), dimension(ninst) :: inst_list = &
       'mhs_n19         ', &
       'mhs_metop-a     ', &
       'mhs_metop-b     ', &
-      'mhs_metop-c     '  &
+      'mhs_metop-c     ', &
+      'iasi_metop-a    ', &
+      'iasi_metop-b    ', &
+      'iasi_metop-c    '  &
    /)
 
 ! variables for outputing netcdf files

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -116,7 +116,11 @@ endif()
 if( iodaconv_bufr_ENABLED )
   list( APPEND test_input
     testinput/bufr_tables
+    testinput/gdas.t12z.1bamua.tm00.bufr_d
+    testinput/gdas.t12z.esamua.tm00.bufr_d
     testinput/gdas.t18z.1bmhs.tm00.bufr_d
+    testinput/gdas.t12z.esmhs.tm00.bufr_d
+    testinput/gdas.t12z.mtiasi.tm00.bufr_d
     testinput/gdas.t00z.1bhrs4.tm00.bufr_d
     testinput/gdas.t06z.adpsfc.tm00.bufr_d
     testinput/bufr_read_2_dim_blocks.bufr
@@ -197,6 +201,10 @@ if( iodaconv_pbfortran_ENABLED )
     testoutput/gnssro_obs_2018041500.nc4
     testoutput/sondes_obs_2020093018.nc4
     testoutput/mhs_metop-b_obs_2020101215.nc4
+    testoutput/mhs_metop-c_obs_2020110112.nc4
+    testoutput/amsua_metop-a_obs_2020110112.nc4
+    testoutput/amsua_metop-b_obs_2020110112.nc4
+    testoutput/iasi_metop-a_obs_2020110112.nc4
   )
 endif()
 
@@ -835,6 +843,42 @@ if( iodaconv_pbfortran_ENABLED )
                             "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
                             -i testinput -o testrun gdas.t18z.1bmhs.tm00.bufr_d"
                             mhs_metop-b_obs_2020101215.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2nc_fortran.x)
+
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ears_mhs_conv
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
+                            -i testinput -o testrun gdas.t12z.esmhs.tm00.bufr_d"
+                            mhs_metop-c_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2nc_fortran.x)
+
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_amsua_conv
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
+                            -i testinput -o testrun gdas.t12z.1bamua.tm00.bufr_d"
+                            amsua_metop-a_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2nc_fortran.x)
+
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ears_amsua_conv
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
+                            -i testinput -o testrun gdas.t12z.esamua.tm00.bufr_d"
+                            amsua_metop-b_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2nc_fortran.x)
+
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_iasi_conv
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
+                            -i testinput -o testrun gdas.t12z.mtiasi.tm00.bufr_d"
+                            iasi_metop-a_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2nc_fortran.x)
 
 endif()

--- a/test/testinput/gdas.t12z.1bamua.tm00.bufr_d
+++ b/test/testinput/gdas.t12z.1bamua.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf8ad9f8021162bc02c7ab0b3ef1f8a869e570e4d78fbea9162429aa4246b729
+size 3241840

--- a/test/testinput/gdas.t12z.esamua.tm00.bufr_d
+++ b/test/testinput/gdas.t12z.esamua.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81bb6beaf44bc4501d797715f133b0d793166dc39547b784710d1af8bd181579
+size 2619528

--- a/test/testinput/gdas.t12z.esmhs.tm00.bufr_d
+++ b/test/testinput/gdas.t12z.esmhs.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3ac45980b6741662b12f9515a77901d4258e55e2c74e324be0b339a00eadf9f
+size 6761232

--- a/test/testinput/gdas.t12z.mtiasi.tm00.bufr_d
+++ b/test/testinput/gdas.t12z.mtiasi.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44df6766f8afaf2b8770fb8279f924776fbcbb53e314a2ac345c09d4bdc221a6
+size 18903104

--- a/test/testoutput/amsua_metop-a_obs_2020110112.nc4
+++ b/test/testoutput/amsua_metop-a_obs_2020110112.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c70affda01b4dc8f6b1c470270cbbd76a5ad36b3652d5e2c0cddee72323c86a7
+size 4897269

--- a/test/testoutput/amsua_metop-b_obs_2020110112.nc4
+++ b/test/testoutput/amsua_metop-b_obs_2020110112.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce99490ccc7683c82b8dedc32e042bbeb82c518f72696dac7ac3a4a116ad1778
+size 3108971

--- a/test/testoutput/iasi_metop-a_obs_2020110112.nc4
+++ b/test/testoutput/iasi_metop-a_obs_2020110112.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c36dd2cc270aa05d6758e20881fe13da892a66312487fce53bf8161a0a2b4022
+size 49872439

--- a/test/testoutput/mhs_metop-c_obs_2020110112.nc4
+++ b/test/testoutput/mhs_metop-c_obs_2020110112.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f4efeef187504928665017c0e47feab252ad91630265c1fd8c571d2330ec486
+size 6224609


### PR DESCRIPTION
## Description
This PR includes the following:
(1) Add the capability of converting the following BUFR data to IODA format in NCAR-BUFR2NC utility:
 - IASI
 - EARS AMSU-A
 - EARS MHS

(2) Add input/output test data sets

