### PR TITLE
Add BUFR-to-IODA support for Aircraft data: gdas.aircar files (similar to amdar_wmoBUFR2ioda.yaml)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,6 +143,8 @@ if( iodaconv_bufr_ENABLED )
     testinput/bufr_read_wmo_radiosonde.yaml
     testinput/bufr_satwnd_old_format.yaml
     testinput/bufr_satwnd_new_format.yaml
+    testinput/aircar_BUFR2ioda.yaml
+    testinput/gdas.aircar.t00z.20210801.bufr
     testinput/airep_wmoBUFR2ioda.yaml
     testinput/airep_wmo_multi.bufr
     testinput/amdar_wmoBUFR2ioda.yaml
@@ -173,6 +175,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/bufr_read_wmo_radiosonde.nc
     testoutput/NC005031.nc
     testoutput/NC005066.nc
+    testoutput/gdas.aircar.t00z.20210801.nc
     testoutput/airep_multi.nc
     testoutput/amdar_wmo_multi.nc
     testoutput/gnssro_2020-306-2358C2E6.nc
@@ -842,6 +845,14 @@ if(iodaconv_bufr_ENABLED)
                     ARGS    netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_satwnd_new_format.yaml"
                     NC005031.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_aircar
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/aircar_BUFR2ioda.yaml"
+                    gdas.aircar.t00z.20210801.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_airep_wmo_bufr

--- a/test/testinput/aircar_BUFR2ioda.yaml
+++ b/test/testinput/aircar_BUFR2ioda.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2022 UCAR
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,8 +6,7 @@
 observations:
   - obs space:
       name: bufr
-#     obsdatain: "./testinput/amdar_wmo_multi.bufr"
-      obsdatain: "/home/gthompsn/src/gdas.aircar.t00z.20210801.bufr"
+      obsdatain: "./testinput/gdas.aircar.t00z.20210801.bufr"
 #     isWmoFormat: true
       tablepath: "./testinput/bufr_tables"
 
@@ -56,7 +55,6 @@ observations:
 
     ioda:
       backend: netcdf
-#     obsdataout: "./testrun/amdar_wmo_multi.nc"
       obsdataout: "./testrun/gdas.aircar.t00z.20210801.nc"
 
       dimensions:

--- a/test/testinput/aircar_BUFR2ioda.yaml
+++ b/test/testinput/aircar_BUFR2ioda.yaml
@@ -12,11 +12,11 @@ observations:
 
       mnemonicSets:
         - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, SECO]
-        - mnemonics: [ACRN, ACID]
+        - mnemonics: [ACID, ACRN]
         - mnemonics: [CLAT, CLON]
-        - mnemonics: [IALT, DPOF]
-        - mnemonics: [TMDB, WDIR, WSPD]
-        - mnemonics: [ROLQ, TASP, ACTH]
+        - mnemonics: [IALT, DPOF, ROLQ]
+        - mnemonics: [MIXR, TMDB, WDIR, WSPD]
+        - mnemonics: [TASP, ACTH]
 
       exports:
         variables:
@@ -34,10 +34,10 @@ observations:
             mnemonic: CLON
           height:
             mnemonic: IALT
-          aircraftRegistrationNum:
-            mnemonic: ACRN
           aircraftFlightNum:
             mnemonic: ACID
+          aircraftRegistrationNum:
+            mnemonic: ACRN
           aircraftFlightPhase:
             mnemonic: DPOF
           aircraftTrueAirspeed:
@@ -48,6 +48,8 @@ observations:
             mnemonic: ROLQ
           temperatureAir:
             mnemonic: TMDB
+          waterVaporMixingRatio:
+            mnemonic: MIXR
           windDirection:
             mnemonic: WDIR
           windSpeed:
@@ -128,6 +130,13 @@ observations:
           dimensions: [ "nlocs" ]
           longName: "Air Temperature"
           units: "K"
+
+        - name: "ObsValue/specific_humidity"
+          coordinates: "longitude latitude"
+          source: variables/waterVaporMixingRatio
+          dimensions: [ "nlocs" ]
+          longName: "specific humidity"
+          units: "kg kg-1"
 
         - name: "ObsValue/wind_direction"
           coordinates: "longitude latitude"

--- a/test/testinput/aircar_BUFR2ioda.yaml
+++ b/test/testinput/aircar_BUFR2ioda.yaml
@@ -1,0 +1,146 @@
+# (C) Copyright 2021 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+#     obsdatain: "./testinput/amdar_wmo_multi.bufr"
+      obsdatain: "/home/gthompsn/src/gdas.aircar.t00z.20210801.bufr"
+#     isWmoFormat: true
+      tablepath: "./testinput/bufr_tables"
+
+      mnemonicSets:
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, SECO]
+        - mnemonics: [ACRN, ACID]
+        - mnemonics: [CLAT, CLON]
+        - mnemonics: [IALT, DPOF]
+        - mnemonics: [TMDB, WDIR, WSPD]
+        - mnemonics: [ROLQ, TASP, ACTH]
+
+      exports:
+        variables:
+          timestamp:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+              second: SECO
+          latitude:
+            mnemonic: CLAT
+          longitude:
+            mnemonic: CLON
+          height:
+            mnemonic: IALT
+          aircraftRegistrationNum:
+            mnemonic: ACRN
+          aircraftFlightNum:
+            mnemonic: ACID
+          aircraftFlightPhase:
+            mnemonic: DPOF
+          aircraftTrueAirspeed:
+            mnemonic: TASP
+          aircraftHeading:
+            mnemonic: ACTH
+          aircraftRollAngle:
+            mnemonic: ROLQ
+          temperatureAir:
+            mnemonic: TMDB
+          windDirection:
+            mnemonic: WDIR
+          windSpeed:
+            mnemonic: WSPD
+
+    ioda:
+      backend: netcdf
+#     obsdataout: "./testrun/amdar_wmo_multi.nc"
+      obsdataout: "./testrun/gdas.aircar.t00z.20210801.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+
+      variables:
+        - name: "MetaData/datetime"
+          source: variables/timestamp
+          dimensions: [ "nlocs" ]
+          longName: "Datetime"
+          units: "datetime"
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          dimensions: [ "nlocs" ]
+          longName: "Latitude"
+          units: "degrees_north"
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          dimensions: [ "nlocs" ]
+          longName: "Longitude"
+          units: "degrees_east"
+
+        - name: "MetaData/height"
+          source: variables/height
+          dimensions: [ "nlocs" ]
+          longName: "Pressure altitude"
+          units: "m"
+
+        - name: "MetaData/aircraftRegistrationNum"
+          source: variables/aircraftRegistrationNum
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft registration number or other ID"
+          units: "none"
+
+        - name: "MetaData/aircraftFlightNum"
+          source: variables/aircraftFlightNum
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft flight number"
+          units: "none"
+
+        - name: "MetaData/aircraftFlightPhase"
+          source: variables/aircraftFlightPhase
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft flight phase (ascending/descending/level)"
+          units: "none"
+
+        - name: "MetaData/aircraftTrueAirspeed"
+          source: variables/aircraftTrueAirspeed
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft true airspeed"
+          units: "m s-1"
+
+        - name: "MetaData/aircraftHeading"
+          source: variables/aircraftHeading
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft heading"
+          units: "deg"
+
+        - name: "MetaData/aircraftRollAngle"
+          source: variables/aircraftRollAngle
+          dimensions: [ "nlocs" ]
+          longName: "Aircraft roll angle quality"
+          units: "none"
+
+        - name: "ObsValue/air_temperature"
+          coordinates: "longitude latitude"
+          source: variables/temperatureAir
+          dimensions: [ "nlocs" ]
+          longName: "Air Temperature"
+          units: "K"
+
+        - name: "ObsValue/wind_direction"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          dimensions: [ "nlocs" ]
+          longName: "Wind Direction"
+          units: "degrees"
+
+        - name: "ObsValue/wind_speed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          dimensions: [ "nlocs" ]
+          longName: "Wind Speed"
+          units: "m s-1"

--- a/test/testinput/amdar_wmoBUFR2ioda.yaml
+++ b/test/testinput/amdar_wmoBUFR2ioda.yaml
@@ -6,7 +6,8 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./testinput/amdar_wmo_multi.bufr"
+#     obsdatain: "./testinput/amdar_wmo_multi.bufr"
+      obsdatain: "/home/gthompsn/2021_07_31T18_00_00Z.P6H.amdar.BUFR"
       isWmoFormat: true
       tablepath: "./testinput/bufr_tables"
 
@@ -62,7 +63,8 @@ observations:
 
     ioda:
       backend: netcdf
-      obsdataout: "./testrun/amdar_wmo_multi.nc"
+#     obsdataout: "./testrun/amdar_wmo_multi.nc"
+      obsdataout: "./testrun/2021_07_31T18_00_00Z.P6H.amdar.nc"
 
       dimensions:
         - name: "nlocs"
@@ -152,7 +154,7 @@ observations:
           coordinates: "longitude latitude"
           source: variables/waterVaporMixingRatio
           dimensions: [ "nlocs" ]
-          longName: "Dewpoint Temperature"
+          longName: "specific humidity"
           units: "kg kg-1"
 
         - name: "ObsValue/wind_direction"

--- a/test/testinput/amdar_wmoBUFR2ioda.yaml
+++ b/test/testinput/amdar_wmoBUFR2ioda.yaml
@@ -6,8 +6,7 @@
 observations:
   - obs space:
       name: bufr
-#     obsdatain: "./testinput/amdar_wmo_multi.bufr"
-      obsdatain: "/home/gthompsn/2021_07_31T18_00_00Z.P6H.amdar.BUFR"
+      obsdatain: "./testinput/amdar_wmo_multi.bufr"
       isWmoFormat: true
       tablepath: "./testinput/bufr_tables"
 
@@ -63,8 +62,7 @@ observations:
 
     ioda:
       backend: netcdf
-#     obsdataout: "./testrun/amdar_wmo_multi.nc"
-      obsdataout: "./testrun/2021_07_31T18_00_00Z.P6H.amdar.nc"
+      obsdataout: "./testrun/amdar_wmo_multi.nc"
 
       dimensions:
         - name: "nlocs"

--- a/test/testinput/gdas.aircar.t00z.20210801.bufr
+++ b/test/testinput/gdas.aircar.t00z.20210801.bufr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8844d7274239e258b7af07aff360aa9858f3c975076b963e75500840f7b9d6e
+size 1951749

--- a/test/testoutput/amdar_wmo_multi.nc
+++ b/test/testoutput/amdar_wmo_multi.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33a300c46219fd7c3d30d997a22712bdffc858f383dd9681d7052575ad71d8ce
+oid sha256:d68c976408ac47e64298bddaa87d568a818e34d257f12bb046d435c15b4affd9
 size 140937

--- a/test/testoutput/gdas.aircar.t00z.20210801.nc
+++ b/test/testoutput/gdas.aircar.t00z.20210801.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ef63fae1a9162232ff2720338d0449f4b85a8ba3d253d6dcb7aaa0fc7bbbfc2
-size 1018348
+oid sha256:283b4eada3d61794b4ff07ed4208b972ceb0689fc730bec72c5bc4a898ec29b5
+size 1028634

--- a/test/testoutput/gdas.aircar.t00z.20210801.nc
+++ b/test/testoutput/gdas.aircar.t00z.20210801.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ef63fae1a9162232ff2720338d0449f4b85a8ba3d253d6dcb7aaa0fc7bbbfc2
+size 1018348


### PR DESCRIPTION
## Description

This is rather similar to what is performed with amdar_wmoBUFR2ioda.yaml, except that the input data are reprocessed NCEP-EMC GDAS BUFR files available from NOMADS and also NCAR-RDA (ds351.0) in files with reference name of gdas.aircar.(date).bufr in place of WMO-formatted BUFR.  The mnemonics are somewhat different with these files compared to WMO BUFR data.  The mnemonics are listed/described as part of ```doc/bufr_table_samples/aircft.nc004004.bufr.table.txt``` because it is the subset that is referred to with NC004004 only.  Various other aircraft data (AIREPs, PIREPs, etc.) are found in other subsets and the gdas.aircft.(date).bufr files, which would need to be split out into separate chunks for different yaml files because of using different mnemonics depending on the subset of data.

This PR should permit the use of some variables (```air_temperature``` and ```specific_humidity```) while others need variable transformations to get into JEDI (wind direction and speed need to be changed to ```eastward_wind``` and ```northward_wind```).

### Issue(s) addressed

A separate issue was not created for this

## Acceptance Criteria (Definition of Done)

When all tests pass.

## Dependencies

There are no dependencies.

## Impact

No impacts to other repos.