### PR TITLE
Remove file 20200720.nc from src/marine

### DIFF
--- a/src/marine/20200720.nc
+++ b/src/marine/20200720.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf357cb7eea15d75e5917ac17a29cff703e033196ffc961c13cb15a003045efb
-size 137402


### PR DESCRIPTION
## Description

Removed 20200720.nc in folder ioda-bundle/iodaconv/src/marine, this file seems redundant and safe to be removed.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #828 


