### PR TITLE
gsi_ncdiag surface pressure converter fixes

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -815,6 +815,10 @@ class Conv(BaseGSI):
                                 tmp = self.var(key1)[idx] - df_key[idx]
                             else:
                                 tmp = df_key[idx]
+                            # convert surface_pressure hofx to Pa from hPa
+                            if "Forecast_" in key and v == 'ps':
+                                if np.median(tmp) < 1100.:
+                                    tmp = tmp * 100.
                             if value in gsiint:
                                 tmp = tmp.astype(np.int32)
                                 tmp[tmp > 4e4] = self.INT_FILL

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -761,7 +761,7 @@ class Conv(BaseGSI):
                     if outvars[o] == 'surface_pressure':
                         if np.median(obsdata) < 1100.:
                             obsdata = obsdata * 100.  # convert to Pa from hPa
-                        obsdata[obsdata > 4e8] = self.FLOAT_FILL # 1e11 is fill value for surface_pressure
+                        obsdata[obsdata > 4e8] = self.FLOAT_FILL  # 1e11 is fill value for surface_pressure
                     obserr = self.var('Errinv_Input')[idx]
                     mask = obserr < self.EPSILON
                     obserr[~mask] = 1.0 / obserr[~mask]

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -770,7 +770,7 @@ class Conv(BaseGSI):
                     # obserr[mask] = self.FLOAT_FILL
                     # obserr[obserr > 4e8] = self.FLOAT_FILL
                     # convert surface_pressure error to Pa from hPa
-                    if v == 'ps' and np.nanmin(tmp) < 10:
+                    if v == 'ps' and np.nanmin(obserr) < 10:
                         obserr = obserr * 100
                     try:
                         obsqc = self.var('Prep_QC_Mark')[idx]

--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -761,6 +761,7 @@ class Conv(BaseGSI):
                     if outvars[o] == 'surface_pressure':
                         if np.median(obsdata) < 1100.:
                             obsdata = obsdata * 100.  # convert to Pa from hPa
+                        obsdata[obsdata > 4e8] = self.FLOAT_FILL # 1e11 is fill value for surface_pressure
                     obserr = self.var('Errinv_Input')[idx]
                     mask = obserr < self.EPSILON
                     obserr[~mask] = 1.0 / obserr[~mask]
@@ -768,6 +769,9 @@ class Conv(BaseGSI):
                     obserr[mask] = 1e8
                     # obserr[mask] = self.FLOAT_FILL
                     # obserr[obserr > 4e8] = self.FLOAT_FILL
+                    # convert surface_pressure error to Pa from hPa
+                    if v == 'ps' and np.nanmin(tmp) < 10:
+                        obserr = obserr * 100
                     try:
                         obsqc = self.var('Prep_QC_Mark')[idx]
                     except BaseException:
@@ -793,6 +797,9 @@ class Conv(BaseGSI):
                                 # below is a temporary hack
                                 tmp[mask] = 1e8
                                 # tmp[mask] = self.FLOAT_FILL
+                                # convert surface_pressure error to Pa from hPa
+                                if v == 'ps' and np.nanmin(tmp) < 10:
+                                    tmp = tmp * 100
                             elif "Obs_Minus_" in key:
                                 if 'u_Forecast_adjusted' in self.df.variables:
                                     continue


### PR DESCRIPTION
## Description

This PR adds temporary fixes for some issues found with gsi ncdiag conversion of surface pressure observations. 

- add checks for processing GSI obs error and hofx, if the unit is hPa, convert to Pa
- check for large value (~1e9) of surface pressure observation, convert to missing value

### Issue(s) addressed

N/A 

## Acceptance Criteria (Definition of Done)

Test and approve by 2 reviewers.

## Dependencies

N/A

## Impact

N/A