### PR TITLE
Fixed issue in the smap9k converter with the variable vegetationOpacity

### DIFF
--- a/src/land/smap9km_ssm2ioda.py
+++ b/src/land/smap9km_ssm2ioda.py
@@ -130,7 +130,6 @@ class smap(object):
         self.varAttrs[('longitude', 'MetaData')]['units'] = 'degrees_east'
         self.outdata[('earthSurfaceType', 'MetaData')] = sflg
         self.outdata[('vegetationOpacity', 'MetaData')] = vegop
-        self.varAttrs[('vegetationOpacity', 'MetaData')]['units'] = 'unitless'
         self.outdata[('easeRowIndex', 'MetaData')] = erowi
         self.varAttrs[('easeRowIndex', 'MetaData')]['units'] = '1'
         self.outdata[('easeColumnIndex', 'MetaData')] = ecoli

--- a/test/testoutput/smap9km_ssm.nc
+++ b/test/testoutput/smap9km_ssm.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2299aca755917cd72b77d2ece74822e8e8f0e95e84d3b26c4ca56ebf92757228
+oid sha256:007214945adb9c439b74c91131e1f61a6ea4c41b8ccacb8ed1a983079f5aa317
 size 387362


### PR DESCRIPTION
## Description

This PR fixes an issue with the variable `vegetaionOpacity` in the smap9k converter. `vegetationOpacity` had a units attribute set to "unitless" which is an outdated setting. Instead the units attribute should be removed (ie, when you have an enumerated/categorical type variable).

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

Ioda converters test for smap9k passes.
The variable `vegetationOpacity` has no units attribute in the smap9k test reference file.

## Dependencies

- [ ] merge with or after jcsda-internal/ioda/pull/708

## Impact

None