### PR TITLE
Enable the C++14 standard for C++ compiles.

### DIFF
--- a/cmake/compiler_flags_Clang_CXX.cmake
+++ b/cmake/compiler_flags_Clang_CXX.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wno-c++11-extensions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -Wall -Wno-c++11-extensions")
 
 ####################################################################
 # RELEASE FLAGS

--- a/cmake/compiler_flags_GNU_CXX.cmake
+++ b/cmake/compiler_flags_GNU_CXX.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -Wall -Wno-deprecated-declarations")
 
 ####################################################################
 # RELEASE FLAGS

--- a/cmake/compiler_flags_Intel_CXX.cmake
+++ b/cmake/compiler_flags_Intel_CXX.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -traceback")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -traceback")
 
 ####################################################################
 # RELEASE FLAGS

--- a/tools/bufr/print_queries.cpp
+++ b/tools/bufr/print_queries.cpp
@@ -34,10 +34,10 @@ std::set<std::string> getSubsets(int fileUnit)
 }
 
 
-std::vector<std::pair<int, std::string> >
+std::vector<std::pair<int, std::string>>
 getDimPaths(const std::vector<Ingester::bufr::QueryData>& queryData)
 {
-    std::map<std::string, std::pair<int, std::string> > dimPathMap;
+    std::map<std::string, std::pair<int, std::string>> dimPathMap;
     for (auto& query : queryData)
     {
         std::stringstream pathStream;
@@ -52,7 +52,7 @@ getDimPaths(const std::vector<Ingester::bufr::QueryData>& queryData)
                                pathStream.str());
     }
 
-    std::vector<std::pair<int, std::string> > result;
+    std::vector<std::pair<int, std::string>> result;
     for (auto& dimPath : dimPathMap)
     {
         result.push_back(dimPath.second);
@@ -120,7 +120,7 @@ std::string dimStyledStr(int dims)
     return ostr.str();
 }
 
-void printDimPaths(std::vector<std::pair<int, std::string> > dimPaths)
+void printDimPaths(std::vector<std::pair<int, std::string>> dimPaths)
 {
     for (auto& dimPath : dimPaths)
     {


### PR DESCRIPTION
## Description

This PR adds in cmake configuration that adds `-std=gnu++14` to all C++ compile commands. This is done to be consistent with the rest of JEDI, and it enables compiles using Apple-Clang to succeed.

Note this PR is focused on getting the CI build to complete successfully for the `feature/query_cxx` branch (PR #1006). When I tested on my Mac, I got a build of ioda-bundle to complete (using NCEPLIBS-bufr version 11.7.0) but there were 182 ctest failures (of which 3 are expected failures on MacOS). We can address these once we get the build to work (which will likely require the new CI test containers).

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

The C++14 standard is used for all C++ compiles.

## Dependencies

None

## Impact

None
