### PR TITLE
Add quick method to return metagroup name

### DIFF
--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -14,6 +14,10 @@ _obiasterm_name = "GsiObsBiasTerm"
 _obiaspred_name = "GsitObsBiasPredictor"
 
 
+def MetaDataName():
+    return _metagroup
+
+
 def OvalName():
     return _oval_name
 


### PR DESCRIPTION
## Description

The ```lib-python/ioda_conv_engines.py``` contains simple methods to return group names (such as ObsValue, ObsError, etc.) but lacks the method to return the ```MetaData``` group name.  This code addition provides that method.

### Issue(s) addressed

One was not created (not needed).

## Acceptance Criteria (Definition of Done)

Approvals

## Dependencies

None

## Impact

None
