### PR TITLE
New marine converter: godae BGC-Argo profiles

### DIFF
--- a/src/marine/CMakeLists.txt
+++ b/src/marine/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND programs
   argoClim2ioda.py
   viirs_modis_l2_oc2ioda.py
   viirs_modis_l3_oc2ioda.py
+  godae_bgc_argo2ioda.py
 )
 
 file( RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_BINARY_DIR}/bin ${PYIODACONV_BUILD_LIBDIR} )

--- a/src/marine/godae_bgc_argo2ioda.py
+++ b/src/marine/godae_bgc_argo2ioda.py
@@ -68,8 +68,8 @@ class Profile(object):
             qcKey = vName['CHL'], iconv.OqcName()
 
             dt = base_date + timedelta(days=float(time[1]))
-            locKey = ma.getdata(lats)[1], ma.getdata(lons)[1], 
-            ma.getdata(dpth)[1][i], dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            locKey = ma.getdata(lats)[1], ma.getdata(lons)[1], \
+                ma.getdata(dpth)[1][i], dt.strftime("%Y-%m-%dT%H:%M:%SZ")
             self.data[locKey][valKey] = ma.getdata(vals)[1][i]
             self.data[locKey][errKey] = ma.getdata(errs)[1][i]
             self.data[locKey][qcKey] = 0

--- a/src/marine/godae_bgc_argo2ioda.py
+++ b/src/marine/godae_bgc_argo2ioda.py
@@ -122,5 +122,6 @@ def main():
     VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'PreQC')]['_FillValue'] = 999
     writer.BuildIoda(ObsVars, VarDims, VarAttrs, GlobalAttrs)
 
+
 if __name__ == '__main__':
     main()

--- a/src/marine/godae_bgc_argo2ioda.py
+++ b/src/marine/godae_bgc_argo2ioda.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+#
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+
+from __future__ import print_function
+import sys
+import argparse
+import netCDF4 as nc
+from datetime import datetime, timedelta
+from pathlib import Path
+import numpy.ma as ma
+
+IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
+if not IODA_CONV_PATH.is_dir():
+    IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
+sys.path.append(str(IODA_CONV_PATH.resolve()))
+
+import ioda_conv_engines as iconv
+from orddicts import DefaultOrderedDict
+
+vName = {
+    'CHL': "mass_concentration_of_chlorophyll_in_sea_water",
+}
+
+locationKeyList = [
+    ("latitude", "float"),
+    ("longitude", "float"),
+    ("depth", "float"),
+    ("datetime", "string")
+]
+
+GlobalAttrs = {}
+
+
+class Profile(object):
+
+    def __init__(self, filename, date):
+        self.filename = filename
+        self.date = date
+        self.data = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
+        self._read()
+
+    def _read(self):
+        ncd = nc.Dataset(self.filename)
+        time = ncd.variables['JULD'][:]
+        dpth = ncd.variables['PRES'][:]
+        lons = ncd.variables['LONGITUDE'][:]
+        lats = ncd.variables['LATITUDE'][:]
+        vals = ncd.variables['CHLA_ADJUSTED'][:]
+        errs = ncd.variables['CHLA_ADJUSTED_ERROR'][:]
+        qcs = ncd.variables['CHLA_ADJUSTED_QC'][:]
+        ncd.close()
+
+        base_date = datetime(1950, 1, 1)
+
+        for i in range(len(dpth[1])-1):
+
+            if ma.getmask(vals)[1][i] == 1:
+                continue
+
+            valKey = vName['CHL'], iconv.OvalName()
+            errKey = vName['CHL'], iconv.OerrName()
+            qcKey = vName['CHL'], iconv.OqcName()
+
+            dt = base_date + timedelta(days=float(time[1]))
+            locKey = ma.getdata(lats)[1], ma.getdata(lons)[1], 
+            ma.getdata(dpth)[1][i], dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            self.data[locKey][valKey] = ma.getdata(vals)[1][i]
+            self.data[locKey][errKey] = ma.getdata(errs)[1][i]
+            self.data[locKey][qcKey] = 0
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description=(
+            'Read BGC-Argo chlorophyll profile from godae'
+            '  and convert to IODA v2 format.'
+        )
+    )
+
+    required = parser.add_argument_group(title='required arguments')
+    required.add_argument(
+        '-i', '--input',
+        help="name of BGC-Argo observation input file(s)",
+        type=str, required=True)
+    required.add_argument(
+        '-o', '--output',
+        help="path of ioda output file",
+        type=str, required=True)
+    required.add_argument(
+        '-d', '--date',
+        help="base date for the center of the window",
+        metavar="YYYYMMDDHH", type=str, required=True)
+    args = parser.parse_args()
+    fdate = datetime.strptime(args.date, '%Y%m%d%H')
+
+    VarDims = {
+        'mass_concentration_of_chlorophyll_in_sea_water': ['nlocs'],
+    }
+
+    # Read in argo profiles
+    prof = Profile(args.input, fdate)
+
+    # write them out
+    ObsVars, nlocs = iconv.ExtractObsData(prof.data, locationKeyList)
+
+    DimDict = {'nlocs': nlocs}
+    writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)
+
+    VarAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'ObsValue')]['units'] = 'mg m-3'
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'ObsError')]['units'] = 'mg m-3'
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'PreQC')]['units'] = 'unitless'
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'ObsValue')]['_FillValue'] = 999.
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'ObsError')]['_FillValue'] = 999.
+    VarAttrs[('mass_concentration_of_chlorophyll_in_sea_water', 'PreQC')]['_FillValue'] = 999
+    writer.BuildIoda(ObsVars, VarDims, VarAttrs, GlobalAttrs)
+
+if __name__ == '__main__':
+    main()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ list( APPEND test_input
   testinput/aeronet_tab.dat
   testinput/imsscf_20191215_c48.nc
   testinput/glider.yaml
+  testinput/godae_bgc_argo.nc
 )
 
 list( APPEND test_output
@@ -102,6 +103,7 @@ list( APPEND test_output
   testoutput/ioda_global_vavh_l3_rt_s3a_20210930T18.nc
   testoutput/aeronet_aaod.nc
   testoutput/imsfv3_scf.nc
+  testoutput/godae_bgc_argo.nc
 )
 
 if( iodaconv_gnssro_ENABLED )
@@ -514,6 +516,17 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_jpss1_oc_l3
                           -o testrun/viirs_jpss1_oc_l3.nc
                           -d 2018041512"
                           viirs_jpss1_oc_l3.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_bgc_argo
+                  TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                  ARGS    netcdf
+                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/godae_bgc_argo2ioda.py
+                          -i testinput/godae_bgc_argo.nc
+                          -o testrun/godae_bgc_argo.nc
+                          -d 2018041512"
+                          godae_bgc_argo.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ncep_bufr
                   TYPE    SCRIPT

--- a/test/testinput/godae_bgc_argo.nc
+++ b/test/testinput/godae_bgc_argo.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1fe66c0068fb5c5854c2aa57e002d8ae7f39afece4680e4893bc7100823577d
+size 335272

--- a/test/testoutput/godae_bgc_argo.nc
+++ b/test/testoutput/godae_bgc_argo.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e36507afc4a2a8cfb54dd5609967bc978d5dea8cc99a2d0d68311729f75e559e
+size 18121


### PR DESCRIPTION
## Description

This PR adds a python script to "marine" that reads in historical or near real-time biogeochemical (BGC) Argo profiles from godae ftp server and converts to a unified format that supports IODA v2.

A small example data file (a single pair of upward and downward profile) was fetched from https://biogeochemical-argo.org/data-access.php (godae ftp server). This portal provides historical and near real-time (w/ approximately 24 hours delay) Argo profiles in .nc format from participating Argo fleets.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #726 
- fixes soca-science issue [#383](https://github.com/JCSDA-internal/soca-science/issues/383)
