### PR TITLE
Change nlocs to Locations

### DIFF
--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -91,7 +91,7 @@ class IodaWriter(object):
                 dims = GeoVarDims[VarName]
             else:
                 # assume it is just nlocs
-                dims = ['nlocs']
+                dims = ['Location']
             fillval = get_default_fill_val(Vvals.dtype)
             # get fill value
             if VarName in GeoVarAttrs.keys():
@@ -120,7 +120,7 @@ class IodaWriter(object):
                 dims = VarDims[Vname]
             else:
                 # assume it is just nlocs
-                dims = ['nlocs']
+                dims = ['Location']
             fillval = get_default_fill_val(Vvals.dtype)
             # get fill value
             if VarKey in VarAttrs.keys():


### PR DESCRIPTION
## Description

Change default dimension from `nlocs` to `Location` in the ioda_conv_engines library. Most users/converters should define their own dimensions anyways but this ensures it won't create nlocs for anything.

### Issue(s) addressed

No issue made.

## Acceptance Criteria (Definition of Done)

N/A

## Dependencies

None


## Impact

None
