### PR TITLE
Sprint: update src/marine/gds2_sst2ioda.py code for JEDI Data Conventions

### DIFF
--- a/src/marine/gds2_sst2ioda.py
+++ b/src/marine/gds2_sst2ioda.py
@@ -212,7 +212,7 @@ def IODA(filename, GlobalAttrs, nlocs, obs_data):
     for key in var_keys:
         if (key, obsValName) in obs_data:
             var_name = varInfo[var_keys.index(key)][1]
-            varDims[var_name] = 'Location'
+            varDims[var_name] = ['Location']
             varAttrs[(var_name, obsValName)]['units'] = varInfo[var_keys.index(key)][2]
             varAttrs[(var_name, obsErrName)]['units'] = varInfo[var_keys.index(key)][2]
             varAttrs[(var_name, obsValName)]['_FillValue'] = varInfo[var_keys.index(key)][3]

--- a/src/marine/gds2_sst2ioda.py
+++ b/src/marine/gds2_sst2ioda.py
@@ -329,7 +329,7 @@ def main():
     # Total number of observations.
     nlocs = len(obs_data[('dateTime', metaDataName)])
 
-    print (f"Preparing to write {nlocs} observations to {args.output}")
+    print(f"Preparing to write {nlocs} observations to {args.output}")
 
     # Write out the file.
     IODA(args.output, GlobalAttrs, nlocs, obs_data)

--- a/src/marine/gds2_sst2ioda.py
+++ b/src/marine/gds2_sst2ioda.py
@@ -16,7 +16,6 @@ import dateutil.parser
 import numpy as np
 from multiprocessing import Pool
 import os
-import re
 from pathlib import Path
 
 IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"

--- a/test/testoutput/gds2_sst_l2p.nc
+++ b/test/testoutput/gds2_sst_l2p.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ae3caa9313de4670f6e8b2f112ccaaf97707db0b8607d551143f79cd5d43eb9
-size 20190
+oid sha256:f2f5fc17845dacb931aba0c7096b44bded5eac1e2be558ac29a3ab0a98c7e3fb
+size 17767

--- a/test/testoutput/gds2_sst_l3u.nc
+++ b/test/testoutput/gds2_sst_l3u.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55049b4906887a975cf1a16e67645297a2340993ec47ad4b71be3e86577c6ab7
-size 20194
+oid sha256:e33fadc7883fac36f093ba1128a6e00b75cca9843e32c8e44dfee687782335f9
+size 17799


### PR DESCRIPTION
## Description

This PR updates the ```src/marine/gds2_sst2ioda.py``` script to follow the JEDI Data Conventions.  Besides some of the regular changes like ```datetime``` to ```dateTime``` a number of relatively minor improvements to code structure becoming more generic and similar to many other marine converters.

### Issue(s) addressed

Closes #935 

## Acceptance Criteria (Definition of Done)

Success on the 2 ctests of this script (2 different processing levels of input data) and ioda-validate program along with positive reviews.

## Dependencies

Waiting on the following PRs:
- [ ] waiting on [JCSDA/ioda/pull/704](https://github.com/JCSDA-internal/ioda/pull/704)

## Impact

No impacts if kept within ```feature/sprint-ioda-converters```
