### PR TITLE
Changes in L2 trace gas retrievals for column operator generalization

### DIFF
--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -165,7 +165,7 @@ class mopitt(object):
                 # add top vertice in IODA file, here it is 0hPa but can be different
                 # for other obs stream
                 for k in range(nlevs+1):
-                    varname_pr = ('pressure_level_'+str(k), 'RtrvlAncData')
+                    varname_pr = ('pressure_level_'+str(k+1), 'RtrvlAncData')
                     self.outdata[varname_pr] = hPa2Pa * pr_gd[:, k][flg]
 
                 self.outdata[self.varDict[iodavar]['valKey']] = xr_tc[flg]

--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -162,7 +162,10 @@ class mopitt(object):
                 for k in range(nlevs):
                     varname_ak = ('averaging_kernel_level_'+str(k+1), 'RtrvlAncData')
                     self.outdata[varname_ak] = ak_tc_dimless[:, k][flg]
-                    varname_pr = ('pressure_level_'+str(k+1), 'RtrvlAncData')
+                # add top vertice in IODA file, here it is 0hPa but can be different
+                # for other obs stream
+                for k in range(nlevs+1):
+                    varname_pr = ('pressure_level_'+str(k), 'RtrvlAncData')
                     self.outdata[varname_pr] = hPa2Pa * pr_gd[:, k][flg]
 
                 self.outdata[self.varDict[iodavar]['valKey']] = xr_tc[flg]
@@ -182,7 +185,10 @@ class mopitt(object):
                     varname_ak = ('averaging_kernel_level_'+str(k+1), 'RtrvlAncData')
                     self.outdata[varname_ak] = np.concatenate(
                         (self.outdata[varname_ak], ak_tc_dimless[:, k][flg]))
-                    varname_pr = ('pressure_level_'+str(k+1), 'RtrvlAncData')
+                # add top vertice in IODA file, here it is 0hPa but can be different
+                # for other obs stream
+                for k in range(nlevs+1):
+                    varname_pr = ('pressure_level_'+str(k), 'RtrvlAncData')
                     self.outdata[varname_pr] = np.concatenate(
                         (self.outdata[varname_pr], hPa2Pa * pr_gd[:, k][flg]))
 

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -129,7 +129,7 @@ class tropomi(object):
                     self.outdata[varname_pr] = ak[k,0] + bk[k,0]*ps[...].ravel()[flg]
                 # add top vertice in IODA file, here it is 0hPa but can be different
                 # for other obs stream
-                varname_pr = ('pressure_level'+str(nlevs), 'RtrvlAncData')
+                varname_pr = ('pressure_level_'+str(nlevs+1), 'RtrvlAncData')
                 self.outdata[varname_pr] = ak[nlevs-1,1] + bk[nlevs-1,1]*ps[...].ravel()
             else:
                 self.outdata[('datetime', 'MetaData')] = np.concatenate((
@@ -153,7 +153,7 @@ class tropomi(object):
                     varname_pr = ('pressure_level_'+str(k+1), 'RtrvlAncData')
                     self.outdata[varname_pr] = np.concatenate(
                         (self.outdata[varname_pr], ak[k] + bk[k]*ps[...].ravel()[flg]))
-                varname_pr = ('pressure_level_'+str(nles), 'RtrvlAncData')
+                varname_pr = ('pressure_level_'+str(nlevs+1), 'RtrvlAncData')
                 self.outdata[varname_pr] = np.concatenate(
                     (self.outdata[varname_pr], ak[nlevs-1,1] + bk[nlevs-1,1]*ps[...].ravel()[flg]))
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,7 +100,8 @@ list( APPEND test_output
   testoutput/ioda.NC001007.2020031012.nc
   testoutput/viirs_aod.nc
   testoutput/viirs_bias.nc 
-  testoutput/tropomi_no2.nc
+  testoutput/tropomi_no2_total.nc
+  testoutput/tropomi_no2_tropo.nc
   testoutput/mopitt_co.nc
   testoutput/modis_aod.nc
   testoutput/imssnow_scf.nc
@@ -858,7 +859,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_viirs_aod
                           -o testrun/viirs_bias.nc"
                           viirs_bias.nc ${IODA_CONV_COMP_TOL_ZERO})
 
-ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2_total
                   TYPE    SCRIPT
                   ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
                   COMMAND bash
@@ -866,8 +867,21 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/tropomi_no2_nc2ioda.py
                           -i testinput/tropomi_no2.nc
-                          -o testrun/tropomi_no2.nc"
-                          tropomi_no2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          -o testrun/tropomi_no2_total.nc
+                          -c total"
+                          tropomi_no2_total.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2_tropo
+                  TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                  COMMAND bash
+                  ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                          netcdf
+                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/tropomi_no2_nc2ioda.py
+                          -i testinput/tropomi_no2.nc
+                          -o testrun/tropomi_no2_tropo.nc
+                          -c tropo"
+                          tropomi_no2_tropo.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
                   TYPE    SCRIPT

--- a/test/testoutput/tropomi_no2.nc
+++ b/test/testoutput/tropomi_no2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a528ea147d921f7493fd9e266ab4f99aa8cfbc9a342df8d6665ee43da8b02f5
-size 220745

--- a/test/testoutput/tropomi_no2_total.nc
+++ b/test/testoutput/tropomi_no2_total.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f8721c75e1c6e66938da84fc781a808af3e34ea4cf1ede050d4b3ec124634f7
+size 122594

--- a/test/testoutput/tropomi_no2_tropo.nc
+++ b/test/testoutput/tropomi_no2_tropo.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a900ec5af9024c083702e980dea54b9db2e005c683823e8b31ac9f8bf5a17dc6
+size 120513


### PR DESCRIPTION
This is a first step for the column operator generalization.

This generalization aim to compute H(x) for any column product:
total columns
partial columns
with or without averaging kernel and with or without apriori contribution

for this the IODA structure needs to be changed a little to accomodate for this:

- adding upper most vertice in pressure coordinate. This was assumed to be top of the atmosphere (TOA) in UFO. This is not always the case, e.g. partial columns without averaging kernels are passed and needs H(x) from 800hPa to 200hPa.
- moving the AMF tropospheric scaling for the AK in DOAS retrievals to the ioda-converter. A proper AMF scaling in UFO should ideally use the model information and not observation information @christophkeller
- (optional) adding a pre-filtering capability in the ioda converter in the tropomi converter as it was done in the mopitt converter.

A UFO PR will be issued soon to account for those changes.
