### PR TITLE
tropomi better flags handling

### DIFF
--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -86,7 +86,7 @@ class tropomi(object):
 
             # adding ability to pre filter the data using the qa value
             # and also perform thinning using random uniform draw
-            qaf = qa_value > self.qa_flg 
+            qaf = qa_value > self.qa_flg
             thi = np.random.uniform(size=len(lons)) > self.thin
             flg = np.logical_and(qaf, thi)
             qc_flag = ncd.groups['PRODUCT'].groups['SUPPORT_DATA'].groups['DETAILED_RESULTS']\

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -85,8 +85,10 @@ class tropomi(object):
             qa_value = qa_value.ravel()
 
             # adding ability to pre filter the data using the qa value
-            # documentation recommends using > 0.75
-            flg = (qa_value > self.qa_flg and np.random.uniform(size=len(lons)) > self.thin)
+            # and also perform thinning using random uniform draw
+            qaf = qa_value > self.qa_flg 
+            thi = np.random.uniform(size=len(lons)) > self.thin
+            flg = np.logical_and(qaf, thi)
             qc_flag = ncd.groups['PRODUCT'].groups['SUPPORT_DATA'].groups['DETAILED_RESULTS']\
                 .variables['processing_quality_flags'][:]
             qc_flag = qc_flag.ravel().astype('int32')
@@ -218,7 +220,7 @@ def main():
         help="qa value used to preflag data the goes into file before QC"
         "default at 0.75 as suggested in documentation. See:"
         "https://sentinel.esa.int/documents/247904/2474726/"
-        "Sentinel-5P-Level-2-Product-User-Manual-Nitrogen-Dioxide.pdf section 8.6"
+        "Sentinel-5P-Level-2-Product-User-Manual-Nitrogen-Dioxide.pdf section 8.6",
         type=float, default=0.75)
     optional.add_argument(
         '-n', '--thin',

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -217,7 +217,7 @@ def main():
     optional = parser.add_argument_group(title='optional arguments')
     optional.add_argument(
         '-q', '--qa_value',
-        help="qa value used to preflag data the goes into file before QC"
+        help="qa value used to preflag data that goes into file before QC"
         "default at 0.75 as suggested in documentation. See:"
         "https://sentinel.esa.int/documents/247904/2474726/"
         "Sentinel-5P-Level-2-Product-User-Manual-Nitrogen-Dioxide.pdf section 8.6",

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -86,7 +86,7 @@ class tropomi(object):
 
             # adding ability to pre filter the data using the qa value
             # documentation recommends using > 0.75
-            flg = ( qa_value > self.qa_flg and np.random.uniform(size=len(lons)) > self.thin )
+            flg = (qa_value > self.qa_flg and np.random.uniform(size=len(lons)) > self.thin)
             qc_flag = ncd.groups['PRODUCT'].groups['SUPPORT_DATA'].groups['DETAILED_RESULTS']\
                 .variables['processing_quality_flags'][:]
             qc_flag = qc_flag.ravel().astype('int32')

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -218,7 +218,7 @@ def main():
     optional.add_argument(
         '-q', '--qa_value',
         help="qa value used to preflag data that goes into file before QC"
-        "default at 0.75 as suggested in documentation. See:"
+        "default at 0.75 as suggested in the documentation. See:"
         "https://sentinel.esa.int/documents/247904/2474726/"
         "Sentinel-5P-Level-2-Product-User-Manual-Nitrogen-Dioxide.pdf section 8.6",
         type=float, default=0.75)

--- a/src/compo/tropomi_no2_nc2ioda.py
+++ b/src/compo/tropomi_no2_nc2ioda.py
@@ -40,9 +40,11 @@ DimDict = {
 
 
 class tropomi(object):
-    def __init__(self, filenames, columnType, obsVar):
+    def __init__(self, filenames, columnType, qa_flg, thin, obsVar):
         self.filenames = filenames
         self.columnType = columnType
+        self.qa_flg = qa_flg
+        self.thin = thin
         self.obsVar = obsVar
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
@@ -84,7 +86,7 @@ class tropomi(object):
 
             # adding ability to pre filter the data using the qa value
             # documentation recommends using > 0.75
-            flg = qa_value > 0.75
+            flg = ( qa_value > self.qa_flg and np.random.uniform(size=len(lons)) > self.thin )
             qc_flag = ncd.groups['PRODUCT'].groups['SUPPORT_DATA'].groups['DETAILED_RESULTS']\
                 .variables['processing_quality_flags'][:]
             qc_flag = qc_flag.ravel().astype('int32')
@@ -149,7 +151,7 @@ class tropomi(object):
                         (self.outdata[varname_ak], avg_kernel[..., k].ravel()[flg] * scaleAK[..., k]))
                     varname_pr = ('pressure_level_'+str(k+1), 'RtrvlAncData')
                     self.outdata[varname_pr] = np.concatenate(
-                        (self.outdata[varname_pr], ak[k] + bk[k]*ps[...].ravel()[flg]))
+                        (self.outdata[varname_pr], ak[k, 0] + bk[k, 0]*ps[...].ravel()[flg]))
                 varname_pr = ('pressure_level_'+str(nlevs+1), 'RtrvlAncData')
                 self.outdata[varname_pr] = np.concatenate(
                     (self.outdata[varname_pr], ak[nlevs-1, 1] + bk[nlevs-1, 1]*ps[...].ravel()[flg]))
@@ -210,6 +212,19 @@ def main():
         '-c', '--column',
         help="type of column: total or tropo",
         type=str, required=True)
+    optional = parser.add_argument_group(title='optional arguments')
+    optional.add_argument(
+        '-q', '--qa_value',
+        help="qa value used to preflag data the goes into file before QC"
+        "default at 0.75 as suggested in documentation. See:"
+        "https://sentinel.esa.int/documents/247904/2474726/"
+        "Sentinel-5P-Level-2-Product-User-Manual-Nitrogen-Dioxide.pdf section 8.6"
+        type=float, default=0.75)
+    optional.add_argument(
+        '-n', '--thin',
+        help="percentage of random thinning from 0.0 to 1.0. Zero indicates"
+        " no thinning is performed. (default: %(default)s)",
+        type=float, default=0.0)
 
     args = parser.parse_args()
 
@@ -234,7 +249,7 @@ def main():
         }
 
     # Read in the NO2 data
-    no2 = tropomi(args.input, args.column, obsVar)
+    no2 = tropomi(args.input, args.column, args.qa_value, args.thin, obsVar)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)


### PR DESCRIPTION
Update the tropomi no2 converter to have two new optional arguments to handle the qa_value flaggin and have a thinning capability give the size and the resolution of the dataset.

The new optional arguments are:
`'-q', '--qa_value'` with the documentation link added for the default value in the description as suggested by @srherbener

`'-n', '--thin'` thinning factor with e.g. 0.9 thinning 90% of the data out. Default is 0.0 and takes all obs. 

CI tests results are not affected.

