### PR TITLE
Add ioda as dependency for ioda converters in cmake configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,11 @@ find_package( Eigen3 QUIET NO_MODULE HINTS
 if( ecbuild_VERSION VERSION_LESS 3.4 )
   find_package( eckit QUIET )
   find_package( oops QUIET )
+  find_package( ioda QUIET )
 else()
   ecbuild_find_package( eckit VERSION 1.13.0 QUIET )
   ecbuild_find_package( oops VERSION 1.0.0 QUIET )
+  ecbuild_find_package( ioda VERSION 1.0.0 QUIET )
 endif()
 # Optional: pygrib for python for GRIB1/GRIB2 input files
 if ( USE_PYGRIB )


### PR DESCRIPTION
## Description

This PR adds ioda as a dependency in the cmake configuration. This is not intended to be an extensive cleanup of the cmake configuration, rather the minimum to get ioda-converters to build standalone (ie, outside of ioda-bundle).

### Issue(s) addressed

Link the issues to be closed with this PR

Partially addresses jcsda-internal/ioda/issues/717

## Acceptance Criteria (Definition of Done)

Able to build ioda-converters outside of ioda-bundle.

## Dependencies

- [x] merge with or after jcsda-internal/ioda/pull/715

## Impact

None
