### PR TITLE
BUGFIX:  Deal with BUFR msg that has more array elements than what was expected (truncate away extras)

### DIFF
--- a/src/conventional/amdar_bufr2ioda.py
+++ b/src/conventional/amdar_bufr2ioda.py
@@ -345,6 +345,10 @@ def read_bufr_message(f, count, start_pos, data):
             logging.warning(f"Key called {k} contains only {len(meta_data[k])} "
                             f" elements, wheras {target_number} were expected.")
             meta_data[k] = assign_missing_meta(meta_data[k], k, target_number, len(meta_data[k])-1)
+        elif (len(meta_data[k]) > target_number):
+            logging.warning(f"Key called {k} contains {len(meta_data[k])} "
+                            f" elements, wheras {target_number} were expected.")
+            meta_data[k] = meta_data[k][:target_number]
 
     # Plus, to construct a dateTime, we always need its components.
     try:


### PR DESCRIPTION

## Description

I encountered a aircraft-AMDAR file that had some data array that was twice as long as all the other arrays.  While it is not optimal, I decided just to chop off the extras.  This could certainly create a problem if the final output list of values does not align with the lat/lon locations properly, but needed a quick fix for right now.

### Issue(s) addressed

A separate one was not created. Just a quick bugfix here.

## Acceptance Criteria (Definition of Done)

This was tested on a real-time file that revealed the problem. No additional test was created.

## Dependencies

None

## Impact

No impacts to other repos expected.
