### PR TITLE
BUFR lib name fixes

### DIFF
--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND _ingester_deps
   eckit
   ${oops_LIBRARIES}
   ioda_engines
-  bufr::bufr_4_DA
+  bufr::bufr_4
 )
 
 ecbuild_add_library( TARGET   ingester

--- a/src/gnssro/CMakeLists.txt
+++ b/src/gnssro/CMakeLists.txt
@@ -5,7 +5,7 @@
          
 ecbuild_add_executable( TARGET  gnssro_bufr2ioda
                         SOURCES gnssro_bufr2ioda.f90
-                        LIBS    bufr::bufr_4_DA
+                        LIBS    bufr::bufr_4
                                 NetCDF::NetCDF_Fortran)
 
 ecbuild_add_executable( TARGET  gnssro_gsidiag2ioda

--- a/src/ncar-bufr2nc-fortran/CMakeLists.txt
+++ b/src/ncar-bufr2nc-fortran/CMakeLists.txt
@@ -18,5 +18,5 @@ list(APPEND bufr2nc_source
 
 ecbuild_add_executable( TARGET  bufr2nc_fortran.x
                         SOURCES ${bufr2nc_source}
-                        LIBS    bufr::bufr_4_DA
+                        LIBS    bufr::bufr_4
                                 NetCDF::NetCDF_Fortran)

--- a/tools/fortran/CMakeLists.txt
+++ b/tools/fortran/CMakeLists.txt
@@ -2,9 +2,9 @@
 if( iodaconv_bufr_ENABLED )
   ecbuild_add_executable( TARGET  pb_decode
                           SOURCES pb_decode.f90
-                          LIBS    bufr::bufr_4_DA)
+                          LIBS    bufr::bufr_4)
 
   ecbuild_add_executable( TARGET  pb_decode_events
                           SOURCES pb_decode_events.f90
-                          LIBS    bufr::bufr_4_DA)
+                          LIBS    bufr::bufr_4)
 endif()


### PR DESCRIPTION
## Description

Fixes https://github.com/JCSDA-internal/ioda-converters/issues/970. See there for details.

I tested locally on my mac's Spack stack, which is using a recent NCEPLIB-bufr library. This PR needs to be tested against the current jedi stack before merging. 