### PR TITLE
coperl4 bug fix

### DIFF
--- a/src/marine/copernicus_l4adt2ioda.py
+++ b/src/marine/copernicus_l4adt2ioda.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"
 if not IODA_CONV_PATH.is_dir():
-    IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"
+    IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
 sys.path.append(str(IODA_CONV_PATH.resolve()))
 
 import ioda_conv_engines as iconv

--- a/src/marine/copernicus_l4adt2ioda.py
+++ b/src/marine/copernicus_l4adt2ioda.py
@@ -73,10 +73,12 @@ class copernicus(object):
         self.datetime = np.empty_like(self.adt, dtype=object)
         self.datetime[:] = self.date
 
+
 class copernicus_l4adt2ioda(object):
+
     def __init__(self, filename, datetime=None):
         self.filename = filename
-        self.datetime=datetime
+        self.datetime = datetime
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.metaDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
@@ -97,9 +99,9 @@ class copernicus_l4adt2ioda(object):
         adt = copernicus(self.filename)
         # put the time at 00 between start and end coverage time
         if self.datetime is not None:
-            ymdh=datetime.strptime(self.datetime, "%Y%m%d")
-            ymdhm=ymdh.strftime("%Y-%m-%dT%H:%M:%SZ")
-            adt.datetime[:]=ymdhm
+            ymdh = datetime.strptime(self.datetime, "%Y%m%d")
+            ymdhm = ymdh.strftime("%Y-%m-%dT%H:%M:%SZ")
+            adt.datetime[:] = ymdhm
         # map copernicus to ioda data structure
         self.outdata[('datetime', 'MetaData')] = adt.datetime
         self.outdata[('latitude', 'MetaData')] = adt.lats

--- a/src/marine/copernicus_l4adt2ioda.py
+++ b/src/marine/copernicus_l4adt2ioda.py
@@ -128,7 +128,7 @@ def main():
         type=str, required=True)
     required.add_argument(
         '-d', '--date',
-        help="date of the file",
+        help="provide date in the format %Y-%m-%dT%H:%M:%SZ",
         type=str, required=False)
 
     args = parser.parse_args()

--- a/src/marine/copernicus_l4adt2ioda.py
+++ b/src/marine/copernicus_l4adt2ioda.py
@@ -97,7 +97,9 @@ class copernicus_l4adt2ioda(object):
         adt = copernicus(self.filename)
         # put the time at 00 between start and end coverage time
         if self.datetime is not None:
-            adt.datetime[:]=self.datetime
+            ymdh=datetime.strptime(self.datetime, "%Y%m%d")
+            ymdhm=ymdh.strftime("%Y-%m-%dT%H:%M:%SZ")
+            adt.datetime[:]=ymdhm
         # map copernicus to ioda data structure
         self.outdata[('datetime', 'MetaData')] = adt.datetime
         self.outdata[('latitude', 'MetaData')] = adt.lats

--- a/src/marine/copernicus_l4adt2ioda.py
+++ b/src/marine/copernicus_l4adt2ioda.py
@@ -14,10 +14,9 @@ import numpy as np
 from datetime import datetime, timedelta
 import os
 from pathlib import Path
-
-IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
+IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"
 if not IODA_CONV_PATH.is_dir():
-    IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
+    IODA_CONV_PATH = Path(__file__).parent/"@SCRIPT_LIB_PATH@"
 sys.path.append(str(IODA_CONV_PATH.resolve()))
 
 import ioda_conv_engines as iconv

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,7 @@ list( APPEND test_input
   testinput/airnow_sites.dat
   testinput/airnow_2020081306.dat
   testinput/aeronet_aod.dat
-  testinput/dt_global_twosat_phy_l4_20150101_vDT2018.nc
+  testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
   testinput/global_vavh_l3_rt_s3a_20210930T18.nc
   testinput/aeronet_cad.dat
   testinput/aeronet_tab.dat
@@ -110,7 +110,7 @@ list( APPEND test_output
   testoutput/smos_sss_l2.nc
   testoutput/airnow_2020081306.nc
   testoutput/aeronet_aod.nc
-  testoutput/ioda_dt_global_twosat_phy_l4_20150101_vDT2018.nc
+  testoutput/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc
   testoutput/ioda_global_vavh_l3_rt_s3a_20210930T18.nc
   testoutput/aeronet_aaod.nc
   testoutput/imsfv3_scf.nc
@@ -515,9 +515,9 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l4adt
                   ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/copernicus_l4adt2ioda.py
-                          -i testinput/dt_global_twosat_phy_l4_20150101_vDT2018.nc
-                          -o testrun/ioda_dt_global_twosat_phy_l4_20150101_vDT2018.nc"
-                          ioda_dt_global_twosat_phy_l4_20150101_vDT2018.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          -i testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
+                          -o testrun/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc -d 20190101"
+                          ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l3swh
                   TYPE    SCRIPT

--- a/test/testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
+++ b/test/testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41327851069478272f2c6faae2b91f7c7344bffa8006210e0c2d2642e88c74f8
+size 186933

--- a/test/testoutput/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc
+++ b/test/testoutput/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22c34ec032f3d07eec9537d04ccaa244e492c11f3b54fd279a1686a49d0f9b10
+size 210989


### PR DESCRIPTION
## Description
This PR includes the following changes:
1.  replace the keyword 'err' by 'err_sla' in the python script
2. fixed datetime inconsistency. One needs to pass the datetime as an argument in the format: %Y-%m-%dT%H:%M:%SZ
### Issues addressed
 #955
