### PR TITLE
Error in git address

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CLANG:[![AWS-clang](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbm
 The converters can be built and tested using ioda-bundle. In ioda-bundle the build of the converters is disabled by default (for now) so you must enable the build using the BUILD_IODA_CONVERTERS directive. Here is an example:
 
 ```
-git clone https://github.com/jcsda-internal/ioda-bundle
+git clone https://github.com/jcsda/ioda-bundle
 cd ioda-bundle
 mkdir build
 cd build


### PR DESCRIPTION
## Description
Corrects the typo in the ioda-bundle git repo address in readme file.

### Issue(s) addressed
No issue. 

If this does not close an existing issue, then [be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)

## Acceptance Criteria (Definition of Done)
Simple error correction of one word. 

## Dependencies
No dependencies.

## Impact
No other repos affected. 
