### PR TITLE
bug fix on mopitt co converter

### DIFF
--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -110,7 +110,8 @@ class mopitt(object):
             # get ak
             AttrData['averaging_kernel_levels'] = np.int32(nlevs)
             # ak to be applied on surface density molecules/m2
-            ak_tc_dimless = dat.variables['TotalColumnAveragingKernelDimless'][:].astype('float32')
+            ak_tc_dimless = dat.variables['TotalColumnAveragingKernelDimless'][:]
+            ak_tc_dimless.mask = np.ma.nomask
 
             # get apriori quantities, profile is needed to compute (I-A)x_a
             xa_tc = dat.variables['APrioriCOTotalColumn'][:]

--- a/test/testoutput/mopitt_co.nc
+++ b/test/testoutput/mopitt_co.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0e9540dc961f0dade65c96a806a837a5fd3cf8b9338f1b81fdf7dbc41f213e7
-size 209593
+oid sha256:26fbf37673b15ccb4d4d9a3e64136cb3134bd34cb0b01366375c06b60a1e4edb
+size 209576


### PR DESCRIPTION
The averaging kernel data in the input was containing masked values. This was working ok until using numpy > 1.20.1.
We have to remove the mask for the converter to work properly.


