### PR TITLE
Update test reference files for the new default fill value for the dateTime variable.

### DIFF
--- a/src/compo/mls_o3_nc2ioda.py
+++ b/src/compo/mls_o3_nc2ioda.py
@@ -255,7 +255,7 @@ class mls(object):
                 self.outdata[k] = self.outdata[k].astype('float32')
             elif(self.outdata[k].dtype == 'int64' and k != ('dateTime', 'MetaData')):
                 self.outdata[k] = self.outdata[k].astype('int32')
-        self.outdata[('dateTime', 'MetaData')].astype(np.int64)
+        self.outdata[('dateTime', 'MetaData')] = self.outdata[('dateTime', 'MetaData')].astype(np.int64)
         self.outdata[('longitude', 'MetaData')] = self.outdata[('longitude', 'MetaData')] % 360
 # end mls object.
 

--- a/src/compo/omi_o3_nc2ioda.py
+++ b/src/compo/omi_o3_nc2ioda.py
@@ -248,7 +248,7 @@ class omi(object):
                 self.outdata[k] = self.outdata[k].astype('int32')
             elif(self.outdata[k].dtype == 'uint16' or self.outdata[k].dtype == 'uint8'):
                 self.outdata[k] = self.outdata[k].astype(int)
-        self.outdata[('dateTime', 'MetaData')].astype('int64')
+        self.outdata[('dateTime', 'MetaData')] = self.outdata[('dateTime', 'MetaData')].astype('int64')
         # ensure lon is 0-360
         self.outdata[('longitude', 'MetaData')] = self.outdata[('longitude', 'MetaData')] % 360
 

--- a/src/compo/ompsnm_o3_nc2ioda.py
+++ b/src/compo/ompsnm_o3_nc2ioda.py
@@ -170,7 +170,7 @@ class ompsnm(object):
                 self.outdata[k] = self.outdata[k].astype('int32')
         DimDict['nlocs'] = self.outdata[('dateTime', 'MetaData')].shape[0]
         AttrData['nlocs'] = np.int32(DimDict['nlocs'])
-        self.outdata[('dateTime', 'MetaData')].astype(np.int64)
+        self.outdata[('dateTime', 'MetaData')] = self.outdata[('dateTime', 'MetaData')].astype(np.int64)
         self.outdata[('longitude', 'MetaData')] = self.outdata[('longitude', 'MetaData')] % 360
 # end ompsnm object.
 

--- a/src/lib-python/ioda_conv_engines.py
+++ b/src/lib-python/ioda_conv_engines.py
@@ -199,6 +199,9 @@ def ExtractObsData(ObsData, loc_key_list):
         if (VarType in [float, np.float32, np.float64]):
             defaultval = get_default_fill_val(np.float32)
             defaultvaltype = np.float32
+        elif ((VarType in [np.int64]) and (o == ('dateTime', 'MetaData'))):
+            defaultval = get_default_fill_val(np.int64)
+            defaultvaltype = np.int64
         elif (VarType in [int, np.int64, np.int32, np.int8]):
             defaultval = get_default_fill_val(np.int32)
             defaultvaltype = np.int32

--- a/test/testoutput/mls_o3_l2.nc
+++ b/test/testoutput/mls_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d133298035477b744edc724ed2a67b7b1389b802a2d0d6ba9597d589600ca58
+oid sha256:6f4d8c7ea2826f9bc127b9e5030dcd02c28e67a1721cfde95fd02fa86788e2b5
 size 26380

--- a/test/testoutput/mls_o3_l2.nc
+++ b/test/testoutput/mls_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f4d8c7ea2826f9bc127b9e5030dcd02c28e67a1721cfde95fd02fa86788e2b5
+oid sha256:0c10b89fb04865b64292e7e5538feedbbce3df9af95e76584d2c5887ff52d440
 size 26380

--- a/test/testoutput/omi_o3_l2.nc
+++ b/test/testoutput/omi_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:754d731c4d86a46a0ade39cf0b288eeca10f8da1af41b85235728c0e0f00841f
+oid sha256:65860bf2435b5cac5525b3da25d54e62ed5dfabecf4338f1ed3c9a501bb126bd
 size 838866

--- a/test/testoutput/omi_o3_l2.nc
+++ b/test/testoutput/omi_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65860bf2435b5cac5525b3da25d54e62ed5dfabecf4338f1ed3c9a501bb126bd
-size 838866
+oid sha256:2b5965a3f258eb901fe23c21f542189dde2d759d40e16a682b6f81e670aa6951
+size 838859

--- a/test/testoutput/ompsnm_o3_l2.nc
+++ b/test/testoutput/ompsnm_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de76964336fc75223da147bd6efa55570e95d701bd1d7c31acb01239a826c3a1
-size 296961
+oid sha256:51ec919979f11174f267aa001eb9d4854071bae6c0c991c27daf9b818b5f4051
+size 296953

--- a/test/testoutput/ompsnm_o3_l2.nc
+++ b/test/testoutput/ompsnm_o3_l2.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:698f75483e06ccc22fc7d26425d69e1114386dbd6409b753ab383caa1a301a8b
+oid sha256:de76964336fc75223da147bd6efa55570e95d701bd1d7c31acb01239a826c3a1
 size 296961


### PR DESCRIPTION
## Description

This PR contains test reference file updates for jcsda-internal/ioda/pull/753. Note that the only thing that has changed are the fill values on the dateTime variables in the new reference files. All other data matches the current files on develop.

### Issue(s) addressed

related to jcsda-internal/ioda/issues/703

## Acceptance Criteria (Definition of Done)

The default fill value for dateTime won't overflow 64-bit integers on all platforms.

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/753

## Impact

None