### PR TITLE
Switch string datetime to int64 dateTime and reference Epoch (unix_time)

### DIFF
--- a/src/conventional/metar_csv2ioda.py
+++ b/src/conventional/metar_csv2ioda.py
@@ -39,8 +39,7 @@ locationKeyList = [
     ("longitude", "float"),
     ("station_elevation", "float"),
     ("height", "float"),
-    ("datetime", "string"),
-    ("unixtime", "integer"),
+    ("dateTime", "integer"),
 ]
 
 obsvars = {
@@ -109,7 +108,7 @@ class reformatMetar(object):
         # Set units of some MetaData variables
         self.varAttrs['station_elevation', 'MetaData']['units'] = 'm'
         self.varAttrs['height', 'MetaData']['units'] = 'm'
-        self.varAttrs['unixtime', 'MetaData']['units'] = 's'
+        self.varAttrs['dateTime', 'MetaData']['units'] = 'seconds since 1970-01-01T00:00:00Z'
 
         # data is the dictionary of incoming observation (METAR) data
         data = {}
@@ -202,8 +201,7 @@ class reformatMetar(object):
                     spfh = self.float_fill
 
                 data['ob_icao'].append(icao)
-                data['ob_time'].append(utime)
-                data['ob_datetime'].append(datetime.fromtimestamp(utime).strftime("%Y-%m-%dT%H:%M:%SZ"))
+                data['ob_datetime'].append(utime)
                 data['ob_lat'].append(lat)
                 data['ob_lon'].append(lon)
                 data['ob_elev'].append(elev)
@@ -219,8 +217,7 @@ class reformatMetar(object):
         nlocs = len(data['ob_datetime'])
 
         self.outdata[('station_id', 'MetaData')] = np.array(data['ob_icao'], dtype=object)
-        self.outdata[('unixtime', 'MetaData')] = np.array(data['ob_time'], dtype=np.int32)
-        self.outdata[('datetime', 'MetaData')] = np.array(data['ob_datetime'], dtype=object)
+        self.outdata[('dateTime', 'MetaData')] = np.array(data['ob_datetime'], dtype=np.int64)
         self.outdata[('latitude', 'MetaData')] = np.array(data['ob_lat'], dtype=np.float32)
         self.outdata[('longitude', 'MetaData')] = np.array(data['ob_lon'], dtype=np.float32)
         self.outdata[('station_elevation', 'MetaData')] = np.array(data['ob_elev'], dtype=np.float32)

--- a/test/testoutput/2020100106_metars_small.nc
+++ b/test/testoutput/2020100106_metars_small.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54bb014883487e1c21d59301687387471cd9146a83c9e360289cb5a94455ac25
-size 33070
+oid sha256:644097a3c509be82cfbece9e127516b7c1d1de2d94b69bbe6b9a38f6ee9cb8b4
+size 28143


### PR DESCRIPTION
## Description

This PR updates the metar_csv2ioda.py script to switch from the older string-based ```datetime``` variable to the newer int64-based ```dateTime``` for newer compatibility and overall smaller size IODA files.  Since an internal variable called ```unix_time``` was already present, it was simple to implement and just assign units attribute of ```seconds since 1970-01-01T00:00:00Z```

### Issue(s) addressed

A separate issue was not created in association with this PR

## Acceptance Criteria (Definition of Done)

That it works.

## Dependencies

No dependencies

## Impact

No impacts to other repos.
