### PR TITLE
Feature/viirs_bias :  First attempt at bias file writer for VIIRS AOD observations. 

### DIFF
--- a/src/compo/CMakeLists.txt
+++ b/src/compo/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND programs
   modis_aod2ioda.py
   aeronet_aod2ioda.py
   aeronet_aaod2ioda.py
+  VIIRS_BiasWriter.py
 )
 
 file( RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_BINARY_DIR}/bin ${PYIODACONV_BUILD_LIBDIR} )

--- a/src/compo/VIIRS_BiasWriter.py
+++ b/src/compo/VIIRS_BiasWriter.py
@@ -1,0 +1,46 @@
+import sys
+import argparse
+import netCDF4
+from netCDF4 import Dataset, chartostring
+import numpy as np
+import os
+from pathlib import Path
+
+parser = argparse.ArgumentParser(
+   description=('Write VIIRS aerosol optical depth bias coefficients to NetCDF')
+)
+parser.add_argument(
+    '-o', '--output',
+    help="name of NetCDF output file",
+    type=str, required=True)
+
+args = parser.parse_args()
+#try: 
+#    ncfile.close()
+#except: pass
+predictor_out = netCDF4.stringtochar(np.array(['constant'], 'S8'))
+channels_out = [4]
+ncfile = Dataset(args.output,mode='w', format='NETCDF4')
+group1 = ncfile.createGroup("MetaData")
+group1.long_name = "MetaData"
+ncfile._ioda_layout = 'ObsGroup'
+ncfile._ioda_layout_version = 0
+coef_dim = ncfile.createDimension('bias_coefficients', 1)
+coef_err_dim = ncfile.createDimension('bias_coeff_errors', 1)
+npredictors = ncfile.createDimension('npredictors', 1)
+nchannels = ncfile.createDimension('nchannels', 1)
+coef = ncfile.createVariable('bias_coefficients', np.float, ('bias_coefficients', ))
+coef_error = ncfile.createVariable('bias_coeff_errors', np.float, ('bias_coeff_errors', )) 
+predictors = ncfile.createVariable('predictors', 'S8', ('npredictors', ))
+channels = ncfile.createVariable('channels', np.int, ('nchannels', ))
+coef.units = 'Aerosol optical depth'
+coef.long_name = 'bias_coefficients'
+coef_error.units = 'Aerosol optical depth'
+coef_error.long_name = 'bias_coeff_errors'
+n_coef = len(coef_dim)
+coef[:] = -0.0163
+coef_error[:] = .0863
+predictor2 = netCDF4.chartostring(predictor_out)
+predictors[:] = predictor2
+channels[:] = channels_out
+ncfile.close()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ list( APPEND test_output
   testoutput/abi_g16_obs_2018041500.nc4
   testoutput/ioda.NC001007.2020031012.nc
   testoutput/viirs_aod.nc
+  testoutput/VIIRS_bias.nc 
   testoutput/tropomi_no2.nc
   testoutput/mopitt_co.nc
   testoutput/modis_aod.nc
@@ -221,6 +222,7 @@ if (iodaconv_satbias_ENABLED )
     testoutput/satbias_amsua_n18.nc4
     testoutput/satbias_cris_npp.nc4
     testoutput/satbias_ssmis_f16.nc4
+    testoutput/VIIRS_bias.nc 
   )
 endif()
 
@@ -749,6 +751,15 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_aod
                           -k maskout
                           -n 0.0"
                           viirs_aod.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_viirs_aod
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf 
+                            "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/VIIRS_BiasWriter.py
+                            -o testrun/VIIRS_bias.nc"
+                            VIIRS_bias.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2
                   TYPE    SCRIPT

--- a/test/testoutput/VIIRS_bias.nc
+++ b/test/testoutput/VIIRS_bias.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0547a507244e84f65cea3b3c197c27a42bdaff21ab20f23877fa6467f21d254
+size 8180


### PR DESCRIPTION
## Description

This is a draft PR for a VIIRS bias writer.   It is a python code that writes a netcdf file with just a single global bias value for VIIRS AOD (and it's uncertainty).  The resulting NetCDF file has been successfully tested with hybrid DA in JEDI. 

But it is not clear if it is in the right directory. It's currently in iodaconv/compo because this is where all the python NetCDF IODA writers are created, but it probably needs to be in iodaconv/satbias.   And while the ctest for this converter passes successfully, it fails in the validator step. This is likely because the validator is looking for items that are needed for IODA obs files, rather than satbias files.   



### Issue(s) addressed

This is connected to the issue #1889, but this issue should remain open after this PR is closed so  that it can be tied to a new PR. 



## Acceptance Criteria (Definition of Done)

What does it mean for this PR to be finished?  This PR will be closed and another issued once the details of where the code should be located, and how the 

## Dependencies

None

