### PR TITLE
Fix for test failure (test_iodaconv_ghcn_snod) with spack-stack build

### DIFF
--- a/src/land/ghcn_snod2ioda.py
+++ b/src/land/ghcn_snod2ioda.py
@@ -102,7 +102,7 @@ class ghcn(object):
         df30 = df30[df30["DATETIME"] == parse(startdate).date()]
         # Read station files
         cols = ["ID", "LATITUDE", "LONGITUDE", "ELEVATION", "STATE", "NAME", "GSN_FLAG", "HCNCRN_FLAG", "WMO_ID"]
-        df10all = pd.read_csv(self.fixfile, header=None, sep='\t')
+        df10all = pd.read_csv(self.fixfile, header=None, sep='\r\n')
         df10all = df10all[0].str.split('\\s+', expand=True)
         df10 = df10all.iloc[:, 0:4]
         sub_cols = {0: "ID", 1: "LATITUDE", 2: "LONGITUDE", 3: "ELEVATION"}

--- a/src/land/ghcn_snod2ioda.py
+++ b/src/land/ghcn_snod2ioda.py
@@ -102,7 +102,7 @@ class ghcn(object):
         df30 = df30[df30["DATETIME"] == parse(startdate).date()]
         # Read station files
         cols = ["ID", "LATITUDE", "LONGITUDE", "ELEVATION", "STATE", "NAME", "GSN_FLAG", "HCNCRN_FLAG", "WMO_ID"]
-        df10all = pd.read_csv(self.fixfile, header=None, sep='\n')
+        df10all = pd.read_csv(self.fixfile, header=None, sep='\t')
         df10all = df10all[0].str.split('\\s+', expand=True)
         df10 = df10all.iloc[:, 0:4]
         sub_cols = {0: "ID", 1: "LATITUDE", 2: "LONGITUDE", 3: "ELEVATION"}


### PR DESCRIPTION
## Description

This PR fixes an issue that surfaced with the `test_iodaconv_ghcn_snod` test when using a spack-stack build. spack-stack builds the pandas python package using the python installation that is found when spack-stack install is running. The `test_iodaconv_ghcn_snod` test runs a python script `ghch_snod2ioda.py` which uses the pandas read_csv command to read a text file containing station names. The read_csv is called with '\n' as a delimiter, but this was failing on my Mac (and possibly other platforms). This issue is that read_csv with it's built-in parser does not recognize '\n' as a delimiter, so it switches to the 'python' parser which can vary depending on the version that is found when spack-stack runs.

I'm not expert with pandas, so there might be a much better way to solve this. Please treat this PR as a proposal, and feel free to suggest a better way to fix this. I changed the delimiter from '\n' to '\t' (tab) which is recognized by the read_csv built-in parser and appears to work (since the intent appears to be to get read_csv to treat the entire line as a single entry in the output dataframe.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

The `test_iodaconv_ghcn_snod` test passes on the Mac (and all platforms).

## Dependencies

None

## Impact

None