### PR TITLE
improve and clean viirs aod

### DIFF
--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -124,29 +124,10 @@ class AOD(object):
                 obs_time = obs_time[mask_thin]
 
             # defined surface type and uncertainty
-            sfctyp = 0*qcall
-            uncertainty = 0.0*errs
-            uncertainty1 = 0.0*errs
-            uncertainty2 = 0.0*errs
-
             if self.method == "nesdis":
-                # Case of water high quality
-                uncertainty = 0.00784394 + 0.219923*vals
-                # case of bright land high quality
-                uncertainty1 = 0.0550472 + 0.299558*vals
-                # case of dark land high quality
-                uncertainty2 = 0.111431 + 0.128699*vals
-
-            for i in range(len(lons)):
-
-                # convert byte to integer
-                sfctyp[i] = int.from_bytes(qcpath[i], byteorder='big')
-                if self.method == "nesdis":
-                    if sfctyp[i] == 1:   # case of bright land high quality
-                        uncertainty[i] = uncertainty1[i]
-                    else:   # case of dark land high quality
-                        uncertainty[i] = uncertainty2[i]
-                    errs[i] = uncertainty[i]
+                errs = 0.00784394 + 0.219923*vals
+                errs[qcpath == 1] = 0.0550472 + 0.299558*vals[qcpath == 1]
+                errs[qcpath != 1] = 0.111431 + 0.128699*vals[qcpath != 1]
 
             #  Write out data
 


### PR DESCRIPTION
## Description

Cleaned the code on the error specification using the nesdis option. 
Removed useless variables.
Removed a for loop that was problematic given the size and number of viirs files.
The code (within those lines) is about 50x faster now in term of process time. I did the tests on my mac... 

Avoid as much as possible for loops with python (I don't think this language has been designed for that....)! Use list comprehensions

Tagged colleagues:
@bhuang95, @mpagowski, @mer-a-o, @rhoneyager    
