### PR TITLE
Added satbias converter for gmi_gpm.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -227,6 +227,7 @@ if (iodaconv_satbias_ENABLED )
   list( APPEND test_input
     testinput/satbias_converter_amsua.yaml
     testinput/satbias_converter_cris.yaml
+    testinput/satbias_converter_gmi_gpm.yaml
     testinput/satbias_converter_ssmis.yaml
     testinput/satbias_crtm_in
     testinput/satbias_crtm_pc
@@ -235,6 +236,7 @@ if (iodaconv_satbias_ENABLED )
   list( APPEND test_output
     testoutput/satbias_amsua_n18.nc4
     testoutput/satbias_cris_npp.nc4
+    testoutput/satbias_gmi_gpm.nc4
     testoutput/satbias_ssmis_f16.nc4
     testoutput/viirs_bias.nc 
   )
@@ -1321,6 +1323,15 @@ if( iodaconv_satbias_ENABLED )
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_cris.yaml"
                             satbias_cris_npp.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS satbias2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_satbias_gmi
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                            "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_gmi_gpm.yaml"
+                            satbias_gmi_gpm.nc4 ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS satbias2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_satbias_ssmis

--- a/test/testinput/satbias_converter.yaml
+++ b/test/testinput/satbias_converter.yaml
@@ -202,7 +202,19 @@ output:
   predictors: *default_preds
 - sensor: gmi_gpm
   output file: satbias_gmi_gpm.nc4
-  predictors: *default_preds
+  predictors:
+  - constant
+  - zenith_angle
+  - cosine_of_latitude_times_orbit_node
+  - lapse_rate_order_2
+  - lapse_rate
+  - cloud_liquid_water_order_2
+  - cloud_liquid_water
+  - emissivity
+  - scan_angle_order_4
+  - scan_angle_order_3
+  - scan_angle_order_2
+  - scan_angle
 - sensor: saphir_meghat
   output file: satbias_saphir_meghat.nc4
   predictors: *default_preds

--- a/test/testinput/satbias_converter_gmi_gpm.yaml
+++ b/test/testinput/satbias_converter_gmi_gpm.yaml
@@ -1,0 +1,18 @@
+input coeff file: testinput/satbias_crtm_in
+input err file: testinput/satbias_crtm_pc
+output:
+- sensor: gmi_gpm
+  predictors:
+  - constant
+  - zenith_angle
+  - cosine_of_latitude_times_orbit_node
+  - lapse_rate_order_2
+  - lapse_rate
+  - cloud_liquid_water_order_2
+  - cloud_liquid_water
+  - emissivity
+  - scan_angle_order_4
+  - scan_angle_order_3
+  - scan_angle_order_2
+  - scan_angle
+  output file: testrun/satbias_gmi_gpm.nc4

--- a/test/testoutput/satbias_gmi_gpm.nc4
+++ b/test/testoutput/satbias_gmi_gpm.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbde42fcf6cb016c12b12a798672888c71a9397b39540bfa503022fa3d11131c
+size 9806


### PR DESCRIPTION
Special treatment to those bias correction predictors of GMI_GPM data. These predictors are different from those for other satellite radiance data in GSI.
  ```
predictors:
  - constant
  - zenith_angle
  - cosine_of_latitude_times_orbit_node
  - lapse_rate_order_2
  - lapse_rate
  - cloud_liquid_water_order_2
  - cloud_liquid_water
  - emissivity
  - scan_angle_order_4
  - scan_angle_order_3
  - scan_angle_order_2
  - scan_angle 
```