### PR TITLE
Fix for ncdiag converter for conv surface type

### DIFF
--- a/src/gsi-ncdiag/gsi_ncdiag.py
+++ b/src/gsi-ncdiag/gsi_ncdiag.py
@@ -867,11 +867,14 @@ class Conv(BaseGSI):
                             tmp[tmp == 10009.] = self.FLOAT_FILL  # for u,v sfc Height values that are 10+9999
                             # GSI sfc obs are at 0m agl, but operator assumes 2m agl, correct output to 2m agl
                             # this is correctly 10m agl though for u,v obs
-                            if lvar == 'Height' and self.obstype in ['conv_t', 'conv_q']:
-                                elev = self.var('Station_Elevation')[idx]
-                                hgt = elev + 2.
-                                hgt[hgt > 9998.] = self.FLOAT_FILL
-                                tmp = hgt
+                            # --- temporarily comment out the following so 2m_t & 2m_q can be properly combined
+                            # --- with surface_pressure ioda obs as single record because 2m_t and 2m_q are used
+                            # --- in UFO surface pressure correction scheme
+                            # if lvar == 'Height' and self.obstype in ['conv_t', 'conv_q']:
+                            #     elev = self.var('Station_Elevation')[idx]
+                            #     hgt = elev + 2.
+                            #     hgt[hgt > 9998.] = self.FLOAT_FILL
+                            #     tmp = hgt
                             outdata[(loc_mdata_name, 'MetaData')] = tmp
                             varAttrs[(loc_mdata_name, 'MetaData')]['units'] = 'm'
                         elif p == 'sondes' or p == 'aircraft' or p == 'satwind':

--- a/test/testoutput/sfc_tv_obs_2018041500.nc4
+++ b/test/testoutput/sfc_tv_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c75ce1884fbd971f47a16b5c60a204f832be58114a764b267aaa1dc02d83ffe
+oid sha256:afa890d54e55b2a7acd27624c90d0adf1d9da8d10329a3b540a4355fd5bd119e
 size 30423


### PR DESCRIPTION
## Description

This PR adds a temporary fix for conversion of conv surface t & q, which are 2 meter temperature and moisture observations. In the current conversion, the height of the 2 meter temperature and moisture is computed from the station height of surface pressure plus 2m. Because of this, 2 meter temperature and moisture observations are not properly combined with surface pressure observation. These 2m variables are used in the UFO sfcpcorrected GSI scheme. A temporary fix is to comment out the section that computes the height of 2m variables as station elevation plus 2m, but instead directly use the station elevation for the 2m variables. 

### Issue(s) addressed

N/A

## Acceptance Criteria (Definition of Done)

Tests pass and approval by two reviewers

## Dependencies

N/A

## Impact

N/A