### PR TITLE
Add converter for SatWinds WMO-formatted BUFR for INSAT and Aqua/Terra

### DIFF
--- a/doc/bufr_obs_samples/satwinds_WMO_Insat_sample.txt
+++ b/doc/bufr_obs_samples/satwinds_WMO_Insat_sample.txt
@@ -1,0 +1,281 @@
+
+Found BUFR message #      1
+  
+        Message length:       14348
+      Section 0 length:           8
+          BUFR edition:           4
+  
+      Section 1 length:          24
+          Master table:           0
+    Originating center:          28 (= New Delhi (RSMC))
+ Originating subcenter:           0
+ Update sequence numbr:           0
+    Section 2 present?: No
+         Data category:           5 (= Single level upper-air data (satellite))
+     Local subcategory:           0
+ Internatl subcategory:           0 (= Cloud wind data (SATOB))
+  Master table version:          13
+   Local table version:           0
+                  Year:        2021
+                 Month:           7
+                   Day:          31
+                  Hour:          18
+                Minute:           0
+                Second:           0
+  
+ Number of data subsets:        1000
+     Data are observed?: No
+   Data are compressed?: Yes
+  Number of descriptors:          39
+        1: 310014
+        2: 222000
+        3: 236000
+        4: 101103
+        5: 031031
+        6: 001031
+        7: 001032
+        8: 101004
+        9: 033007
+       10: 222000
+       11: 237000
+       12: 001031
+       13: 001032
+       14: 101004
+       15: 033035
+       16: 222000
+       17: 237000
+       18: 001031
+       19: 001032
+       20: 101004
+       21: 033036
+       22: 222000
+       23: 237000
+       24: 001031
+       25: 001032
+       26: 101004
+       27: 033007
+       28: 222000
+       29: 237000
+       30: 001031
+       31: 001032
+       32: 101004
+       33: 033035
+       34: 222000
+       35: 237000
+       36: 001031
+       37: 001032
+       38: 101004
+       39: 033036
+
+BUFR message #      1 of type MSTTB001 and date 2021073118 contains   1000 subsets:
+
+MESSAGE TYPE MSTTB001  
+
+001007  SAID                       471.0  CODE TABLE                    Satellite identifier                            
+                                    471 = INSAT 3D
+001031  GCLONG                      28.0  CODE TABLE                    Identification of originating/generating centre 
+                                     28 = New Delhi (RSMC)
+002020  SCLF                       301.0  CODE TABLE                    Satellite classification                        
+                                    301 = INSAT
+002028  SSNX                     MISSING  M                             Segment size at nadir in x-direction            
+002029  SSNY                     MISSING  M                             Segment size at nadir in y-direction            
+004001  YEAR                      2021.0  YEAR                          Year                                            
+004002  MNTH                         7.0  MONTH                         Month                                           
+004003  DAYS                        31.0  DAY                           Day                                             
+004004  HOUR                        18.0  HOUR                          Hour                                            
+004005  MINU                         0.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+005001  CLATH                  -22.44000  DEGREE                        Latitude (high accuracy)                        
+006001  CLONH                   37.25000  DEGREE                        Longitude (high accuracy)                       
+002152  SIDP                     MISSING  FLAG TABLE                    Satellite instrument used in data processing    
+002023  SWCM                         1.0  CODE TABLE                    Satellite-derived wind computation method       
+                                      1 = Wind derived from cloud motion observed in the infrared channel
+007004  PRLC                     97500.0  PA                            Pressure                                        
+011001  WDIR                       149.0  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                        11.9  M S⁻¹                      Wind speed                                      
+002153  SCCF            78299900000000.0  HZ                            Satellite channel centre frequency              
+002154  SCBW             3800000000000.0  HZ                            Satellite channel band width                    
+012071  CCST                     MISSING  K                             Coldest cluster temperature                     
+002163  HAMD                        14.0  CODE TABLE                    Height assignment method                        
+                                     14 = Composite height assignment
+002164  TCMD                     MISSING  CODE TABLE                    Tracer correlation method                       
+008012  LSQL                     MISSING  CODE TABLE                    Land/sea qualifier                              
+007024  SAZA                       54.57  DEGREE                        Satellite zenith angle                          
+002057  OFGI                     MISSING  CODE TABLE                    Origin of first-guess information for GOES-I/M s
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004001  YEAR                     MISSING  YEAR                          Year                                            
+004002  MNTH                     MISSING  MONTH                         Month                                           
+004003  DAYS                     MISSING  DAY                           Day                                             
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004024  TPHR                     MISSING  HOUR                          Time period or displacement                     
+           "RPSEQ001"     4 REPLICATIONS
+    ++++++  RPSEQ001  REPLICATION #     1  ++++++
+008021  TSIG                        28.0  CODE TABLE                    Time significance                               
+                                     28 = Start of scan
+004004  HOUR                        17.0  HOUR                          Hour                                            
+004005  MINU                        30.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+008021  TSIG                        29.0  CODE TABLE                    Time significance                               
+                                     29 = End of scan
+004004  HOUR                        18.0  HOUR                          Hour                                            
+004005  MINU                        30.0  MINUTE                        Minute                                          
+004006  SECO                         0.0  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     2  ++++++
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     3  ++++++
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+    ++++++  RPSEQ001  REPLICATION #     4  ++++++
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+008021  TSIG                     MISSING  CODE TABLE                    Time significance                               
+004004  HOUR                     MISSING  HOUR                          Hour                                            
+004005  MINU                     MISSING  MINUTE                        Minute                                          
+004006  SECO                     MISSING  S                             Second                                          
+011001  WDIR                     MISSING  DEGREE TRUE                   Wind direction                                  
+011002  WSPD                     MISSING  M S⁻¹                      Wind speed                                      
+           "RPSEQ002"    10 REPLICATIONS
+    ++++++  RPSEQ002  REPLICATION #     1  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     2  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     3  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     4  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     5  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     6  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     7  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     8  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #     9  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+    ++++++  RPSEQ002  REPLICATION #    10  ++++++
+002163  HAMD                     MISSING  CODE TABLE                    Height assignment method                        
+007004  PRLC                     MISSING  PA                            Pressure                                        
+012001  TMDBST                   MISSING  K                             Temperature/dry-bulb temperature                
+           "RPSEQ003"   103 REPLICATIONS
+    ++++++  RPSEQ003  REPLICATION #     1  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+    ++++++  RPSEQ003  REPLICATION #     2  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+    ++++++  RPSEQ003  REPLICATION #     3  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+    ++++++  RPSEQ003  REPLICATION #   102  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+    ++++++  RPSEQ003  REPLICATION #   103  ++++++
+031031  DPRI                     MISSING  FLAG TABLE                    Data present indicator                          
+001031  GCLONG                      28.0  CODE TABLE                    Identification of originating/generating centre 
+                                     28 = New Delhi (RSMC)
+001032  GNAP                         1.0  CODE TABLE                    Generating application                          
+           "RPSEQ004"     4 REPLICATIONS
+    ++++++  RPSEQ004  REPLICATION #     1  ++++++
+033007  PCCF                        73.0  %                             Percent confidence for PRLC                     
+    ++++++  RPSEQ004  REPLICATION #     2  ++++++
+033007  PCCF                        73.0  %                             Percent confidence for WDIR                     
+    ++++++  RPSEQ004  REPLICATION #     3  ++++++
+033007  PCCF                        73.0  %                             Percent confidence for WSPD                     
+    ++++++  RPSEQ004  REPLICATION #     4  ++++++
+033007  PCCF                     MISSING  %                             Percent confidence                              
+001031  GCLONG                      28.0  CODE TABLE                    Identification of originating/generating centre 
+                                     28 = New Delhi (RSMC)
+001032  GNAP                         1.0  CODE TABLE                    Generating application                          
+           "RPSEQ005"     4 REPLICATIONS
+    ++++++  RPSEQ005  REPLICATION #     1  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for PRLC       
+    ++++++  RPSEQ005  REPLICATION #     2  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for WDIR       
+    ++++++  RPSEQ005  REPLICATION #     3  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for WSPD       
+    ++++++  RPSEQ005  REPLICATION #     4  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control                
+001031  GCLONG                      28.0  CODE TABLE                    Identification of originating/generating centre 
+                                     28 = New Delhi (RSMC)
+001032  GNAP                         1.0  CODE TABLE                    Generating application                          
+           "RPSEQ006"     4 REPLICATIONS
+    ++++++  RPSEQ006  REPLICATION #     1  ++++++
+033036  NCTH                        50.0  %                             Nominal confidence threshold for PRLC           
+    ++++++  RPSEQ006  REPLICATION #     2  ++++++
+033036  NCTH                        50.0  %                             Nominal confidence threshold for WDIR           
+    ++++++  RPSEQ006  REPLICATION #     3  ++++++
+033036  NCTH                        50.0  %                             Nominal confidence threshold for WSPD           
+    ++++++  RPSEQ006  REPLICATION #     4  ++++++
+033036  NCTH                        50.0  %                             Nominal confidence threshold                    
+001031  GCLONG                   MISSING  CODE TABLE                    Identification of originating/generating centre 
+001032  GNAP                     MISSING  CODE TABLE                    Generating application                          
+           "RPSEQ007"     4 REPLICATIONS
+    ++++++  RPSEQ007  REPLICATION #     1  ++++++
+033007  PCCF                     MISSING  %                             Percent confidence for PRLC                     
+    ++++++  RPSEQ007  REPLICATION #     2  ++++++
+033007  PCCF                     MISSING  %                             Percent confidence for WDIR                     
+    ++++++  RPSEQ007  REPLICATION #     3  ++++++
+033007  PCCF                     MISSING  %                             Percent confidence for WSPD                     
+    ++++++  RPSEQ007  REPLICATION #     4  ++++++
+033007  PCCF                     MISSING  %                             Percent confidence                              
+001031  GCLONG                   MISSING  CODE TABLE                    Identification of originating/generating centre 
+001032  GNAP                     MISSING  CODE TABLE                    Generating application                          
+           "RPSEQ008"     4 REPLICATIONS
+    ++++++  RPSEQ008  REPLICATION #     1  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for PRLC       
+    ++++++  RPSEQ008  REPLICATION #     2  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for WDIR       
+    ++++++  RPSEQ008  REPLICATION #     3  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control for WSPD       
+    ++++++  RPSEQ008  REPLICATION #     4  ++++++
+033035  MAQC                     MISSING  CODE TABLE                    Manual/automatic quality control                
+001031  GCLONG                   MISSING  CODE TABLE                    Identification of originating/generating centre 
+001032  GNAP                     MISSING  CODE TABLE                    Generating application                          
+           "RPSEQ009"     4 REPLICATIONS
+    ++++++  RPSEQ009  REPLICATION #     1  ++++++
+033036  NCTH                     MISSING  %                             Nominal confidence threshold for PRLC           
+    ++++++  RPSEQ009  REPLICATION #     2  ++++++
+033036  NCTH                     MISSING  %                             Nominal confidence threshold for WDIR           
+    ++++++  RPSEQ009  REPLICATION #     3  ++++++
+033036  NCTH                     MISSING  %                             Nominal confidence threshold for WSPD           
+    ++++++  RPSEQ009  REPLICATION #     4  ++++++
+033036  NCTH                     MISSING  %                             Nominal confidence threshold                    
+
+ >>> END OF SUBSET <<< 

--- a/doc/bufr_table_samples/satwinds_WMO_Insat_mnemonics.txt
+++ b/doc/bufr_table_samples/satwinds_WMO_Insat_mnemonics.txt
@@ -1,0 +1,148 @@
+Here is the DX table that was generated:
+
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| MSTTB001 | A54000 | TABLE A MNEMONIC MSTTB001                                |
+|          |        |                                                          |
+| GEOSTWND | 310014 | Satellite - geostationary wind data                      |
+| SIDENSEQ | 301072 | Satellite identification                                 |
+| SIDGRSEQ | 301071 | Satellite identifier/Generating resolution               |
+| YYMMDD   | 301011 |                                                          |
+| HHMMSS   | 301013 |                                                          |
+| LTLONH   | 301021 |                                                          |
+| WINDSEQN | 303041 | Wind sequence                                            |
+| GOESIMIN | 304011 | GOES-I/M info                                            |
+| RPSEQ001 | 354001 | REPLICATION SEQUENCE 001                                 |
+| RPSEQ002 | 354002 | REPLICATION SEQUENCE 002                                 |
+| RPSEQ003 | 354003 | REPLICATION SEQUENCE 003                                 |
+| RPSEQ004 | 354004 | REPLICATION SEQUENCE 004                                 |
+| RPSEQ005 | 354005 | REPLICATION SEQUENCE 005                                 |
+| RPSEQ006 | 354006 | REPLICATION SEQUENCE 006                                 |
+| RPSEQ007 | 354007 | REPLICATION SEQUENCE 007                                 |
+| RPSEQ008 | 354008 | REPLICATION SEQUENCE 008                                 |
+| RPSEQ009 | 354009 | REPLICATION SEQUENCE 009                                 |
+|          |        |                                                          |
+| SAID     | 001007 | Satellite identifier                                     |
+| GCLONG   | 001031 | Identification of originating/generating centre          |
+| SCLF     | 002020 | Satellite classification                                 |
+| SSNX     | 002028 | Segment size at nadir in x-direction                     |
+| SSNY     | 002029 | Segment size at nadir in y-direction                     |
+| YEAR     | 004001 | Year                                                     |
+| MNTH     | 004002 | Month                                                    |
+| DAYS     | 004003 | Day                                                      |
+| HOUR     | 004004 | Hour                                                     |
+| MINU     | 004005 | Minute                                                   |
+| SECO     | 004006 | Second                                                   |
+| CLATH    | 005001 | Latitude (high accuracy)                                 |
+| CLONH    | 006001 | Longitude (high accuracy)                                |
+| SIDP     | 002152 | Satellite instrument used in data processing             |
+| SWCM     | 002023 | Satellite-derived wind computation method                |
+| PRLC     | 007004 | Pressure                                                 |
+| WDIR     | 011001 | Wind direction                                           |
+| WSPD     | 011002 | Wind speed                                               |
+| SCCF     | 002153 | Satellite channel centre frequency                       |
+| SCBW     | 002154 | Satellite channel band width                             |
+| CCST     | 012071 | Coldest cluster temperature                              |
+| HAMD     | 002163 | Height assignment method                                 |
+| TCMD     | 002164 | Tracer correlation method                                |
+| LSQL     | 008012 | Land/sea qualifier                                       |
+| SAZA     | 007024 | Satellite zenith angle                                   |
+| OFGI     | 002057 | Origin of first-guess information for GOES-I/M sounding  |
+| TSIG     | 008021 | Time significance                                        |
+| TPHR     | 004024 | Time period or displacement                              |
+| TMDBST   | 012001 | Temperature/dry-bulb temperature                         |
+| DPRI     | 031031 | Data present indicator                                   |
+| GNAP     | 001032 | Generating application                                   |
+| PCCF     | 033007 | Percent confidence                                       |
+| MAQC     | 033035 | Manual/automatic quality control                         |
+| NCTH     | 033036 | Nominal confidence threshold                             |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| MSTTB001 | GEOSTWND  222000  236000  "RPSEQ003"103  GCLONG  GNAP             |
+| MSTTB001 | "RPSEQ004"4  222000  237000  GCLONG  GNAP  "RPSEQ005"4  222000    |
+| MSTTB001 | 237000  GCLONG  GNAP  "RPSEQ006"4  222000  237000  GCLONG  GNAP   |
+| MSTTB001 | "RPSEQ007"4  222000  237000  GCLONG  GNAP  "RPSEQ008"4  222000    |
+| MSTTB001 | 237000  GCLONG  GNAP  "RPSEQ009"4                                 |
+|          |                                                                   |
+| GEOSTWND | SIDENSEQ  WINDSEQN  GOESIMIN                                      |
+|          |                                                                   |
+| SIDENSEQ | SIDGRSEQ  YYMMDD  HHMMSS  LTLONH                                  |
+|          |                                                                   |
+| SIDGRSEQ | SAID  GCLONG  SCLF  SSNX  SSNY                                    |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMMSS   | HOUR  MINU  SECO                                                  |
+|          |                                                                   |
+| LTLONH   | CLATH  CLONH                                                      |
+|          |                                                                   |
+| WINDSEQN | SIDP  SWCM  PRLC  WDIR  WSPD  SCCF  SCBW  CCST                    |
+|          |                                                                   |
+| GOESIMIN | HAMD  TCMD  LSQL  SAZA  OFGI  TSIG  YEAR  MNTH  DAYS  HOUR  TSIG  |
+| GOESIMIN | TPHR  "RPSEQ001"4  "RPSEQ002"10                                   |
+|          |                                                                   |
+| RPSEQ001 | TSIG  HOUR  MINU  SECO  TSIG  HOUR  MINU  SECO  WDIR  WSPD        |
+|          |                                                                   |
+| RPSEQ002 | HAMD  PRLC  TMDBST                                                |
+|          |                                                                   |
+| RPSEQ003 | DPRI                                                              |
+|          |                                                                   |
+| RPSEQ004 | PCCF                                                              |
+|          |                                                                   |
+| RPSEQ005 | MAQC                                                              |
+|          |                                                                   |
+| RPSEQ006 | NCTH                                                              |
+|          |                                                                   |
+| RPSEQ007 | PCCF                                                              |
+|          |                                                                   |
+| RPSEQ008 | MAQC                                                              |
+|          |                                                                   |
+| RPSEQ009 | NCTH                                                              |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| SAID     |    0 |           0 |  10 | CODE TABLE               |-------------|
+| GCLONG   |    0 |           0 |  16 | CODE TABLE               |-------------|
+| SCLF     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| SSNX     |    0 |           0 |  18 | M                        |-------------|
+| SSNY     |    0 |           0 |  18 | M                        |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SECO     |    0 |           0 |   6 | S                        |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREE                   |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREE                   |-------------|
+| SIDP     |    0 |           0 |  31 | FLAG TABLE               |-------------|
+| SWCM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| PRLC     |   -1 |           0 |  14 | PA                       |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREE TRUE              |-------------|
+| WSPD     |    1 |           0 |  12 | M S⁻¹                 |-------------|
+| SCCF     |   -8 |           0 |  26 | HZ                       |-------------|
+| SCBW     |   -8 |           0 |  26 | HZ                       |-------------|
+| CCST     |    1 |           0 |  12 | K                        |-------------|
+| HAMD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TCMD     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| LSQL     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| SAZA     |    2 |       -9000 |  15 | DEGREE                   |-------------|
+| OFGI     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| TSIG     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TMDBST   |    1 |           0 |  12 | K                        |-------------|
+| DPRI     |    0 |           0 |   1 | FLAG TABLE               |-------------|
+| GNAP     |    0 |           0 |   8 | CODE TABLE               |-------------|
+| PCCF     |    0 |           0 |   7 | %                        |-------------|
+| MAQC     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| NCTH     |    0 |           0 |   7 | %                        |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -166,6 +166,8 @@ if( iodaconv_bufr_ENABLED )
     testinput/satwind_EUMet_wmo.bufr
     testinput/satwind_Himawari_wmoBUFR2ioda.yaml
     testinput/satwind_Himawari_wmo.bufr
+    testinput/satwind_Insat_wmoBUFR2ioda.yaml
+    testinput/satwind_Insat_wmo.bufr
     testinput/vadwinds_wmoBUFR2ioda.yaml
     testinput/vadwinds_wmo_multi.bufr
   )
@@ -192,6 +194,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/synop_wmo_multi.nc
     testoutput/satwind_EUMet.nc
     testoutput/satwind_Himawari.nc
+    testoutput/satwind_Insat.nc
     testoutput/vadwinds_wmo_multi.nc
   )
 endif()
@@ -944,6 +947,14 @@ if(iodaconv_bufr_ENABLED)
                     ARGS    netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_Himawari_wmoBUFR2ioda.yaml"
                     satwind_Himawari.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_Insat_wmo_bufr
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    ARGS    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_Insat_wmoBUFR2ioda.yaml"
+                    satwind_Insat.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_vadwinds_wmo_bufr

--- a/test/testinput/satwind_Insat_wmo.bufr
+++ b/test/testinput/satwind_Insat_wmo.bufr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a442cd9e74efc51aaa89b4aad4ade24843f44682a37fd7402d4af3710d423e0a
+size 100211

--- a/test/testinput/satwind_Insat_wmoBUFR2ioda.yaml
+++ b/test/testinput/satwind_Insat_wmoBUFR2ioda.yaml
@@ -1,0 +1,177 @@
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+      obsdatain: "./testinput/satwind_Insat_wmo.bufr"
+      isWmoFormat: true
+      tablepath: "./testinput/bufr_tables"
+
+      mnemonicSets:
+        - mnemonics: [SAID, GCLONG]
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, CLATH, CLONH]
+        - mnemonics: [SIDP, SWCM]
+        - mnemonics: [PRLC, WDIR, WSPD, SCCF]
+        - mnemonics: [HAMD, TCMD, SAZA, GNAP]
+        - mnemonics: [MAQC]
+          channels: 1-4
+        - mnemonics: [PCCF]
+          channels: 1-4
+
+      exports:
+        filters:
+          - bounding:
+              mnemonic: CLONH
+              lowerBound: -180
+              upperBound: 180
+        variables:
+          timestamp:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+          latitude:
+            mnemonic: CLATH
+          longitude:
+            mnemonic: CLONH
+          satelliteId:
+            mnemonic: SAID
+          dataProviderOrigin:
+            mnemonic: GCLONG
+          generatingApplication:
+            mnemonic: GNAP
+          sensorCentralFrequency:
+            mnemonic: SCCF
+          windComputationMethod:
+            mnemonic: SWCM
+          windHeightAssignMethod:
+            mnemonic: HAMD
+          windTrackingCorrelation:
+            mnemonic: TCMD
+          sensorZenithAngle:
+            mnemonic: SAZA
+          pressureAir:
+            mnemonic: PRLC
+          windDirection:
+            mnemonic: WDIR
+          windSpeed:
+            mnemonic: WSPD
+          windPercentConfidence:
+            mnemonic: PCCF
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/satwind_Insat.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+        - name: "nconfidences"
+          size: variables/windPercentConfidence.ncols
+
+      globals:
+        - name: "MetaData/platformCommonName"
+          type: string
+          value: "Insat_AMV"
+
+        - name: "MetaData/platformLongDescription"
+          type: string
+          value: "Insat (Indian) AMV from IR cloudy regions"
+
+      variables:
+        - name: "MetaData/satelliteId"
+          source: variables/satelliteId
+          dimensions: ["nlocs"]
+          longName: "Satellite identification"
+          units: ""
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          dimensions: ["nlocs"]
+          longName: "Latitude"
+          units: "degrees"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          dimensions: ["nlocs"]
+          longName: "Longitude"
+          units: "degrees"
+          range: [-180, 180]
+
+        - name: "MetaData/dateTime"
+          source: variables/timestamp
+          dimensions: ["nlocs"]
+          longName: "dateTime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/dataProviderOrigin"
+          source: variables/dataProviderOrigin
+          dimensions: ["nlocs"]
+          longName: "Data provider origin"
+          units: ""
+
+        - name: "MetaData/generatingApplication"
+          source: variables/generatingApplication
+          dimensions: ["nlocs"]
+          longName: "Generating application"
+          units: ""
+
+        - name: "MetaData/windComputationMethod"
+          source: variables/windComputationMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind calculation method"
+          units: " "
+
+        - name: "MetaData/windHeightAssignMethod"
+          source: variables/windHeightAssignMethod
+          dimensions: ["nlocs"]
+          longName: "Satellite wind height assignment method"
+          units: " "
+
+        - name: "MetaData/sensorZenithAngle"
+          coordinates: "longitude latitude"
+          source: variables/sensorZenithAngle
+          dimensions: ["nlocs"]
+          longName: "Satellite zenith angle"
+          units: "degrees"
+
+        - name: "MetaData/air_pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressureAir
+          dimensions: ["nlocs"]
+          longName: "Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          dimensions: ["nlocs"]
+          longName: "Wind direction"
+          units: "degrees true"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          dimensions: ["nlocs"]
+          longName: "Wind Speed"
+          units: "m s-1"
+
+        - name: "MetaData/windPercentConfidence"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/windPercentConfidence
+          dimensions: ["nlocs", "nconfidences"]
+          longName: "Percent confidence"
+          units: "percent"
+
+        - name: "MetaData/sensorCentralFrequency"
+          coordinates: "longitude latitude nconfidences"
+          source: variables/sensorCentralFrequency
+          dimensions: ["nlocs"]
+          longName: "Sensor Central Frequency"
+          units: "hz"

--- a/test/testoutput/satwind_Insat.nc
+++ b/test/testoutput/satwind_Insat.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53c69f2962c5a6e436be6540acf92c0ea6e52dd44cad708ff12cc1595822aae2
+size 144131


### PR DESCRIPTION

## Description

This PR adds in the capability to run bufr2ioda.x on the WMO-formatted BUFR files that contain either INSAT (India) or the MODIS Aqua/Terra satellite atmospheric motion vectors (AMVs).  The sample input BUFR file contains only INSAT data, but the same yaml was used for a MODIS-only file and works equivalently.  There are only minor differences in the variable list between the 2 different data sets.  This PR includes doc/bufr_table_samples (and obs_samples) with the mnemonics used for the variables.

### Issue(s) addressed

A separate issue was not created for this.

## Acceptance Criteria (Definition of Done)

Working ctest and reviews.

## Dependencies

There are no dependencies.

## Impact

No impacts to other repos expected.
