### PR TITLE
Second round of "Compatibility with System Integrity Protection on MacOS"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -965,8 +965,9 @@ if(iodaconv_bufr_ENABLED)
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_rass_wmo_bufr
                     TYPE    SCRIPT
-                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
-                    ARGS    netcdf
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/rass_wmoBUFR2ioda.yaml"
                     rass_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
@@ -1008,8 +1009,9 @@ if(iodaconv_bufr_ENABLED)
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_vadwinds_wmo_bufr
                     TYPE    SCRIPT
-                    COMMAND ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
-                    ARGS    netcdf
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/vadwinds_wmoBUFR2ioda.yaml"
                     vadwinds_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )


### PR DESCRIPTION
## Description

This is a follow-up PR to #771 that fixes two additional shell-script based file comparisons.

See #771 and https://github.com/JCSDA-internal/ioda/issues/581 for details.


### Issue(s) addressed

This PR, together with https://github.com/JCSDA-internal/ioda/pull/595, fixes #771.

## Acceptance Criteria (Definition of Done)

All ioda-converters ctests run on macOS

## Dependencies

none

## Impact

none