### PR TITLE
add cleaner exit using curl to check for file on server

### DIFF
--- a/tools/ingest/retrieve_data_from_noaa_nomads.sh
+++ b/tools/ingest/retrieve_data_from_noaa_nomads.sh
@@ -21,7 +21,7 @@
 
 nomads_address='https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod'
 
-usage="usage bash ${0} yyyymmdd [user_input_data_type]"
+usage="usage bash ${0} yyyymmddhh [user_input_data_type]"
 example="example:  bash ${0} 2021091500 [adpupa]"
 
 if (( ${#@} == 0 ))  ||  (( ${#@} > 2 )) || [[ $1 == [hH]elp ]]; then

--- a/tools/ingest/retrieve_data_from_noaa_nomads.sh
+++ b/tools/ingest/retrieve_data_from_noaa_nomads.sh
@@ -62,23 +62,23 @@ get_files() {
         # retrieve the files
         gfile=${nomads_address}/${data_cut}.${dtg:0:8}/${dtg:8:2}/atmos/${data_cut}.t${dtg:8:2}z.${atype}.tm00.bufr_d
         nfile=${nomads_address}/${data_cut}.${dtg:0:8}/${dtg:8:2}/atmos/${data_cut}.t${dtg:8:2}z.${atype}.tm00.bufr_d.nr
-        out_file=${gfile##*/}
-        # optional rename
-        #out_file="${out_file%.bufr_d*}.bfr"
-        #echo "wget ${gfile} -O ${out_file}"
-        wget -nc ${gfile} -O ${out_file}
-        if [[ -e ${out_file} && ! -s ${out_file} ]]; then
-            rm ${out_file}
-            out_file=${nfile##*/}
-            wget -nc ${nfile} -O ${out_file}
-            if [[ ! -s ${out_file} ]]; then
-                rm -f ${out_file}
+        # check both "normal" name and one with restricted data stripped ( appended with "nr" )
+        for afile in ${gfile} ${nfile}; do
+            out_file=${afile##*/}
+            # optional rename
+            # out_file="${out_file%.bufr_d*}.bfr"
+            # does the file exist on the server
+            if curl --output /dev/null --silent --head --fail "${afile}"; then
+                wget -nc ${afile} -O ${out_file}
+                echo " ... wget exit status: ${?}"
+                # remove if file is zero length
+                if [[ -e ${out_file} && ! -s ${out_file} ]]; then
+                    rm ${out_file}
+                fi
             else
-                return  # successfully pulled a file
+                echo "  .. file does not exist on server: ${afile}"
             fi
-        else
-            return  # successfully pulled a file
-        fi
+        done
     done
 }
 


### PR DESCRIPTION
## Description

Currently the script passes back a non-zero exit from wget if the file does not exist

This happens because there are 4 files names checked for each data type for simplicity though only 2 typically exist.  Rather than explicitly trying to predict the specific 2 names just always check for 4 makes it much simpler


### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #1890

## Acceptance Criteria (Definition of Done)

Scripts runs and retrieves data

## Dependencies

wget