### PR TITLE
Added bias writer for viirs.

### DIFF
--- a/src/compo/CMakeLists.txt
+++ b/src/compo/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND programs
   modis_aod2ioda.py
   aeronet_aod2ioda.py
   aeronet_aaod2ioda.py
+  VIIRS_BiasWriter.py
 )
 
 file( RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_BINARY_DIR}/bin ${PYIODACONV_BUILD_LIBDIR} )

--- a/src/compo/VIIRS_BiasWriter.py
+++ b/src/compo/VIIRS_BiasWriter.py
@@ -1,0 +1,43 @@
+import sys
+import argparse
+import netCDF4
+from netCDF4 import Dataset, chartostring
+import numpy as np
+import os
+from pathlib import Path
+
+parser = argparse.ArgumentParser(
+    description=('Write VIIRS aerosol optical depth bias coefficients to NetCDF')
+)
+parser.add_argument(
+    '-o', '--output',
+    help="name of NetCDF output file",
+    type=str, required=True)
+
+args = parser.parse_args()
+predictor_out = netCDF4.stringtochar(np.array(['constant'], 'S8'))
+channels_out = [4]
+ncfile = Dataset(args.output, mode='w', format='NETCDF4')
+group1 = ncfile.createGroup("MetaData")
+group1.long_name = "MetaData"
+ncfile._ioda_layout = 'ObsGroup'
+ncfile._ioda_layout_version = 0
+coef_dim = ncfile.createDimension('bias_coefficients', 1)
+coef_err_dim = ncfile.createDimension('bias_coeff_errors', 1)
+npredictors = ncfile.createDimension('npredictors', 1)
+nchannels = ncfile.createDimension('nchannels', 1)
+coef = ncfile.createVariable('bias_coefficients', np.float, ('bias_coefficients', ))
+coef_error = ncfile.createVariable('bias_coeff_errors', np.float, ('bias_coeff_errors', ))
+predictors = ncfile.createVariable('predictors', 'S8', ('npredictors', ))
+channels = ncfile.createVariable('channels', np.int, ('nchannels', ))
+coef.units = 'Aerosol optical depth'
+coef.long_name = 'bias_coefficients'
+coef_error.units = 'Aerosol optical depth'
+coef_error.long_name = 'bias_coeff_errors'
+n_coef = len(coef_dim)
+coef[:] = -0.0163
+coef_error[:] = .0863
+predictor2 = netCDF4.chartostring(predictor_out)
+predictors[:] = predictor2
+channels[:] = channels_out
+ncfile.close()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ list( APPEND test_output
   testoutput/abi_g16_obs_2018041500.nc4
   testoutput/ioda.NC001007.2020031012.nc
   testoutput/viirs_aod.nc
+  testoutput/viirs_bias.nc 
   testoutput/tropomi_no2.nc
   testoutput/mopitt_co.nc
   testoutput/modis_aod.nc
@@ -222,6 +223,7 @@ if (iodaconv_satbias_ENABLED )
     testoutput/satbias_amsua_n18.nc4
     testoutput/satbias_cris_npp.nc4
     testoutput/satbias_ssmis_f16.nc4
+    testoutput/viirs_bias.nc 
   )
 endif()
 
@@ -750,6 +752,15 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_aod
                           -k maskout
                           -n 0.0"
                           viirs_aod.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_viirs_aod
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf 
+                            "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/VIIRS_BiasWriter.py
+                            -o testrun/viirs_bias.nc"
+                            viirs_bias.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2
                   TYPE    SCRIPT

--- a/test/testoutput/viirs_bias.nc
+++ b/test/testoutput/viirs_bias.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e620fe33162705077f44ac19a52bb6bf9116b495cf65533a53c414e30abf4ad4
+size 8232


### PR DESCRIPTION
Adds python code to write netcdf bias file for VIIRS AOD observations. This initial code is simply a global bias value. More detailed variations (regional, seasonal, etc) will be added later. 

What problem does it fix? What new capability does it add?

Allows for variational bias correction of VIIRS AOD observations.





Link the issues to be closed with this PR
- fixes #1889



What does it mean for this PR to be finished?

## Dependencies

None

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

fv30jedi will need a test yaml that includes viirs aod bias correction. This will be done next. 
