### PR TITLE
add capability to create MOPITT IODA files for DA window 

### DIFF
--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -243,7 +243,7 @@ def main():
     optional.add_argument(
         '-r', '--date_range',
         help="extract a date range to fit the data assimilation window"
-        "format -r YYYYMMDDHH YYYMMDDHH",
+        "format -r YYYYMMDDHH YYYYMMDDHH",
         type=str, metavar=('begindate', 'enddate'), nargs=2,
         default=('1970010100', '2170010100'))
 

--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -54,8 +54,9 @@ hPa2Pa = 1E2
 
 
 class mopitt(object):
-    def __init__(self, filenames):
+    def __init__(self, filenames, date_range):
         self.filenames = filenames
+        self.date_rage = date_range
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         self.varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -153,6 +154,8 @@ class mopitt(object):
             # set flag: rule out all anomalous data
             flg = qa == 0
 
+            print(self.date_range)
+
             if first:
                 # add metadata variables
                 self.outdata[('datetime', 'MetaData')] = times[flg]
@@ -230,10 +233,18 @@ def main():
         help="path of IODA output file",
         type=str, required=True)
 
+    optional = parser.add_argument_group(title='optional arguments')
+    optional.add_argument(
+        '-r', '--date_range',
+        help="extract a date range to fit the data assimilation windows"
+        "format -r YYYYMMDDHH YYYMMDDHH",
+        type=str, metavar=('begindate', 'enddate'), nargs=2, 
+        default=('1970010100','2170010100'))
+
     args = parser.parse_args()
 
     # Read in the MOPITT CO data
-    co = mopitt(args.input)
+    co = mopitt(args.input,args.date_range)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)

--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -158,7 +158,7 @@ class mopitt(object):
             date_start = datetime.strptime(self.date_range[0], "%Y%m%d%H")
             date_end = datetime.strptime(self.date_range[1], "%Y%m%d%H")
             date_list = [datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ") for date in times]
-            tsf = [(date_i > date_start) & (date_i < date_end) for date_i in date_list]
+            tsf = [(date_i >= date_start) & (date_i < date_end) for date_i in date_list]
 
             flg = np.logical_and(qaf, tsf)
 

--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -54,9 +54,9 @@ hPa2Pa = 1E2
 
 
 class mopitt(object):
-    def __init__(self, filenames, date_range):
+    def __init__(self, filenames, time_range):
         self.filenames = filenames
-        self.date_range = date_range
+        self.time_range = time_range
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         self.varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -155,8 +155,8 @@ class mopitt(object):
             qaf = qa == 0
 
             # date range to fit DA window
-            date_start = datetime.strptime(self.date_range[0], "%Y%m%d%H")
-            date_end = datetime.strptime(self.date_range[1], "%Y%m%d%H")
+            date_start = datetime.strptime(self.time_range[0], "%Y%m%d%H")
+            date_end = datetime.strptime(self.time_range[1], "%Y%m%d%H")
             date_list = [datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ") for date in times]
             tsf = [(date_i >= date_start) & (date_i < date_end) for date_i in date_list]
 
@@ -241,7 +241,7 @@ def main():
 
     optional = parser.add_argument_group(title='optional arguments')
     optional.add_argument(
-        '-r', '--date_range',
+        '-r', '--time_range',
         help="extract a date range to fit the data assimilation window"
         "format -r YYYYMMDDHH YYYYMMDDHH",
         type=str, metavar=('begindate', 'enddate'), nargs=2,
@@ -250,7 +250,7 @@ def main():
     args = parser.parse_args()
 
     # Read in the MOPITT CO data
-    co = mopitt(args.input, args.date_range)
+    co = mopitt(args.input, args.time_range)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)

--- a/src/compo/mopitt_co_nc2ioda.py
+++ b/src/compo/mopitt_co_nc2ioda.py
@@ -242,7 +242,7 @@ def main():
     optional = parser.add_argument_group(title='optional arguments')
     optional.add_argument(
         '-r', '--date_range',
-        help="extract a date range to fit the data assimilation windows"
+        help="extract a date range to fit the data assimilation window"
         "format -r YYYYMMDDHH YYYMMDDHH",
         type=str, metavar=('begindate', 'enddate'), nargs=2,
         default=('1970010100', '2170010100'))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -891,7 +891,8 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/mopitt_co_nc2ioda.py
                           -i testinput/mopitt_co.he5
-                          -o testrun/mopitt_co.nc"
+                          -o testrun/mopitt_co.nc
+                          -r 2021092903 2021092921"
                           mopitt_co.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_aod

--- a/test/testoutput/mopitt_co.nc
+++ b/test/testoutput/mopitt_co.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a6c239fbb5b72df4ba40a0f3fd534e485569b60f5d4e2e84bc239cd90bd230a
-size 210375
+oid sha256:5a5703deff298e440fb7f4349a4d8585335d16b3d9b9e0e141f4927ac3f42ab4
+size 171846


### PR DESCRIPTION
the MOPITT raw files are daily files we need to have additional options to slice the dataset when creating the IODA files for ingest and fit the DA windows (6h).

new option is `'-r', '--date_range'` and is optional. If not specified, the whole dataset in the raw file will be processed.

