### PR TITLE
Add support for WMO-formatted BUFR files of 2 satellite wind (AMV) sources: EU_MetSat and Himawari

### DIFF
--- a/doc/bufr_obs_samples/satwind_EUMet_bufr_sample.txt
+++ b/doc/bufr_obs_samples/satwind_EUMet_bufr_sample.txt
@@ -1,0 +1,555 @@
+
+Found BUFR message #      1
+  
+        Message length:       18638
+      Section 0 length:           8
+          BUFR edition:           4
+  
+      Section 1 length:          22
+          Master table:           0
+    Originating center:         254 (= EUMETSAT Operation Centre)
+ Originating subcenter:           0 (= No sub-centre)
+ Update sequence numbr:           0
+    Section 2 present?: No
+         Data category:           5 (= Single level upper-air data (satellite))
+     Local subcategory:          10
+ Internatl subcategory:         255
+  Master table version:          31
+   Local table version:           0
+                  Year:        2021
+                 Month:           3
+                   Day:          24
+                  Hour:          23
+                Minute:          30
+                Second:           0
+  
+ Number of data subsets:         307
+     Data are observed?: Yes
+   Data are compressed?: Yes
+  Number of descriptors:           1
+        1: 310077
+
+BUFR message #      1 of type MSTTB001 and date 2021032423 contains    307 subsets:
+
+MESSAGE TYPE MSTTB001  
+
+001033  OGCE                       254.0  CODE TABLE                    Identification of originating/generating centre 
+                                    254 = EUMETSAT Operation Centre
+001034  GSES                         0.0  CODE TABLE                    Identification of originating/generating sub-cen
+                                      0 = No sub-centre
+025061  SOFTV                   MPEF_2.9  (12)CCITT IA5                 Software identification and version number      
+025062  DBID                     MISSING  NUMERIC                       Database identification                         
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+001012  DOMO                     MISSING  DEGREE TRUE                   Direction of motion of moving observing platform
+002026  CTRE                     MISSING  M                             Cross-track resolution                          
+002027  ATRE                     MISSING  M                             Along-track resolution                          
+002028  SSNX                     72000.0  M                             Segment size at nadir in x-direction            
+002029  SSNY                     72000.0  M                             Segment size at nadir in y-direction            
+002161  WDPF                     MISSING  FLAG TABLE                    Wind processing method                          
+002164  TCMD                         2.0  CODE TABLE                    Tracer correlation method                       
+                                      2 = CC - Cross correlation
+002023  SWCM                         3.0  CODE TABLE                    Satellite-derived wind computation method       
+                                      3 = Wind derived from motion observed in the water vapour channel
+008012  LSQL                         1.0  CODE TABLE                    Land/sea qualifier                              
+                                      1 = Sea
+008013  DNQL                     MISSING  CODE TABLE                    Day/night qualifier                             
+001124  GPTI                     MISSING  NUMERIC                       Grid point identifier                           
+005001  CLATH                  -46.40128  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                   91.59269  DEGREE                        Longitude (high accuracy)                       
+004001  YEAR                      2021.0  YEAR                          Year                                            
+004002  MNTH                         3.0  MONTH                         Month                                           
+004003  DAYS                        24.0  DAY                           Day                                             
+004004  HOUR                        23.0  HOUR                          Hour                                            
+004005  MINU                        30.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+004086  LTDS                      3600.0  S                             Long time period or displacement                
+002162  EHAM                         4.0  CODE TABLE                    Extended height assignment method               
+                                      4 = CO₂ slicing height assignment
+007004  PRLC                     22720.0  PA                            Pressure                                        
+011001  WDIR                       282.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        41.1  M S⁻¹                      Wind speed                                      
+011003  UWND                        40.2  M S⁻¹                      u-component                                     
+011004  VWND                        -8.6  M S⁻¹                      v-component                                     
+012001  TMDBST                     217.3  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+007024  SAZA                       73.70  DEGREE                        Satellite zenith angle                          
+001023  OSQN                     MISSING  NUMERIC                       Observation sequence number                     
+           {RPSEQ001}     3 REPLICATIONS
+    ++++++  RPSEQ001  REPLICATION #     1  ++++++
+002162  EHAM                         2.0  CODE TABLE                    Extended height assignment method               
+                                      2 = WV height assignment
+007004  PRLC                     22060.0  PA                            Pressure                                        
+012001  TMDBST                     216.6  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ001  REPLICATION #     2  ++++++
+002162  EHAM                        15.0  CODE TABLE                    Extended height assignment method               
+                                     15 = Optimal estimation
+007004  PRLC                     23650.0  PA                            Pressure                                        
+012001  TMDBST                     218.3  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ001  REPLICATION #     3  ++++++
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+           {RPSEQ002}     4 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+004086  LTDS                     -1800.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       73.70  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+004086  LTDS                      -900.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       73.70  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+004086  LTDS                         0.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       73.70  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     4  ++++++
+004086  LTDS                       900.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       73.70  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+           {RPSEQ003}     3 REPLICATIONS
+    ++++++  RPSEQ003  REPLICATION #     1  ++++++
+004086  LTDS                     -1800.0  S                             Long time period or displacement                
+004086  LTDS                         0.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        45.4  M S⁻¹                      u-component                                     
+011004  VWND                       -10.9  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+    ++++++  RPSEQ003  REPLICATION #     2  ++++++
+004086  LTDS                      -900.0  S                             Long time period or displacement                
+004086  LTDS                       900.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        41.2  M S⁻¹                      u-component                                     
+011004  VWND                        -9.8  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+    ++++++  RPSEQ003  REPLICATION #     3  ++++++
+004086  LTDS                         0.0  S                             Long time period or displacement                
+004086  LTDS                      1800.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        34.0  M S⁻¹                      u-component                                     
+011004  VWND                        -5.0  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+001033  OGCE                       254.0  CODE TABLE                    Identification of originating/generating centre 
+                                    254 = EUMETSAT Operation Centre
+008021  TSIG                        27.0  CODE TABLE                    Time significance                               
+                                     27 = First guess
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008021  TSIG                         4.0  CODE TABLE                    Time significance                               
+                                      4 = Forecast
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+008086  VSNWP                       10.0  FLAG TABLE(9,11)              Vertical significance for NWP                   
+                                      9 = Virtual station height
+                                     11 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008086  VSNWP                    MISSING  FLAG TABLE                    Vertical significance for NWP                   
+           "RPSEQ006"     4 REPLICATIONS
+    ++++++  RPSEQ006  REPLICATION #     1  ++++++
+001044  GNAPS                        6.0  CODE TABLE                    Standard generating application                 
+                                      6 = QI with forecast
+033007  PCCF                        78.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     2  ++++++
+001044  GNAPS                        5.0  CODE TABLE                    Standard generating application                 
+                                      5 = QI without forecast
+033007  PCCF                        75.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     3  ++++++
+001044  GNAPS                        4.0  CODE TABLE                    Standard generating application                 
+                                      4 = Common quality index (QI) without forecast
+033007  PCCF                        57.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     4  ++++++
+001044  GNAPS                        2.0  CODE TABLE                    Standard generating application                 
+                                      2 = Weighted mixture of individual tests, but excluding forecast comparison
+033007  PCCF                        71.0  %                             Per cent confidence                             
+008092  MUNCEX                       0.0  CODE TABLE                    Measurement uncertainty expression              
+                                      0 = Standard uncertainty
+007004  PRLC                       900.0  PA                            Pressure                                        
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008092  MUNCEX                   MISSING  CODE TABLE                    Measurement uncertainty expression              
+033066  AMVQ                     MISSING  FLAG TABLE                    AMV quality flag                                
+020081  CLDMNT                   MISSING  %                             Cloud amount in segment                         
+020012  CLTP                     MISSING  CODE TABLE                    Cloud type                                      
+020056  CLDP                     MISSING  CODE TABLE                    Cloud phase                                     
+           {RPSEQ007}     1 REPLICATIONS
+008023  FOST                         4.0  CODE TABLE                    First-order statistics                          
+                                      4 = Mean value
+020016  CDTP                     23650.0  PA                            Pressure at top of cloud                        
+008092  MUNCEX                       0.0  CODE TABLE                    Measurement uncertainty expression              
+                                      0 = Standard uncertainty
+008003  VSAT                         2.0  CODE TABLE                    Vertical significance (satellite observations)  
+                                      2 = Cloud top
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+008003  VSAT                     MISSING  CODE TABLE                    Vertical significance (satellite observations)  
+020016  CDTP                       420.0  PA                            Pressure at top of cloud                        
+008092  MUNCEX                   MISSING  CODE TABLE                    Measurement uncertainty expression              
+025149  OECS                     MISSING  NUMERIC                       Optimal estimation cost                         
+020016  CDTP                     MISSING  PA                            Pressure at top of cloud                        
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+013093  COPT                     MISSING  NUMERIC                       Cloud optical thickness                         
+013109  ILWP                     MISSING  KG M⁻²                     Ice/liquid water path                           
+040038  COTH                     MISSING  M                             Cloud particle size                             
+008011  METFET                      12.0  CODE TABLE                    Meteorological feature                          
+                                     12 = Cloud
+014050  EMMI                     MISSING  %                             Emissivity                                      
+008011  METFET                   MISSING  CODE TABLE                    Meteorological feature                          
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+
+ >>> END OF SUBSET <<< 
+
+
+MESSAGE TYPE MSTTB001  
+
+001033  OGCE                       254.0  CODE TABLE                    Identification of originating/generating centre 
+                                    254 = EUMETSAT Operation Centre
+001034  GSES                         0.0  CODE TABLE                    Identification of originating/generating sub-cen
+                                      0 = No sub-centre
+025061  SOFTV                   MPEF_2.9  (12)CCITT IA5                 Software identification and version number      
+025062  DBID                     MISSING  NUMERIC                       Database identification                         
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+001012  DOMO                     MISSING  DEGREE TRUE                   Direction of motion of moving observing platform
+002026  CTRE                     MISSING  M                             Cross-track resolution                          
+002027  ATRE                     MISSING  M                             Along-track resolution                          
+002028  SSNX                     72000.0  M                             Segment size at nadir in x-direction            
+002029  SSNY                     72000.0  M                             Segment size at nadir in y-direction            
+002161  WDPF                     MISSING  FLAG TABLE                    Wind processing method                          
+002164  TCMD                         2.0  CODE TABLE                    Tracer correlation method                       
+                                      2 = CC - Cross correlation
+002023  SWCM                         3.0  CODE TABLE                    Satellite-derived wind computation method       
+                                      3 = Wind derived from motion observed in the water vapour channel
+008012  LSQL                         1.0  CODE TABLE                    Land/sea qualifier                              
+                                      1 = Sea
+008013  DNQL                     MISSING  CODE TABLE                    Day/night qualifier                             
+001124  GPTI                     MISSING  NUMERIC                       Grid point identifier                           
+005001  CLATH                  -44.86068  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                   91.73624  DEGREE                        Longitude (high accuracy)                       
+004001  YEAR                      2021.0  YEAR                          Year                                            
+004002  MNTH                         3.0  MONTH                         Month                                           
+004003  DAYS                        24.0  DAY                           Day                                             
+004004  HOUR                        23.0  HOUR                          Hour                                            
+004005  MINU                        30.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+004086  LTDS                      3600.0  S                             Long time period or displacement                
+002162  EHAM                         4.0  CODE TABLE                    Extended height assignment method               
+                                      4 = CO₂ slicing height assignment
+007004  PRLC                     23900.0  PA                            Pressure                                        
+011001  WDIR                       269.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        49.0  M S⁻¹                      Wind speed                                      
+011003  UWND                        49.0  M S⁻¹                      u-component                                     
+011004  VWND                         0.5  M S⁻¹                      v-component                                     
+012001  TMDBST                     218.4  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+007024  SAZA                       72.92  DEGREE                        Satellite zenith angle                          
+001023  OSQN                     MISSING  NUMERIC                       Observation sequence number                     
+           {RPSEQ001}     3 REPLICATIONS
+    ++++++  RPSEQ001  REPLICATION #     1  ++++++
+002162  EHAM                         2.0  CODE TABLE                    Extended height assignment method               
+                                      2 = WV height assignment
+007004  PRLC                     23120.0  PA                            Pressure                                        
+012001  TMDBST                     217.0  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ001  REPLICATION #     2  ++++++
+002162  EHAM                        15.0  CODE TABLE                    Extended height assignment method               
+                                     15 = Optimal estimation
+007004  PRLC                     24070.0  PA                            Pressure                                        
+012001  TMDBST                     218.7  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ001  REPLICATION #     3  ++++++
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+           {RPSEQ002}     4 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+004086  LTDS                     -1800.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       72.92  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+004086  LTDS                      -900.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       72.92  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+004086  LTDS                         0.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       72.92  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+    ++++++  RPSEQ002  REPLICATION #     4  ++++++
+004086  LTDS                       900.0  S                             Long time period or displacement                
+002020  SCLF                       333.0  CODE TABLE                    Satellite classification                        
+                                    333 = METEOSAT Second Generation Programme (MSG)
+001007  SAID                        55.0  CODE TABLE                    Satellite identifier                            
+                                     55 = METEOSAT 8
+002019  SIID                       207.0  CODE TABLE                    Satellite instruments                           
+                                    207 = EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+005042  CHNM                         5.0  NUMERIC                       Channel number                                  
+002153  SCCF            47966800000000.0  HZ                            Satellite channel centre frequency              
+005040  ORBN                     MISSING  NUMERIC                       Orbit number                                    
+007024  SAZA                       72.92  DEGREE                        Satellite zenith angle                          
+005021  BEARAZ                   MISSING  DEGREE TRUE                   Bearing or azimuth                              
+002162  EHAM                     MISSING  CODE TABLE                    Extended height assignment method               
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+           {RPSEQ003}     3 REPLICATIONS
+    ++++++  RPSEQ003  REPLICATION #     1  ++++++
+004086  LTDS                     -1800.0  S                             Long time period or displacement                
+004086  LTDS                         0.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        49.7  M S⁻¹                      u-component                                     
+011004  VWND                        -0.8  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+    ++++++  RPSEQ003  REPLICATION #     2  ++++++
+004086  LTDS                      -900.0  S                             Long time period or displacement                
+004086  LTDS                       900.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        49.6  M S⁻¹                      u-component                                     
+011004  VWND                         0.5  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+    ++++++  RPSEQ003  REPLICATION #     3  ++++++
+004086  LTDS                         0.0  S                             Long time period or displacement                
+004086  LTDS                      1800.0  S                             Long time period or displacement                
+005001  CLATH                    MISSING  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                    MISSING  DEGREE                        Longitude (high accuracy)                       
+011003  UWND                        47.7  M S⁻¹                      u-component                                     
+011004  VWND                         1.7  M S⁻¹                      v-component                                     
+011113  TCOV                     MISSING  NUMERIC                       Tracking correlation of vector                  
+025148  CVWD                     MISSING  NUMERIC                       Coefficient of variation                        
+           {RPSEQ004}     1 REPLICATIONS
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+           {RPSEQ005}     1 REPLICATIONS
+020111  XEEM                     MISSING  M                             x-axis error ellipse major component            
+020112  YEEM                     MISSING  M                             y-axis error ellipse minor component            
+020114  AXEE                     MISSING  DEGREE                        Angle of x-axis in error ellipse                
+001033  OGCE                       254.0  CODE TABLE                    Identification of originating/generating centre 
+                                    254 = EUMETSAT Operation Centre
+008021  TSIG                        27.0  CODE TABLE                    Time significance                               
+                                     27 = First guess
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008021  TSIG                         4.0  CODE TABLE                    Time significance                               
+                                      4 = Forecast
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+008086  VSNWP                       10.0  FLAG TABLE(9,11)              Vertical significance for NWP                   
+                                      9 = Virtual station height
+                                     11 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+007004  PRLC                     MISSING  PA                            Pressure                                        
+011095  UMWV                     MISSING  M S⁻¹                      u-component of the model wind vector            
+011096  VWMV                     MISSING  M S⁻¹                      v-component of the model wind vector            
+008086  VSNWP                    MISSING  FLAG TABLE                    Vertical significance for NWP                   
+           "RPSEQ006"     4 REPLICATIONS
+    ++++++  RPSEQ006  REPLICATION #     1  ++++++
+001044  GNAPS                        6.0  CODE TABLE                    Standard generating application                 
+                                      6 = QI with forecast
+033007  PCCF                        95.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     2  ++++++
+001044  GNAPS                        5.0  CODE TABLE                    Standard generating application                 
+                                      5 = QI without forecast
+033007  PCCF                        94.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     3  ++++++
+001044  GNAPS                        4.0  CODE TABLE                    Standard generating application                 
+                                      4 = Common quality index (QI) without forecast
+033007  PCCF                        59.0  %                             Per cent confidence                             
+    ++++++  RPSEQ006  REPLICATION #     4  ++++++
+001044  GNAPS                        2.0  CODE TABLE                    Standard generating application                 
+                                      2 = Weighted mixture of individual tests, but excluding forecast comparison
+033007  PCCF                        94.0  %                             Per cent confidence                             
+008092  MUNCEX                       0.0  CODE TABLE                    Measurement uncertainty expression              
+                                      0 = Standard uncertainty
+007004  PRLC                       900.0  PA                            Pressure                                        
+011003  UWND                     MISSING  M S⁻¹                      u-component                                     
+011004  VWND                     MISSING  M S⁻¹                      v-component                                     
+008092  MUNCEX                   MISSING  CODE TABLE                    Measurement uncertainty expression              
+033066  AMVQ                     MISSING  FLAG TABLE                    AMV quality flag                                
+020081  CLDMNT                   MISSING  %                             Cloud amount in segment                         
+020012  CLTP                     MISSING  CODE TABLE                    Cloud type                                      
+020056  CLDP                     MISSING  CODE TABLE                    Cloud phase                                     
+           {RPSEQ007}     1 REPLICATIONS
+008023  FOST                         4.0  CODE TABLE                    First-order statistics                          
+                                      4 = Mean value
+020016  CDTP                     24070.0  PA                            Pressure at top of cloud                        
+008092  MUNCEX                       0.0  CODE TABLE                    Measurement uncertainty expression              
+                                      0 = Standard uncertainty
+008003  VSAT                         2.0  CODE TABLE                    Vertical significance (satellite observations)  
+                                      2 = Cloud top
+012001  TMDBST                   MISSING  K                             Temperature/air temperature                     
+008003  VSAT                     MISSING  CODE TABLE                    Vertical significance (satellite observations)  
+020016  CDTP                       200.0  PA                            Pressure at top of cloud                        
+008092  MUNCEX                   MISSING  CODE TABLE                    Measurement uncertainty expression              
+025149  OECS                     MISSING  NUMERIC                       Optimal estimation cost                         
+020016  CDTP                     MISSING  PA                            Pressure at top of cloud                        
+020014  HOCT                     MISSING  M                             Height of top of cloud                          
+013093  COPT                     MISSING  NUMERIC                       Cloud optical thickness                         
+013109  ILWP                     MISSING  KG M⁻²                     Ice/liquid water path                           
+040038  COTH                     MISSING  M                             Cloud particle size                             
+008011  METFET                      12.0  CODE TABLE                    Meteorological feature                          
+                                     12 = Cloud
+014050  EMMI                     MISSING  %                             Emissivity                                      
+008011  METFET                   MISSING  CODE TABLE                    Meteorological feature                          
+008023  FOST                     MISSING  CODE TABLE                    First-order statistics                          
+
+ >>> END OF SUBSET <<< 
+
+End of BUFR message #      1

--- a/doc/bufr_table_samples/satwind_EUMet_mnemonics.txt
+++ b/doc/bufr_table_samples/satwind_EUMet_mnemonics.txt
@@ -1,0 +1,189 @@
+
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| MSTTB001 | A54000 | TABLE A MNEMONIC MSTTB001                                |
+|          |        |                                                          |
+| SATDRWN2 | 310077 | Satellite-derived winds                                  |
+| RPSEQ001 | 354001 | REPLICATION SEQUENCE 001                                 |
+| RPSEQ002 | 354002 | REPLICATION SEQUENCE 002                                 |
+| RPSEQ003 | 354003 | REPLICATION SEQUENCE 003                                 |
+| RPSEQ004 | 354004 | REPLICATION SEQUENCE 004                                 |
+| RPSEQ005 | 354005 | REPLICATION SEQUENCE 005                                 |
+| RPSEQ006 | 354006 | REPLICATION SEQUENCE 006                                 |
+| RPSEQ007 | 354007 | REPLICATION SEQUENCE 007                                 |
+|          |        |                                                          |
+| OGCE     | 001033 | Identification of originating/generating centre          |
+| GSES     | 001034 | Identification of originating/generating sub-centre      |
+| SOFTV    | 025061 | Software identification and version number               |
+| DBID     | 025062 | Database identification                                  |
+| SAID     | 001007 | Satellite identifier                                     |
+| SCCF     | 002153 | Satellite channel centre frequency                       |
+| DOMO     | 001012 | Direction of motion of moving observing platform         |
+| CTRE     | 002026 | Cross-track resolution                                   |
+| ATRE     | 002027 | Along-track resolution                                   |
+| SSNX     | 002028 | Segment size at nadir in x-direction                     |
+| SSNY     | 002029 | Segment size at nadir in y-direction                     |
+| WDPF     | 002161 | Wind processing method                                   |
+| TCMD     | 002164 | Tracer correlation method                                |
+| SWCM     | 002023 | Satellite-derived wind computation method                |
+| LSQL     | 008012 | Land/sea qualifier                                       |
+| DNQL     | 008013 | Day/night qualifier                                      |
+| GPTI     | 001124 | Grid point identifier                                    |
+| CLATH    | 005001 | Latitude (high accuracy)                                 |
+| CLONH    | 006001 | Longitude (high accuracy)                                |
+| YEAR     | 004001 | Year                                                     |
+| MNTH     | 004002 | Month                                                    |
+| DAYS     | 004003 | Day                                                      |
+| HOUR     | 004004 | Hour                                                     |
+| MINU     | 004005 | Minute                                                   |
+| SECO     | 004006 | Second                                                   |
+| LTDS     | 004086 | Long time period or displacement                         |
+| EHAM     | 002162 | Extended height assignment method                        |
+| PRLC     | 007004 | Pressure                                                 |
+| WDIR     | 011001 | Wind direction                                           |
+| WSPD     | 011002 | Wind speed                                               |
+| UWND     | 011003 | u-component                                              |
+| VWND     | 011004 | v-component                                              |
+| TMDBST   | 012001 | Temperature/air temperature                              |
+| HOCT     | 020014 | Height of top of cloud                                   |
+| SAZA     | 007024 | Satellite zenith angle                                   |
+| OSQN     | 001023 | Observation sequence number                              |
+| SCLF     | 002020 | Satellite classification                                 |
+| SIID     | 002019 | Satellite instruments                                    |
+| CHNM     | 005042 | Channel number                                           |
+| ORBN     | 005040 | Orbit number                                             |
+| BEARAZ   | 005021 | Bearing or azimuth                                       |
+| TCOV     | 011113 | Tracking correlation of vector                           |
+| CVWD     | 025148 | Coefficient of variation                                 |
+| FOST     | 008023 | First-order statistics                                   |
+| XEEM     | 020111 | x-axis error ellipse major component                     |
+| YEEM     | 020112 | y-axis error ellipse minor component                     |
+| AXEE     | 020114 | Angle of x-axis in error ellipse                         |
+| TSIG     | 008021 | Time significance                                        |
+| UMWV     | 011095 | u-component of the model wind vector                     |
+| VWMV     | 011096 | v-component of the model wind vector                     |
+| VSNWP    | 008086 | Vertical significance for NWP                            |
+| GNAPS    | 001044 | Standard generating application                          |
+| PCCF     | 033007 | Per cent confidence                                      |
+| MUNCEX   | 008092 | Measurement uncertainty expression                       |
+| AMVQ     | 033066 | AMV quality flag                                         |
+| CLDMNT   | 020081 | Cloud amount in segment                                  |
+| CLTP     | 020012 | Cloud type                                               |
+| CLDP     | 020056 | Cloud phase                                              |
+| CDTP     | 020016 | Pressure at top of cloud                                 |
+| VSAT     | 008003 | Vertical significance (satellite observations)           |
+| OECS     | 025149 | Optimal estimation cost                                  |
+| COPT     | 013093 | Cloud optical thickness                                  |
+| ILWP     | 013109 | Ice/liquid water path                                    |
+| COTH     | 040038 | Cloud particle size                                      |
+| METFET   | 008011 | Meteorological feature                                   |
+| EMMI     | 014050 | Emissivity                                               |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| MSTTB001 | SATDRWN2                                                          |
+|          |                                                                   |
+| SATDRWN2 | OGCE  GSES  SOFTV  DBID  SAID  SCCF  DOMO  201138  CTRE  ATRE     |
+| SATDRWN2 | 201000  SSNX  SSNY  WDPF  TCMD  SWCM  LSQL  DNQL  GPTI  CLATH     |
+| SATDRWN2 | CLONH  YEAR  MNTH  DAYS  HOUR  MINU  SECO  LTDS  EHAM  PRLC  WDIR |
+| SATDRWN2 | WSPD  UWND  VWND  TMDBST  HOCT  SAZA  OSQN  {RPSEQ001}            |
+| SATDRWN2 | {RPSEQ002}  {RPSEQ003}  OGCE  TSIG  PRLC  UMWV  VWMV  TSIG  PRLC  |
+| SATDRWN2 | UMWV  VWMV  TSIG  VSNWP  PRLC  UMWV  VWMV  VSNWP  "RPSEQ006"4     |
+| SATDRWN2 | MUNCEX  PRLC  UWND  VWND  MUNCEX  AMVQ  CLDMNT  CLTP  CLDP        |
+| SATDRWN2 | {RPSEQ007}  FOST                                                  |
+|          |                                                                   |
+| RPSEQ001 | EHAM  PRLC  TMDBST  HOCT                                          |
+|          |                                                                   |
+| RPSEQ002 | LTDS  SCLF  SAID  SIID  CHNM  SCCF  ORBN  SAZA  BEARAZ  EHAM      |
+| RPSEQ002 | PRLC  TMDBST  HOCT                                                |
+|          |                                                                   |
+| RPSEQ003 | LTDS  LTDS  CLATH  CLONH  UWND  VWND  TCOV  CVWD  {RPSEQ004}      |
+| RPSEQ003 | FOST  {RPSEQ005}                                                  |
+|          |                                                                   |
+| RPSEQ004 | FOST  UWND  VWND                                                  |
+|          |                                                                   |
+| RPSEQ005 | XEEM  YEEM  AXEE                                                  |
+|          |                                                                   |
+| RPSEQ006 | GNAPS  PCCF                                                       |
+|          |                                                                   |
+| RPSEQ007 | FOST  CDTP  MUNCEX  VSAT  TMDBST  VSAT  CDTP  MUNCEX  OECS  CDTP  |
+| RPSEQ007 | HOCT  COPT  ILWP  COTH  METFET  EMMI  METFET                      |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| OGCE     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| GSES     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| SOFTV    |    0 |           0 |  96 | CCITT IA5                |-------------|
+| DBID     |    0 |           0 |  14 | NUMERIC                  |-------------|
+| SAID     |    0 |           0 |  10 | CODE TABLE               |-------------|
+| SCCF     |   -8 |           0 |  26 | HZ                       |-------------|
+| DOMO     |    0 |           0 |   9 | DEGREE TRUE              |-------------|
+| CTRE     |    2 |           0 |  12 | M                        |-------------|
+| ATRE     |    2 |           0 |  12 | M                        |-------------|
+| SSNX     |    0 |           0 |  18 | M                        |-------------|
+| SSNY     |    0 |           0 |  18 | M                        |-------------|
+| WDPF     |    0 |           0 |  16 | FLAG TABLE               |-------------|
+| TCMD     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| SWCM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| LSQL     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| DNQL     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| GPTI     |    0 |           0 |  24 | NUMERIC                  |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE                   |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE                   |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | S                        |-------------|
+| LTDS     |    0 |       -8192 |  15 | S                        |-------------|
+| EHAM     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRLC     |   -1 |           0 |  14 | PA                       |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREE TRUE              |-------------|
+| WSPD     |    1 |           0 |  12 | M S⁻¹                 |-------------|
+| UWND     |    1 |       -4096 |  13 | M S⁻¹                 |-------------|
+| VWND     |    1 |       -4096 |  13 | M S⁻¹                 |-------------|
+| TMDBST   |    1 |           0 |  12 | K                        |-------------|
+| HOCT     |   -1 |         -40 |  11 | M                        |-------------|
+| SAZA     |    2 |       -9000 |  15 | DEGREE                   |-------------|
+| OSQN     |    0 |           0 |   9 | NUMERIC                  |-------------|
+| SCLF     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| SIID     |    0 |           0 |  11 | CODE TABLE               |-------------|
+| CHNM     |    0 |           0 |   6 | NUMERIC                  |-------------|
+| ORBN     |    0 |           0 |  24 | NUMERIC                  |-------------|
+| BEARAZ   |    2 |           0 |  16 | DEGREE TRUE              |-------------|
+| TCOV     |    3 |       -1000 |  12 | NUMERIC                  |-------------|
+| CVWD     |    2 |      -10000 |  15 | NUMERIC                  |-------------|
+| FOST     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| XEEM     |   -1 |           0 |  17 | M                        |-------------|
+| YEEM     |   -1 |           0 |  17 | M                        |-------------|
+| AXEE     |    2 |      -18000 |  16 | DEGREE                   |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| UMWV     |    1 |       -4096 |  13 | M S⁻¹                 |-------------|
+| VWMV     |    1 |       -4096 |  13 | M S⁻¹                 |-------------|
+| VSNWP    |    0 |           0 |  12 | FLAG TABLE               |-------------|
+| GNAPS    |    0 |           0 |   8 | CODE TABLE               |-------------|
+| PCCF     |    0 |           0 |   7 | %                        |-------------|
+| MUNCEX   |    0 |           0 |   5 | CODE TABLE               |-------------|
+| AMVQ     |    0 |           0 |  24 | FLAG TABLE               |-------------|
+| CLDMNT   |    0 |           0 |   7 | %                        |-------------|
+| CLTP     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| CLDP     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| CDTP     |   -1 |           0 |  14 | PA                       |-------------|
+| VSAT     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| OECS     |    0 |           0 |   8 | NUMERIC                  |-------------|
+| COPT     |    0 |           0 |   8 | NUMERIC                  |-------------|
+| ILWP     |    3 |           0 |  10 | KG M⁻²                |-------------|
+| COTH     |    7 |           0 |  28 | M                        |-------------|
+| METFET   |    0 |           0 |   6 | CODE TABLE               |-------------|
+| EMMI     |    1 |           0 |  10 | %                        |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/satwind_Himawari_bufr_sample.txt
+++ b/doc/bufr_table_samples/satwind_Himawari_bufr_sample.txt
@@ -1,0 +1,333 @@
+
+Found BUFR message #      1
+  
+        Message length:       11721
+      Section 0 length:           8
+          BUFR edition:           4
+  
+      Section 1 length:          23
+          Master table:           0
+    Originating center:          34 (= Tokyo (RSMC), Japan Meteorological Agency)
+ Originating subcenter:           0 (= No sub-centre)
+ Update sequence numbr:           0
+    Section 2 present?: No
+         Data category:           5 (= Single level upper-air data (satellite))
+     Local subcategory:           0
+ Internatl subcategory:           0 (= Cloud wind data (SATOB))
+  Master table version:           8
+   Local table version:           0
+                  Year:        2019
+                 Month:          11
+                   Day:          27
+                  Hour:          12
+                Minute:           0
+                Second:           0
+  
+ Number of data subsets:         420
+     Data are observed?: Yes
+   Data are compressed?: Yes
+  Number of descriptors:          57
+        1: 310014
+        2: 222000
+        3: 236000
+        4: 101103
+        5: 031031
+        6: 001031
+        7: 001032
+        8: 101004
+        9: 033007
+       10: 222000
+       11: 237000
+       12: 001031
+       13: 001032
+       14: 101004
+       15: 033035
+       16: 222000
+       17: 237000
+       18: 001031
+       19: 001032
+       20: 101004
+       21: 033036
+       22: 222000
+       23: 237000
+       24: 001031
+       25: 001032
+       26: 101004
+       27: 033007
+       28: 222000
+       29: 237000
+       30: 001031
+       31: 001032
+       32: 101004
+       33: 033035
+       34: 222000
+       35: 237000
+       36: 001031
+       37: 001032
+       38: 101004
+       39: 033036
+       40: 222000
+       41: 237000
+       42: 001031
+       43: 001032
+       44: 101004
+       45: 033007
+       46: 222000
+       47: 237000
+       48: 001031
+       49: 001032
+       50: 101004
+       51: 033035
+       52: 222000
+       53: 237000
+       54: 001031
+       55: 001032
+       56: 101004
+       57: 033036
+
+BUFR message #      1 of type MSTTB001 and date 2019112712 contains    420 subsets:
+
+MESSAGE TYPE MSTTB001  
+
+001007  SAID                       173.0  CODE TABLE                    Satellite identifier                            
+                                    173 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+002020  SCLF                       273.0  CODE TABLE                    Satellite classification                        
+                                    273 = ***THIS IS AN ILLEGAL/UNDEFINED VALUE***
+002028  SSNX                     14000.0  M                             Segment size at nadir in x-direction            
+002029  SSNY                     14000.0  M                             Segment size at nadir in y-direction            
+004001  YEAR                      2019.0  YEAR                          Year                                            
+004002  MNTH                        11.0  MONTH                         Month                                           
+004003  DAYS                        27.0  DAY                           Day                                             
+004004  HOUR                        12.0  HOUR                          Hour                                            
+004005  MINU                        10.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+005001  CLATH                    2.37973  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                  139.25200  DEGREE                        Longitude (high accuracy)                       
+002152  SIDP                   4194304.0  FLAG TABLE(9)                 Satellite instrument used in data processing    
+                                      9 = Geostationary Imager
+002023  SWCM                         1.0  CODE TABLE                    Satellite-derived wind computation method       
+                                      1 = Wind derived from cloud motion observed in the infrared channel
+007004  PRLC                     97200.0  PA                            Pressure                                        
+011001  WDIR                       273.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        13.2  M S⁻¹                      Wind speed                                      
+002153  SCCF            28826100000000.0  HZ                            Satellite channel centre frequency              
+002154  SCBW             1164600000000.0  HZ                            Satellite channel band width                    
+012071  CCST                     MISSING  K                             Coldest cluster temperature                     
+002163  HAMD                        14.0  CODE TABLE                    Height assignment method                        
+                                     14 = Composite height assignment
+002164  TCMD                         2.0  CODE TABLE                    Tracer correlation method                       
+                                      2 = CC - Cross correlation
+008012  LSQL                     MISSING  CODE TABLE                    Land/sea qualifier                              
+007024  SAZA                        3.26  DEGREE                        Satellite zenith angle                          
+002057  OFGI                     MISSING  CODE TABLE                    Origin of first-guess information for GOES-I/M s
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004001  YEAR                     MISSING  YEAR                          Year                                            
+004002  MNTH                     MISSING  MONTH                         Month                                           
+004003  DAYS                     MISSING  DAY                           Day                                             
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004024  TPHR                     MISSING  HOUR                          Time period or displacement                     
+           "RPSEQ001"     4 REPLICATIONS
+    ++++++  RPSEQ001  REPLICATION #     1  ++++++
+008021  TSIG                        28.0  CODE TABLE                    Time significance                               
+                                     28 = Start of scan
+004004  HOUR                        11.0  HOUR                          Hour                                            
+004005  MINU                        50.0  MINUTE                        Minute                                          
+004006  SECO                        20.0  S                             Second                                          
+008021  TSIG                        29.0  CODE TABLE                    Time significance                               
+                                     29 = End of scan
+004004  HOUR                        12.0  HOUR                          Hour                                            
+004005  MINU                         0.0  MINUTE                        Minute                                          
+004006  SECO                        20.0  S                             Second                                          
+011001  WDIR                       273.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        13.2  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     2  ++++++
+008021  TSIG                        28.0  CODE TABLE                    Time significance                               
+                                     28 = Start of scan
+004004  HOUR                        12.0  HOUR                          Hour                                            
+004005  MINU                         0.0  MINUTE                        Minute                                          
+004006  SECO                        20.0  S                             Second                                          
+008021  TSIG                        29.0  CODE TABLE                    Time significance                               
+                                     29 = End of scan
+004004  HOUR                        12.0  HOUR                          Hour                                            
+004005  MINU                        10.0  MINUTE                        Minute                                          
+004006  SECO                        20.0  S                             Second                                          
+011001  WDIR                       273.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        13.2  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     3  ++++++
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     4  ++++++
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+           "RPSEQ002"    10 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+002163  HAMD                        14.0  CODE TABLE                    Height assignment method                        
+                                     14 = Composite height assignment
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+<REPEATS SNIPPED>
+    ++++++  RPSEQ002  REPLICATION #    10  ++++++
+002163  HAMD                        14.0  CODE TABLE                    Height assignment method                        
+                                     14 = Composite height assignment
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+           "RPSEQ003"   103 REPLICATIONS
+    ++++++  RPSEQ003  REPLICATION #     1  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+<REPEATS SNIPPED>
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       101.0  CODE TABLE                    Generating application                          
+                                    101 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+           "RPSEQ004"     4 REPLICATIONS
+    ++++++  RPSEQ004  REPLICATION #     1  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for PRLC                     
+    ++++++  RPSEQ004  REPLICATION #     2  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for WDIR                     
+    ++++++  RPSEQ004  REPLICATION #     3  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for WSPD                     
+    ++++++  RPSEQ004  REPLICATION #     4  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for CCST                     
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       101.0  CODE TABLE                    Generating application                          
+                                    101 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+           "RPSEQ005"     4 REPLICATIONS
+    ++++++  RPSEQ005  REPLICATION #     1  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for PRLC       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ005  REPLICATION #     2  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WDIR       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ005  REPLICATION #     3  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WSPD       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ005  REPLICATION #     4  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for CCST       
+                                      0 = Automatic quality control passed and not manually checked
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       101.0  CODE TABLE                    Generating application                          
+                                    101 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+           "RPSEQ006"     4 REPLICATIONS
+    ++++++  RPSEQ006  REPLICATION #     1  ++++++
+033036  NCTH                        65.0  %                             Nominal confidence threshold for PRLC           
+    ++++++  RPSEQ006  REPLICATION #     2  ++++++
+033036  NCTH                        65.0  %                             Nominal confidence threshold for WDIR           
+    ++++++  RPSEQ006  REPLICATION #     3  ++++++
+033036  NCTH                        65.0  %                             Nominal confidence threshold for WSPD           
+    ++++++  RPSEQ006  REPLICATION #     4  ++++++
+033036  NCTH                        65.0  %                             Nominal confidence threshold for CCST           
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       102.0  CODE TABLE                    Generating application                          
+                                    102 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+           "RPSEQ007"     4 REPLICATIONS
+    ++++++  RPSEQ007  REPLICATION #     1  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for PRLC                     
+    ++++++  RPSEQ007  REPLICATION #     2  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for WDIR                     
+    ++++++  RPSEQ007  REPLICATION #     3  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for WSPD                     
+    ++++++  RPSEQ007  REPLICATION #     4  ++++++
+033007  PCCF                        99.0  %                             Percent confidence for CCST                     
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       102.0  CODE TABLE                    Generating application                          
+                                    102 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+           "RPSEQ008"     4 REPLICATIONS
+    ++++++  RPSEQ008  REPLICATION #     1  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for PRLC       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ008  REPLICATION #     2  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WDIR       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ008  REPLICATION #     3  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WSPD       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ008  REPLICATION #     4  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for CCST       
+                                      0 = Automatic quality control passed and not manually checked
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       102.0  CODE TABLE                    Generating application                          
+                                    102 = Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+           "RPSEQ009"     4 REPLICATIONS
+    ++++++  RPSEQ009  REPLICATION #     1  ++++++
+033036  NCTH                        70.0  %                             Nominal confidence threshold for PRLC           
+    ++++++  RPSEQ009  REPLICATION #     2  ++++++
+033036  NCTH                        70.0  %                             Nominal confidence threshold for WDIR           
+    ++++++  RPSEQ009  REPLICATION #     3  ++++++
+033036  NCTH                        70.0  %                             Nominal confidence threshold for WSPD           
+    ++++++  RPSEQ009  REPLICATION #     4  ++++++
+033036  NCTH                        70.0  %                             Nominal confidence threshold for CCST           
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       103.0  CODE TABLE                    Generating application                          
+                                    103 = Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+           "RPSEQ010"     4 REPLICATIONS
+    ++++++  RPSEQ010  REPLICATION #     1  ++++++
+033007  PCCF                       100.0  %                             Percent confidence for PRLC                     
+    ++++++  RPSEQ010  REPLICATION #     2  ++++++
+033007  PCCF                       100.0  %                             Percent confidence for WDIR                     
+    ++++++  RPSEQ010  REPLICATION #     3  ++++++
+033007  PCCF                       100.0  %                             Percent confidence for WSPD                     
+    ++++++  RPSEQ010  REPLICATION #     4  ++++++
+033007  PCCF                       100.0  %                             Percent confidence for CCST                     
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       103.0  CODE TABLE                    Generating application                          
+                                    103 = Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+           "RPSEQ011"     4 REPLICATIONS
+    ++++++  RPSEQ011  REPLICATION #     1  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for PRLC       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ011  REPLICATION #     2  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WDIR       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ011  REPLICATION #     3  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for WSPD       
+                                      0 = Automatic quality control passed and not manually checked
+    ++++++  RPSEQ011  REPLICATION #     4  ++++++
+033035  MAQC                         0.0  CODE TABLE                    Manual/automatic quality control for CCST       
+                                      0 = Automatic quality control passed and not manually checked
+001031  GCLONG                      34.0  CODE TABLE                    Identification of originating/generating centre 
+                                     34 = Tokyo (RSMC), Japan Meteorological Agency
+001032  GNAP                       103.0  CODE TABLE                    Generating application                          
+                                    103 = Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+           "RPSEQ012"     4 REPLICATIONS
+    ++++++  RPSEQ012  REPLICATION #     1  ++++++
+033036  NCTH                        80.0  %                             Nominal confidence threshold for PRLC           
+    ++++++  RPSEQ012  REPLICATION #     2  ++++++
+033036  NCTH                        80.0  %                             Nominal confidence threshold for WDIR           
+    ++++++  RPSEQ012  REPLICATION #     3  ++++++
+033036  NCTH                        80.0  %                             Nominal confidence threshold for WSPD           
+    ++++++  RPSEQ012  REPLICATION #     4  ++++++
+033036  NCTH                        80.0  %                             Nominal confidence threshold for CCST           
+
+ >>> END OF SUBSET <<< 
+
+End of BUFR message #      1
+
+------------------------------------------------------------------------------------------------------------------------
+
+Reached end of BUFR file; it contained a total of      1 messages and      420 subsets

--- a/doc/bufr_table_samples/satwind_Himawari_mnemonics.txt
+++ b/doc/bufr_table_samples/satwind_Himawari_mnemonics.txt
@@ -1,0 +1,160 @@
+
+Here is the DX table that was generated:
+
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| MSTTB001 | A54000 | TABLE A MNEMONIC MSTTB001                                |
+|          |        |                                                          |
+| GEOSTWND | 310014 | Satellite - geostationary wind data                      |
+| SIDENSEQ | 301072 | Satellite identification                                 |
+| SIDGRSEQ | 301071 | Satellite identifier/Generating resolution               |
+| YYMMDD   | 301011 |                                                          |
+| HHMMSS   | 301013 |                                                          |
+| LTLONH   | 301021 |                                                          |
+| WINDSEQN | 303041 | Wind sequence                                            |
+| GOESIMIN | 304011 | GOES-I/M info                                            |
+| RPSEQ001 | 354001 | REPLICATION SEQUENCE 001                                 |
+| RPSEQ002 | 354002 | REPLICATION SEQUENCE 002                                 |
+| RPSEQ003 | 354003 | REPLICATION SEQUENCE 003                                 |
+| RPSEQ004 | 354004 | REPLICATION SEQUENCE 004                                 |
+| RPSEQ005 | 354005 | REPLICATION SEQUENCE 005                                 |
+| RPSEQ006 | 354006 | REPLICATION SEQUENCE 006                                 |
+| RPSEQ007 | 354007 | REPLICATION SEQUENCE 007                                 |
+| RPSEQ008 | 354008 | REPLICATION SEQUENCE 008                                 |
+| RPSEQ009 | 354009 | REPLICATION SEQUENCE 009                                 |
+| RPSEQ010 | 354010 | REPLICATION SEQUENCE 010                                 |
+| RPSEQ011 | 354011 | REPLICATION SEQUENCE 011                                 |
+| RPSEQ012 | 354012 | REPLICATION SEQUENCE 012                                 |
+|          |        |                                                          |
+| SAID     | 001007 | Satellite identifier                                     |
+| GCLONG   | 001031 | Identification of originating/generating centre          |
+| SCLF     | 002020 | Satellite classification                                 |
+| SSNX     | 002028 | Segment size at nadir in x-direction                     |
+| SSNY     | 002029 | Segment size at nadir in y-direction                     |
+| YEAR     | 004001 | Year                                                     |
+| MNTH     | 004002 | Month                                                    |
+| DAYS     | 004003 | Day                                                      |
+| HOUR     | 004004 | Hour                                                     |
+| MINU     | 004005 | Minute                                                   |
+| SECO     | 004006 | Second                                                   |
+| CLATH    | 005001 | Latitude (high accuracy)                                 |
+| CLONH    | 006001 | Longitude (high accuracy)                                |
+| SIDP     | 002152 | Satellite instrument used in data processing             |
+| SWCM     | 002023 | Satellite-derived wind computation method                |
+| PRLC     | 007004 | Pressure                                                 |
+| WDIR     | 011001 | Wind direction                                           |
+| WSPD     | 011002 | Wind speed                                               |
+| SCCF     | 002153 | Satellite channel centre frequency                       |
+| SCBW     | 002154 | Satellite channel band width                             |
+| CCST     | 012071 | Coldest cluster temperature                              |
+| HAMD     | 002163 | Height assignment method                                 |
+| TCMD     | 002164 | Tracer correlation method                                |
+| LSQL     | 008012 | Land/sea qualifier                                       |
+| SAZA     | 007024 | Satellite zenith angle                                   |
+| OFGI     | 002057 | Origin of first-guess information for GOES-I/M sounding  |
+| TSIG     | 008021 | Time significance                                        |
+| TPHR     | 004024 | Time period or displacement                              |
+| TMDBST   | 012001 | Temperature/dry-bulb temperature                         |
+| DPRI     | 031031 | Data present indicator                                   |
+| GNAP     | 001032 | Generating application                                   |
+| PCCF     | 033007 | Percent confidence                                       |
+| MAQC     | 033035 | Manual/automatic quality control                         |
+| NCTH     | 033036 | Nominal confidence threshold                             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| MSTTB001 | GEOSTWND  222000  236000  "RPSEQ003"103  GCLONG  GNAP             |
+| MSTTB001 | "RPSEQ004"4  222000  237000  GCLONG  GNAP  "RPSEQ005"4  222000    |
+| MSTTB001 | 237000  GCLONG  GNAP  "RPSEQ006"4  222000  237000  GCLONG  GNAP   |
+| MSTTB001 | "RPSEQ007"4  222000  237000  GCLONG  GNAP  "RPSEQ008"4  222000    |
+| MSTTB001 | 237000  GCLONG  GNAP  "RPSEQ009"4  222000  237000  GCLONG  GNAP   |
+| MSTTB001 | "RPSEQ010"4  222000  237000  GCLONG  GNAP  "RPSEQ011"4  222000    |
+| MSTTB001 | 237000  GCLONG  GNAP  "RPSEQ012"4                                 |
+|          |                                                                   |
+| GEOSTWND | SIDENSEQ  WINDSEQN  GOESIMIN                                      |
+|          |                                                                   |
+| SIDENSEQ | SIDGRSEQ  YYMMDD  HHMMSS  LTLONH                                  |
+|          |                                                                   |
+| SIDGRSEQ | SAID  GCLONG  SCLF  SSNX  SSNY                                    |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMMSS   | HOUR  MINU  SECO                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| WINDSEQN | SIDP  SWCM  PRLC  WDIR  WSPD  SCCF  SCBW  CCST                    |
+|          |                                                                   |
+| GOESIMIN | HAMD  TCMD  LSQL  SAZA  OFGI  TSIG  YEAR  MNTH  DAYS  HOUR  TSIG  |
+| GOESIMIN | TPHR  "RPSEQ001"4  "RPSEQ002"10                                   |
+|          |                                                                   |
+| RPSEQ001 | TSIG  HOUR  MINU  SECO  TSIG  HOUR  MINU  SECO  WDIR  WSPD        |
+|          |                                                                   |
+| RPSEQ002 | HAMD  PRLC  TMDBST                                                |
+|          |                                                                   |
+| RPSEQ003 | DPRI                                                              |
+|          |                                                                   |
+| RPSEQ004 | PCCF                                                              |
+|          |                                                                   |
+| RPSEQ005 | MAQC                                                              |
+|          |                                                                   |
+| RPSEQ006 | NCTH                                                              |
+|          |                                                                   |
+| RPSEQ007 | PCCF                                                              |
+|          |                                                                   |
+| RPSEQ008 | MAQC                                                              |
+|          |                                                                   |
+| RPSEQ009 | NCTH                                                              |
+|          |                                                                   |
+| RPSEQ010 | PCCF                                                              |
+|          |                                                                   |
+| RPSEQ011 | MAQC                                                              |
+|          |                                                                   |
+| RPSEQ012 | NCTH                                                              |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| SAID     |    0 |           0 |  10 | CODE TABLE               |-------------|
+| GCLONG   |    0 |           0 |  16 | CODE TABLE               |-------------|
+| SCLF     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| SSNX     |    0 |           0 |  18 | M                        |-------------|
+| SSNY     |    0 |           0 |  18 | M                        |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | S                        |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE                   |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE                   |-------------|
+| SIDP     |    0 |           0 |  31 | FLAG TABLE               |-------------|
+| SWCM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| PRLC     |   -1 |           0 |  14 | PA                       |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREE TRUE              |-------------|
+| WSPD     |    1 |           0 |  12 | M S⁻¹                 |-------------|
+| SCCF     |   -8 |           0 |  26 | HZ                       |-------------|
+| SCBW     |   -8 |           0 |  26 | HZ                       |-------------|
+| CCST     |    1 |           0 |  12 | K                        |-------------|
+| HAMD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TCMD     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| LSQL     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| SAZA     |    2 |       -9000 |  15 | DEGREE                   |-------------|
+| OFGI     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TMDBST   |    1 |           0 |  12 | K                        |-------------|
+| DPRI     |    0 |           0 |   1 | FLAG TABLE               |-------------|
+| GNAP     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| PCCF     |    0 |           0 |   7 | %                        |-------------|
+| MAQC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| NCTH     |    0 |           0 |   7 | %                        |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,10 @@ if( iodaconv_bufr_ENABLED )
     testinput/amdar_wmo_single.bufr
     testinput/gnssro_wmoBUFR2ioda.yaml
     testinput/gnssro_2020-306-2358C2E6.bufr
+    testinput/satwind_EUMet_wmoBUFR2ioda.yaml
+    testinput/satwind_EUMet_wmo.bufr
+    testinput/satwind_Himawari_wmoBUFR2ioda.yaml
+    testinput/satwind_Himawari_wmo.bufr
   )
 
   list( APPEND test_output
@@ -157,6 +161,8 @@ if( iodaconv_bufr_ENABLED )
     testoutput/airep_multi.nc
     testoutput/amdar_single.nc
     testoutput/gnssro_2020-306-2358C2E6.nc
+    testoutput/satwind_EUMet.nc
+    testoutput/satwind_Himawari.nc
   )
 endif()
 
@@ -801,6 +807,22 @@ if(iodaconv_bufr_ENABLED)
                     ARGS    netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/gnssro_wmoBUFR2ioda.yaml"
                     gnssro_2020-306-2358C2E6.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_EUMet_wmo_bufr
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_EUMet_wmoBUFR2ioda.yaml"
+                    satwind_EUMet.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_Himawari_wmo_bufr
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_Himawari_wmoBUFR2ioda.yaml"
+                    satwind_Himawari.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 endif()
 

--- a/test/testinput/satwind_EUMet_wmo.bufr
+++ b/test/testinput/satwind_EUMet_wmo.bufr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0387ff051c4a347a815dd8f4bad52c4bd0018a7b1172ede96740f010ab7e570
+size 3087915

--- a/test/testinput/satwind_EUMet_wmoBUFR2ioda.yaml
+++ b/test/testinput/satwind_EUMet_wmoBUFR2ioda.yaml
@@ -1,0 +1,170 @@
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+      obsdatain: "./testinput/satwind_EUMet_wmo.bufr"
+      isWmoFormat: true
+
+      tablepath: "./testinput/bufr_tables"
+
+      mnemonicSets:
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, CLATH, CLONH]
+        - mnemonics: [SAID, SWCM, GNAPS, EHAM, AMVQ]
+        - mnemonics: [SAZA, TCMD]
+        - mnemonics: [SCCF]
+        - mnemonics: [PRLC, UWND, VWND]
+        - mnemonics: [PCCF]
+          channels: 1-4
+
+      exports:
+        filters:
+          - bounding:
+              mnemonic: CLONH
+              lowerBound: -180
+              upperBound: 180
+        variables:
+          datetime:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+          latitude:
+            mnemonic: CLATH
+          longitude:
+            mnemonic: CLONH
+          satelliteId:
+            mnemonic: SAID
+          generatingApplication:
+            mnemonic: GNAPS
+          sensorCentralFrequency:
+            mnemonic: SCCF
+          windComputationMethod:
+            mnemonic: SWCM
+          windHeightAssignMethod:
+            mnemonic: EHAM
+          windTrackingCorrelation:
+            mnemonic: TCMD
+          amvQualityFlag:
+            mnemonic: AMVQ
+          sensorZenithAngle:
+            mnemonic: SAZA
+          pressureAir:
+            mnemonic: PRLC
+          windEastward:
+            mnemonic: UWND
+          windNorthward:
+            mnemonic: VWND
+          windPercentConfidence:
+            mnemonic: PCCF
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/satwind_EUMet.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+        - name: "nconfidences"
+          size: variables/windPercentConfidence.ncols
+
+      globals:
+        - name: "MetaData/platformCommonName"
+          type: string
+          value: "EUMetSat_AMV"
+
+        - name: "MetaData/platformLongDescription"
+          type: string
+          value: "EUMetSat AMV from IR cloudy regions"
+
+      variables:
+        - name: "MetaData/satelliteId"
+          source: variables/satelliteId
+          dimensions: ["nlocs"]
+          longName: "Satellite identification"
+          units: ""
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          dimensions: ["nlocs"]
+          longName: "Latitude"
+          units: "degrees"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          dimensions: ["nlocs"]
+          longName: "Longitude"
+          units: "degrees"
+          range: [-180, 180]
+
+        - name: "MetaData/datetime"
+          source: variables/datetime
+          dimensions: ["nlocs"]
+          longName: "DateTime"
+          units: "datetime"
+
+        - name: "MetaData/generatingApplication"
+          source: variables/generatingApplication
+          dimensions: ["nlocs"]
+          longName: "Generating application"
+          units: "unitless"
+
+        - name: "MetaData/windComputationMethod"
+          source: variables/windComputationMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind calculation method"
+          units: "unitless"
+
+        - name: "MetaData/windHeightAssignMethod"
+          source: variables/windHeightAssignMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind height assignment method"
+          units: "unitless"
+
+        - name: "MetaData/sensorZenithAngle"
+          coordinates: "longitude latitude"
+          source: variables/sensorZenithAngle
+          dimensions: ["nlocs"]
+          longName: "Satellite zenith angle"
+          units: "degrees"
+
+        - name: "MetaData/pressureAir"
+          coordinates: "longitude latitude"
+          source: variables/pressureAir
+          dimensions: ["nlocs"]
+          longName: "Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/windEastward"
+          coordinates: "longitude latitude"
+          source: variables/windEastward
+          dimensions: ["nlocs"]
+          longName: "Wind eastward component"
+          units: "m s-1"
+
+        - name: "ObsValue/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windNorthward
+          dimensions: ["nlocs"]
+          longName: "Wind northward component"
+          units: "m s-1"
+
+        - name: "MetaData/windPercentConfidence"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/windPercentConfidence
+          dimensions: ["nlocs", "nconfidences"]
+          longName: "Percent confidence"
+          units: "percent"
+
+        - name: "MetaData/sensorCentralFrequency"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/sensorCentralFrequency
+          dimensions: ["nlocs"]
+          longName: "Sensor Central Frequency"
+          units: "hz"

--- a/test/testinput/satwind_Himawari_wmo.bufr
+++ b/test/testinput/satwind_Himawari_wmo.bufr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b7906c38207659ffab3fdf16ed964023327e7934413f058c0c3d600eb7a45a3
+size 16032

--- a/test/testinput/satwind_Himawari_wmoBUFR2ioda.yaml
+++ b/test/testinput/satwind_Himawari_wmoBUFR2ioda.yaml
@@ -1,0 +1,178 @@
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+      obsdatain: "./testinput/satwind_Himawari_wmo.bufr"
+      isWmoFormat: true
+
+      tablepath: "./testinput/bufr_tables"
+
+      mnemonicSets:
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, CLATH, CLONH]
+        - mnemonics: [SAID, GCLONG, SIDP, SWCM, GNAP, HAMD]
+        - mnemonics: [SAZA, TCMD]
+        - mnemonics: [SCCF]
+        - mnemonics: [PRLC, WDIR, WSPD]
+        - mnemonics: [MAQC]
+          channels: 1-4
+        - mnemonics: [PCCF]
+          channels: 1-4
+
+      exports:
+        filters:
+          - bounding:
+              mnemonic: CLONH
+              lowerBound: -180
+              upperBound: 180
+        variables:
+          datetime:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+          latitude:
+            mnemonic: CLATH
+          longitude:
+            mnemonic: CLONH
+          satelliteId:
+            mnemonic: SAID
+          dataProviderOrigin:
+            mnemonic: GCLONG
+          generatingApplication:
+            mnemonic: GNAP
+          sensorCentralFrequency:
+            mnemonic: SCCF
+          windComputationMethod:
+            mnemonic: SWCM
+          windHeightAssignMethod:
+            mnemonic: HAMD
+          windTrackingCorrelation:
+            mnemonic: TCMD
+          sensorZenithAngle:
+            mnemonic: SAZA
+          pressureAir:
+            mnemonic: PRLC
+          windDirection:
+            mnemonic: WDIR
+          windSpeed:
+            mnemonic: WSPD
+          windPercentConfidence:
+            mnemonic: PCCF
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/satwind_Himawari.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+        - name: "nconfidences"
+          size: variables/windPercentConfidence.ncols
+
+      globals:
+        - name: "MetaData/platformCommonName"
+          type: string
+          value: "Himiwari_AMV"
+
+        - name: "MetaData/platformLongDescription"
+          type: string
+          value: "Himiwari AMV from IR cloudy regions"
+
+      variables:
+        - name: "MetaData/satelliteId"
+          source: variables/satelliteId
+          dimensions: ["nlocs"]
+          longName: "Satellite identification"
+          units: ""
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          dimensions: ["nlocs"]
+          longName: "Latitude"
+          units: "degrees"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          dimensions: ["nlocs"]
+          longName: "Longitude"
+          units: "degrees"
+          range: [-180, 180]
+
+        - name: "MetaData/datetime"
+          source: variables/datetime
+          dimensions: ["nlocs"]
+          longName: "DateTime"
+          units: "datetime"
+
+        - name: "MetaData/dataProviderOrigin"
+          source: variables/dataProviderOrigin
+          dimensions: ["nlocs"]
+          longName: "Data provider origin"
+          units: ""
+
+        - name: "MetaData/generatingApplication"
+          source: variables/generatingApplication
+          dimensions: ["nlocs"]
+          longName: "Generating application"
+          units: ""
+
+        - name: "MetaData/windComputationMethod"
+          source: variables/windComputationMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind calculation method"
+          units: " "
+
+        - name: "MetaData/windHeightAssignMethod"
+          source: variables/windHeightAssignMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind height assignment method"
+          units: " "
+
+        - name: "MetaData/sensorZenithAngle"
+          coordinates: "longitude latitude"
+          source: variables/sensorZenithAngle
+          dimensions: ["nlocs"]
+          longName: "Satellite zenith angle"
+          units: "degrees"
+
+        - name: "MetaData/pressureAir"
+          coordinates: "longitude latitude"
+          source: variables/pressureAir
+          dimensions: ["nlocs"]
+          longName: "Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          dimensions: ["nlocs"]
+          longName: "Wind direction"
+          units: "degrees true"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          dimensions: ["nlocs"]
+          longName: "Wind Speed"
+          units: "m s-1"
+
+        - name: "MetaData/windPercentConfidence"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/windPercentConfidence
+          dimensions: ["nlocs", "nconfidences"]
+          longName: "Percent confidence"
+          units: "percent"
+
+        - name: "MetaData/sensorCentralFrequency"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/sensorCentralFrequency
+          dimensions: ["nlocs"]
+          longName: "Sensor Central Frequency"
+          units: "hz"

--- a/test/testoutput/satwind_EUMet.nc
+++ b/test/testoutput/satwind_EUMet.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09ab07008dcf31738c36d7ffdf33720ddcd2d5b9b218611ef89aa89e3fe26a04
+size 4011241

--- a/test/testoutput/satwind_Himawari.nc
+++ b/test/testoutput/satwind_Himawari.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c504a76429365bd8f617912c04ae50bec22f1356feed4a7cd5808a5e0068cff
+size 78663


### PR DESCRIPTION
## Description

This PR adds 2 observation types of satellite atmospheric motion vectors (AMV) from EU_Met and Himawari in WMO-formatted BUFR to convert to IODA. Included in the PR are a sample of a single observation of each type, the BUFR table (in doc folder) and sample print of the bufr contents (doc folder).

### Issue(s) addressed

Closes #717 

## Acceptance Criteria (Definition of Done)

Working ctests

## Dependencies

None, although #714 might need to precede this PR since there could otherwise appear to be a merge conflict with test/CMakelists.txt file since they are added subsequently in same file location as that PR.

## Impact

No impacts to other repos.
