### PR TITLE
Feature/sprint ioda converters ne viirs modis l3 oc2ioda

### DIFF
--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -75,6 +75,7 @@ class OCL3(object):
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
         GlobalAttrs['time_coverage_start'] = ncd.getncattr('time_coverage_start')
 
+        timevar=GlobalAttrs['time_coverage_start'][:19]+':00Z'
 
         ncd.close()
 
@@ -97,7 +98,7 @@ class OCL3(object):
             vals = vals[mask_thin]
 
         for i in range(len(vals)):
-            locKey = lats[i], lons[i], GlobalAttrs['time_coverage_start']
+            locKey = lats[i], lons[i], timevar
             self.data[locKey][valKey] = vals[i]
             self.data[locKey][errKey] = vals[i] * 0.25
             self.data[locKey][qcKey] = 0

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -73,9 +73,9 @@ class OCL3(object):
         GlobalAttrs['platform'] = ncd.getncattr('platform')
         GlobalAttrs['sensor'] = ncd.getncattr('instrument')
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
-        GlobalAttrs['time_coverage_start'] = ncd.getncattr('time_coverage_start')
 
-        timevar=GlobalAttrs['time_coverage_start'][:19]+'Z'
+        timevar= ncd.getncattr('time_coverage_start')
+        obstime=GlobalAttrs['time_coverage_start'][:19]+'Z'
 
         ncd.close()
 
@@ -88,7 +88,7 @@ class OCL3(object):
         self.VarAttrs[vName['chlor_a'], iconv.OqcName()]['_FillValue'] = -32767
         self.VarAttrs[vName['chlor_a'], iconv.OvalName()]['units'] = 'mg m^-3'
         self.VarAttrs[vName['chlor_a'], iconv.OerrName()]['units'] = 'mg m^-3'
-        self.VarAttrs[vName['chlor_a'], iconv.OqcName()]['units'] = 'unitless'
+#        self.VarAttrs[vName['chlor_a'], iconv.OqcName()]['units'] = 'unitless'
 
         # apply thinning mask
         if self.thin > 0.0:
@@ -98,7 +98,7 @@ class OCL3(object):
             vals = vals[mask_thin]
 
         for i in range(len(vals)):
-            locKey = lats[i], lons[i], timevar
+            locKey = lats[i], lons[i], obstime 
             self.data[locKey][valKey] = vals[i]
             self.data[locKey][errKey] = vals[i] * 0.25
             self.data[locKey][qcKey] = 0

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -26,7 +26,7 @@ from orddicts import DefaultOrderedDict
 
 
 vName = {
-    'chlor_a': "mass_concentration_of_chlorophyll_in_sea_water",
+    'chlor_a': "chlorophyllMassConcentration",
 }
 
 VarDims = {
@@ -38,7 +38,7 @@ DimDict = {}
 locationKeyList = [
     ("latitude", "float"),
     ("longitude", "float"),
-    ("datetime", "string")
+    ("dateTime", "string")
 ]
 
 GlobalAttrs = {}

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -75,7 +75,7 @@ class OCL3(object):
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
 
         timevar= ncd.getncattr('time_coverage_start')
-        obstime=GlobalAttrs['time_coverage_start'][:19]+'Z'
+        obstime=timevar[:19]+'Z'
 
         ncd.close()
 

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -30,7 +30,7 @@ vName = {
 }
 
 VarDims = {
-    vName['chlor_a']: ['nlocs']
+    vName['chlor_a']: ['Location']
 }
 
 DimDict = {}
@@ -67,9 +67,14 @@ class OCL3(object):
         lats = lats.ravel()[mask]
 
         # get global attributes
-        for v in ('platform', 'instrument', 'processing_version',
-                  'time_coverage_start'):
-            GlobalAttrs[v] = ncd.getncattr(v)
+#        for v in ('platform', 'instrument', 'processing_version',
+#                  'time_coverage_start'):
+#            GlobalAttrs[v] = ncd.getncattr(v)
+        GlobalAttrs['platform'] = ncd.getncattr('platform')
+        GlobalAttrs['sensor'] = ncd.getncattr('instrument')
+        GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
+
+
         ncd.close()
 
         valKey = vName['chlor_a'], iconv.OvalName()
@@ -90,11 +95,11 @@ class OCL3(object):
             lats = lats[mask_thin]
             vals = vals[mask_thin]
 
-        for i in range(len(vals)):
-            locKey = lats[i], lons[i], GlobalAttrs['time_coverage_start']
-            self.data[locKey][valKey] = vals[i]
-            self.data[locKey][errKey] = vals[i] * 0.25
-            self.data[locKey][qcKey] = 0
+#        for i in range(len(vals)):
+#            locKey = lats[i], lons[i], GlobalAttrs['time_coverage_start']
+#            self.data[locKey][valKey] = vals[i]
+#            self.data[locKey][errKey] = vals[i] * 0.25
+#            self.data[locKey][qcKey] = 0
 
 
 def main():
@@ -123,12 +128,12 @@ def main():
     chl = OCL3(args.input, fdate, args.thin)
 
     # Extract the obs data
-    ObsVars, nlocs = iconv.ExtractObsData(chl.data, locationKeyList)
+    ObsVars, Location = iconv.ExtractObsData(chl.data, locationKeyList)
 
     # Set Attributes
     GlobalAttrs['thinning'] = args.thin
     GlobalAttrs['converter'] = os.path.basename(__file__)
-    DimDict['nlocs'] = nlocs
+    DimDict['Location'] = Location
 
     # Set up the writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -73,6 +73,7 @@ class OCL3(object):
         GlobalAttrs['platform'] = ncd.getncattr('platform')
         GlobalAttrs['sensor'] = ncd.getncattr('instrument')
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
+        GlobalAttrs['time_coverage_start'] = ncd.getncattr('time_coverage_start')
 
 
         ncd.close()
@@ -95,11 +96,11 @@ class OCL3(object):
             lats = lats[mask_thin]
             vals = vals[mask_thin]
 
-#        for i in range(len(vals)):
-#            locKey = lats[i], lons[i], GlobalAttrs['time_coverage_start']
-#            self.data[locKey][valKey] = vals[i]
-#            self.data[locKey][errKey] = vals[i] * 0.25
-#            self.data[locKey][qcKey] = 0
+        for i in range(len(vals)):
+            locKey = lats[i], lons[i], GlobalAttrs['time_coverage_start']
+            self.data[locKey][valKey] = vals[i]
+            self.data[locKey][errKey] = vals[i] * 0.25
+            self.data[locKey][qcKey] = 0
 
 
 def main():

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -75,7 +75,7 @@ class OCL3(object):
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
         GlobalAttrs['time_coverage_start'] = ncd.getncattr('time_coverage_start')
 
-        timevar=GlobalAttrs['time_coverage_start'][:19]+':00Z'
+        timevar=GlobalAttrs['time_coverage_start'][:19]+'Z'
 
         ncd.close()
 

--- a/src/marine/viirs_modis_l3_oc2ioda.py
+++ b/src/marine/viirs_modis_l3_oc2ioda.py
@@ -66,10 +66,6 @@ class OCL3(object):
         lons = lons.ravel()[mask]
         lats = lats.ravel()[mask]
 
-        # get global attributes
-#        for v in ('platform', 'instrument', 'processing_version',
-#                  'time_coverage_start'):
-#            GlobalAttrs[v] = ncd.getncattr(v)
         GlobalAttrs['platform'] = ncd.getncattr('platform')
         GlobalAttrs['sensor'] = ncd.getncattr('instrument')
         GlobalAttrs['description'] = str(ncd.getncattr('processing_level')+' processing')
@@ -88,7 +84,6 @@ class OCL3(object):
         self.VarAttrs[vName['chlor_a'], iconv.OqcName()]['_FillValue'] = -32767
         self.VarAttrs[vName['chlor_a'], iconv.OvalName()]['units'] = 'mg m^-3'
         self.VarAttrs[vName['chlor_a'], iconv.OerrName()]['units'] = 'mg m^-3'
-#        self.VarAttrs[vName['chlor_a'], iconv.OqcName()]['units'] = 'unitless'
 
         # apply thinning mask
         if self.thin > 0.0:

--- a/test/testoutput/viirs_jpss1_oc_l3.nc
+++ b/test/testoutput/viirs_jpss1_oc_l3.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5d661789206e72268bf5a4e91cd957cbc4cf6da53df6e8af12ea9a0e4ab8dfe
-size 10749
+oid sha256:dbce51941b5eff79dd1846f1cc6fb70c8e099c141e807b15efa6bf688c61ad28
+size 13387

--- a/test/testoutput/viirs_jpss1_oc_l3.nc
+++ b/test/testoutput/viirs_jpss1_oc_l3.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb96f50b7fa2f0885bd6b23ef242c7b047042e305c9f863bdb5d6891ad1a22b8
-size 17642
+oid sha256:a5d661789206e72268bf5a4e91cd957cbc4cf6da53df6e8af12ea9a0e4ab8dfe
+size 10749


### PR DESCRIPTION
## Description

This updates the python HDF5 converter to the latest IODA conventions for viirs modis level 3 data.

### Issue(s) addressed

- fixes #928 

## Acceptance Criteria (Definition of Done)

successful pass of the ctest 'test_iodaconv_viirs_jpss1_oc_l3' , 'iodaconv_validate_testoutput_viirs_jpss1_oc_l3.nc' 


## Dependencies
None
