### PR TITLE
Convert ISO date string to Python datetime object

### DIFF
--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -77,6 +77,7 @@ _defaultF4 = 9.969209968386869e+36
 class IodaWriter(object):
     # Constructor
     def __init__(self, Fname, LocKeyList, DimDict, TestKeyList=None):
+        # note: loc_key_list does nothing
         self._loc_key_list = LocKeyList
         self._dim_dict = DimDict
         self._test_key_list = TestKeyList
@@ -160,17 +161,12 @@ class IodaWriter(object):
             raise KeyError("Required variable 'MetaData/dateTime' does not exist.")
         # check if the array is type 'object' or not
         # otherwise we will assume it is an integer and already set up
-        isostr = False
         if (dtvar.dtype == np.dtype('object')):
+            # object is used for strings or datetime objects
             if (isinstance(dtvar[0], str)):
-                isostr = True
-        if isostr:
-            # convert ISO date strings to datetime objects
-            newdtvar = [dt.datetime.strptime(x, "%Y-%m-%dT%H:%M:%SZ") for x in dtvar]
-            ObsVars[VarKey] = np.array(newdtvar, dtype=object)
-        else:
-            # assumed to be an integer with proper attributes
-            pass
+                # convert ISO date strings to datetime objects
+                newdtvar = [dt.datetime.strptime(x, "%Y-%m-%dT%H:%M:%SZ") for x in dtvar]
+                ObsVars[VarKey] = np.array(newdtvar, dtype=object)
 
         return ObsVars
 

--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import datetime as dt
 import ioda_obs_space as ioda_os
 import numpy as np
 from collections import OrderedDict
@@ -157,7 +158,21 @@ class IodaWriter(object):
             dtvar = ObsVars[VarKey]
         except KeyError:
             raise KeyError("Required variable 'MetaData/dateTime' does not exist.")
-        print(dtvar)
+        # check if the array is type 'object' or not
+        # otherwise we will assume it is an integer and already set up
+        isostr = False
+        if (dtvar.dtype == np.dtype('object')):
+            if (isinstance(dtvar[0], str)):
+                isostr = True
+        if isostr:
+            # convert ISO date strings to datetime objects
+            newdtvar = [dt.datetime.strptime(x, "%Y-%m-%dT%H:%M:%SZ") for x in dtvar]
+            ObsVars[VarKey] = np.array(newdtvar, dtype=object)
+        else:
+            # assumed to be an integer with proper attributes
+            pass
+
+        return ObsVars
 
 
     def WriteGlobalAttrs(self, GlobalAttrs):

--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -148,6 +148,18 @@ class IodaWriter(object):
             except KeyError:
                 pass  # no metadata for this variable
 
+    def VerifyDateTime(self, ObsVars):
+        # this method will check if the variable
+        # MetaData/dateTime is a string or datetime object
+        # if string, convert to datetime object
+        VarKey = ('dateTime', 'MetaData')
+        try:
+            dtvar = ObsVars[VarKey]
+        except KeyError:
+            raise KeyError("Required variable 'MetaData/dateTime' does not exist.")
+        print(dtvar)
+
+
     def WriteGlobalAttrs(self, GlobalAttrs):
         # this method will create global attributes from GlobalAttrs dictionary
         for AttrKey, AttrVal in GlobalAttrs.items():
@@ -155,6 +167,8 @@ class IodaWriter(object):
 
     def BuildIoda(self, ObsVars, VarDims, VarAttrs, GlobalAttrs,
                   TestData=None, geovals=False):
+        # check and fix dateTime if necessary
+        ObsVars = self.VerifyDateTime(ObsVars)
         if geovals:
             self.WriteGeoVars(ObsVars, VarDims, VarAttrs)
         else:

--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -155,10 +155,9 @@ class IodaWriter(object):
         # MetaData/dateTime is a string or datetime object
         # if string, convert to datetime object
         VarKey = ('dateTime', 'MetaData')
-        try:
-            dtvar = ObsVars[VarKey]
-        except KeyError:
+        if VarKey not in ObsVars.keys():
             raise KeyError("Required variable 'MetaData/dateTime' does not exist.")
+        dtvar = ObsVars[VarKey]
         # check if the array is type 'object' or not
         # otherwise we will assume it is an integer and already set up
         if (dtvar.dtype == np.dtype('object')):
@@ -169,7 +168,6 @@ class IodaWriter(object):
                 ObsVars[VarKey] = np.array(newdtvar, dtype=object)
 
         return ObsVars
-
 
     def WriteGlobalAttrs(self, GlobalAttrs):
         # this method will create global attributes from GlobalAttrs dictionary


### PR DESCRIPTION
## Description

This PR adds to `ioda_conv_engines` the capability to check:

- Does the variable MetaData/dateTime exist?
- If so, is it a string?
- If so, convert it to datetime objects

Existing datetime objects are unaffected, and if the variable is defined as a integer with attributes describing the reference time, no changes occur.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #827 


## Acceptance Criteria (Definition of Done)

Approved and tested by folks, note it won't work properly until changes are made to IODA

## Dependencies

Needs changes to be made to IODA Python API to handle Python datetime objects before it will write to file properly.

## Impact

None
