### PR TITLE
Bugfix/omi ompsnm converter get files correctly at beginning of window

### DIFF
--- a/src/compo/omi_o3_nc2ioda.py
+++ b/src/compo/omi_o3_nc2ioda.py
@@ -328,7 +328,7 @@ def main():
         rawFiles.sort()
         # only read files in window
         rawFilesOut = []
-        for fi,f in enumerate(rawFiles):
+        for fi, f in enumerate(rawFiles):
             vv = f.split('_')
             # v003-2020m1214t060743.he5 2020m1214t0003-o87313
             startDateFile = datetime.strptime(vv[-2][0:-7], "%Ym%m%dt%H%M")

--- a/src/compo/omi_o3_nc2ioda.py
+++ b/src/compo/omi_o3_nc2ioda.py
@@ -328,11 +328,15 @@ def main():
         rawFiles.sort()
         # only read files in window
         rawFilesOut = []
-        for f in rawFiles:
+        for fi,f in enumerate(rawFiles):
             vv = f.split('_')
             # v003-2020m1214t060743.he5 2020m1214t0003-o87313
             startDateFile = datetime.strptime(vv[-2][0:-7], "%Ym%m%dt%H%M")
-            endDateFile = datetime.strptime(vv[-1][5:-6], "%Ym%m%dt%H%M")
+            endDateFile = startDateFile
+            # Check the the start time for the next file to get the end time of current file.
+            if(fi != len(rawFiles)-1):
+                vv = rawFiles[fi+1].split('_')
+                endDateFile = datetime.strptime(vv[-2][0:-7], "%Ym%m%dt%H%M")
             if(startDateWindow <= startDateFile <= endDateWindow or startDateWindow <= endDateFile <= endDateWindow):
                 rawFilesOut.append(f)
         rawFiles = rawFilesOut

--- a/src/compo/ompsnm_o3_nc2ioda.py
+++ b/src/compo/ompsnm_o3_nc2ioda.py
@@ -248,7 +248,7 @@ def main():
 
         # only read files in the window.
         rawFilesOut = []
-        for fi,f in enumerate(rawFiles):
+        for fi, f in enumerate(rawFiles):
             vv = f.split('_')
             # 2020m1216t011958.h5 2020m1215t222840
             startDateFile = datetime.strptime(vv[-3][0:-2], "%Ym%m%dt%H%M")

--- a/src/compo/ompsnm_o3_nc2ioda.py
+++ b/src/compo/ompsnm_o3_nc2ioda.py
@@ -248,11 +248,15 @@ def main():
 
         # only read files in the window.
         rawFilesOut = []
-        for f in rawFiles:
+        for fi,f in enumerate(rawFiles):
             vv = f.split('_')
             # 2020m1216t011958.h5 2020m1215t222840
             startDateFile = datetime.strptime(vv[-3][0:-2], "%Ym%m%dt%H%M")
-            endDateFile = datetime.strptime(vv[-1][0:-5], "%Ym%m%dt%H%M")
+            endDateFile = startDateFile
+            # Check the the start time for the next file to get the end time of current file.
+            if(fi != len(rawFiles)-1):
+                vv = rawFiles[fi+1].split('_')
+                endDateFile = datetime.strptime(vv[-2][0:-7], "%Ym%m%dt%H%M")
             if(startDateWindow <= startDateFile <= endDateWindow or startDateWindow <= endDateFile <= endDateWindow):
                 rawFilesOut.append(f)
         rawFiles = rawFilesOut


### PR DESCRIPTION
## Description

This fixes a problem with not grabbing raw files at the start of the window. 


What problem does it fix? What new capability does it add?
When I wrote the script to grab files within the window, I mistakenly used the last date/time in the filename as the end date/time of the data, when in fact it is just the processing time.  This now just uses the start time of each file to get files within the window.

## Dependencies
None

## Impact
None