### PR TITLE
Feature/query datetime subset fix

### DIFF
--- a/src/bufr/BufrParser/BufrParser.cpp
+++ b/src/bufr/BufrParser/BufrParser.cpp
@@ -48,7 +48,7 @@ namespace Ingester {
     {
         auto startTime = std::chrono::steady_clock::now();
 
-        auto querySet = bufr::QuerySet();
+        auto querySet = bufr::QuerySet(description_.getExport().getSubsets());
 
         for (const auto &var : description_.getExport().getVariables())
         {
@@ -56,12 +56,6 @@ namespace Ingester {
             {
                 querySet.add(queryPair.name, queryPair.query);
             }
-        }
-
-        auto subsets =  description_.getExport().getSubsets();
-        if (!subsets.empty())
-        {
-            querySet.limitSubsets(subsets);
         }
 
         oops::Log::info() << "Executing Queries" << std::endl;

--- a/src/bufr/BufrParser/BufrParser.cpp
+++ b/src/bufr/BufrParser/BufrParser.cpp
@@ -49,12 +49,19 @@ namespace Ingester {
         auto startTime = std::chrono::steady_clock::now();
 
         auto querySet = bufr::QuerySet();
+
         for (const auto &var : description_.getExport().getVariables())
         {
             for (const auto &queryPair : var->getQueryList())
             {
                 querySet.add(queryPair.name, queryPair.query);
             }
+        }
+
+        auto subsets =  description_.getExport().getSubsets();
+        if (!subsets.empty())
+        {
+            querySet.limitSubsets(subsets);
         }
 
         oops::Log::info() << "Executing Queries" << std::endl;

--- a/src/bufr/BufrParser/Exports/Export.cpp
+++ b/src/bufr/BufrParser/Exports/Export.cpp
@@ -28,6 +28,7 @@ namespace
         const char* Splits = "splits";
         const char* Variables = "variables";
         const char* GroupByVariable = "group_by_variable";
+        const char* Subsets = "subsets";
 
         namespace Variable
         {
@@ -73,6 +74,11 @@ namespace Ingester
         if (conf.has(ConfKeys::GroupByVariable))  // Optional
         {
             groupByVariable = conf.getString(ConfKeys::GroupByVariable);
+        }
+
+        if (conf.has(ConfKeys::Subsets))
+        {
+            subsets_ = conf.getStringVector(ConfKeys::Subsets);
         }
 
         if (conf.has(ConfKeys::Variables))

--- a/src/bufr/BufrParser/Exports/Export.h
+++ b/src/bufr/BufrParser/Exports/Export.h
@@ -35,7 +35,7 @@ namespace Ingester
         inline Splits getSplits() const { return splits_; }
         inline Variables getVariables() const { return variables_; }
         inline Filters getFilters() const { return filters_; }
-        inline std::vector<std::string> getSubsets() const { return subsets_; };
+        inline std::vector<std::string> getSubsets() const { return subsets_; }
 
      private:
         Splits splits_;

--- a/src/bufr/BufrParser/Exports/Export.h
+++ b/src/bufr/BufrParser/Exports/Export.h
@@ -35,11 +35,13 @@ namespace Ingester
         inline Splits getSplits() const { return splits_; }
         inline Variables getVariables() const { return variables_; }
         inline Filters getFilters() const { return filters_; }
+        inline std::vector<std::string> getSubsets() const { return subsets_; };
 
      private:
         Splits splits_;
         Variables  variables_;
         Filters filters_;
+        std::vector<std::string> subsets_;
 
         /// \brief Create Variables exports from config.
         void addVariables(const eckit::Configuration &conf,

--- a/src/bufr/BufrParser/Exports/Splits/CategorySplit.cpp
+++ b/src/bufr/BufrParser/Exports/Splits/CategorySplit.cpp
@@ -83,11 +83,10 @@ namespace Ingester
                 auto location = Location(dataObject->getDims().size(), 0);
                 location[0] = rowIdx;
 
-                auto itemVal =  dataObject->getAsFloat(location);
-                if (trunc(itemVal) == itemVal)
+                if (auto dat = std::dynamic_pointer_cast<DataObject<int>> (dataObject))
                 {
-                    nameMap_.insert({static_cast<int> (itemVal),
-                                     std::to_string(static_cast<int> (itemVal))});
+                    auto itemVal = dat->get(location);
+                    nameMap_.insert({itemVal, std::to_string(itemVal)});
                 }
                 else
                 {

--- a/src/bufr/BufrParser/Query/File.cpp
+++ b/src/bufr/BufrParser/Query/File.cpp
@@ -72,7 +72,7 @@ namespace bufr {
         auto dataProvider = DataProvider(fileUnit_);
 
         auto resultSet = ResultSet(querySet.names());
-        auto query = QueryRunner(querySet, resultSet, dataProvider);
+        auto queryRunner = QueryRunner(querySet, resultSet, dataProvider);
 
         while (ireadmg_f(fileUnit_, subsetChars, &iddate, SubsetLen) == 0)
         {
@@ -85,14 +85,14 @@ namespace bufr {
                 {
                     status_f(fileUnit_, &bufrLoc, &il, &im);
                     dataProvider.updateData(bufrLoc);
-                    query.query();
+                    queryRunner.accumulate();
                 }
 
                 if (next > 0 && ++messageNum >= next) break;
             }
         }
 
-        resultSet.setTargets(query.getTargets());
+        resultSet.setTargets(queryRunner.getTargets());
 
         dataProvider.deleteData();
 

--- a/src/bufr/BufrParser/Query/File.cpp
+++ b/src/bufr/BufrParser/Query/File.cpp
@@ -7,9 +7,11 @@
 
 #include "File.h"
 
+#include <algorithm>
+
 #include "bufr_interface.h"
 
-#include "Query.h"
+#include "QueryRunner.h"
 #include "QuerySet.h"
 #include "DataProvider.h"
 
@@ -61,7 +63,7 @@ namespace bufr {
     {
         static int SubsetLen = 9;
         unsigned int messageNum = 0;
-        char subset[SubsetLen];
+        char subsetChars[SubsetLen];
         int iddate;
 
         int bufrLoc;
@@ -70,18 +72,24 @@ namespace bufr {
         auto dataProvider = DataProvider(fileUnit_);
 
         auto resultSet = ResultSet(querySet.names());
-        auto query = Query(querySet, resultSet, dataProvider);
+        auto query = QueryRunner(querySet, resultSet, dataProvider);
 
-        while (ireadmg_f(fileUnit_, subset, &iddate, SubsetLen) == 0)
+        while (ireadmg_f(fileUnit_, subsetChars, &iddate, SubsetLen) == 0)
         {
-            while (ireadsb_f(fileUnit_) == 0)
-            {
-                status_f(fileUnit_, &bufrLoc, &il, &im);
-                dataProvider.updateData(bufrLoc);
-                query.query();
-            }
+            auto subset = std::string(subsetChars);
+            subset.erase(std::remove_if(subset.begin(), subset.end(), isspace), subset.end());
 
-            if (next > 0 && ++messageNum >= next) break;
+            if (querySet.includesSubset(subset))
+            {
+                while (ireadsb_f(fileUnit_) == 0)
+                {
+                    status_f(fileUnit_, &bufrLoc, &il, &im);
+                    dataProvider.updateData(bufrLoc);
+                    query.query();
+                }
+
+                if (next > 0 && ++messageNum >= next) break;
+            }
         }
 
         resultSet.setTargets(query.getTargets());

--- a/src/bufr/BufrParser/Query/QueryParser.h
+++ b/src/bufr/BufrParser/Query/QueryParser.h
@@ -13,24 +13,29 @@
 namespace Ingester {
 namespace bufr {
 
+    struct Query
+    {
+        std::string queryStr;
+        std::string subset;
+        std::vector<std::string> mnemonics;
+        int index;
+    };
+
     /// \brief Parses a user supplied query string into its component parts.
     /// \note Will be refactored to properly tokenize the query string.
     class QueryParser
     {
      public:
+        static std::vector<Query> parse(const std::string& queryStr);
+
+     private:
         /// \brief Split a multi query (ex: ["*/CLONH", "*/CLON"]) into a vector of single queries.
         /// \param query The query to split.
         static std::vector<std::string> splitMultiquery(const std::string& query);
 
         /// \brief Split a single query (ex: "*/ROSEQ1/ROSEQ2/PCCF[2]") into its component parts.
         /// \param query The query to split.
-        /// \param[out] subset The subset part of the query (ex: *).
-        /// \param[out] mnemonics  Query path components (ex: ["ROSEQ1", "ROSEQ2", "PCCF"]).
-        /// \param[out] index The index associated with this query (ex: 2).
-        static void splitQueryStr(const std::string& query,
-                                  std::string& subset,
-                                  std::vector<std::string>& mnemonics,
-                                  int& index);
+        static Query splitQueryStr(const std::string& query);
 
      private:
         /// \brief Private constructor.

--- a/src/bufr/BufrParser/Query/QueryRunner.cpp
+++ b/src/bufr/BufrParser/Query/QueryRunner.cpp
@@ -31,7 +31,7 @@ namespace bufr {
     {
     }
 
-    void QueryRunner::query()
+    void QueryRunner::accumulate()
     {
         Targets targets;
         std::shared_ptr<__details::ProcessingMasks> masks;

--- a/src/bufr/BufrParser/Query/QueryRunner.cpp
+++ b/src/bufr/BufrParser/Query/QueryRunner.cpp
@@ -31,7 +31,8 @@ namespace bufr {
     {
     }
 
-    void QueryRunner::query() {
+    void QueryRunner::query()
+    {
         Targets targets;
         std::shared_ptr<__details::ProcessingMasks> masks;
 
@@ -39,9 +40,12 @@ namespace bufr {
         collectData(targets, masks, resultSet_);
     }
 
-    void QueryRunner::findTargets(Targets &targets, std::shared_ptr<__details::ProcessingMasks> &masks) {
+    void QueryRunner::findTargets(Targets &targets,
+                                  std::shared_ptr<__details::ProcessingMasks> &masks)
+    {
         // Check if the target list for this subset is cached
-        if (targetCache_.find(dataProvider_.getSubset()) != targetCache_.end()) {
+        if (targetCache_.find(dataProvider_.getSubset()) != targetCache_.end())
+        {
             targets = targetCache_.at(dataProvider_.getSubset());
             masks = maskCache_.at(dataProvider_.getSubset());
             return;

--- a/src/bufr/BufrParser/Query/QueryRunner.h
+++ b/src/bufr/BufrParser/Query/QueryRunner.h
@@ -51,14 +51,14 @@ namespace bufr {
     }  // namespace __details
 
     /// \brief Manages the execution of queries against on a BUFR file.
-    class Query
+    class QueryRunner
     {
      public:
         /// \brief Constructor.
         /// \param[in] querySet The set of queries to execute against the BUFR file.
         /// \param[in, out] resultSet The object used to store the accumulated collected data.
         /// \param[in] dataProvider The BUFR data provider to use.
-        Query(const QuerySet& querySet, ResultSet& resultSet, const DataProvider& dataProvider);
+        QueryRunner(const QuerySet& querySet, ResultSet& resultSet, const DataProvider& dataProvider);
         void query();
 
         Targets getTargets()
@@ -96,8 +96,8 @@ namespace bufr {
         /// \brief Find the target associated with a specific user provided query string.
         /// \param[in] targetName The name specified for the target.
         /// \param[in] query The query string to use.
-        std::shared_ptr<Target> findTarget(const std::string& targetName,
-                                           const std::string& query) const;
+        std::shared_ptr<Target> findTarget(const std::string &targetName,
+                                           const Query& query) const;
 
 
         /// \brief Does the node idx correspond to an element you'd find in a query string (repeat

--- a/src/bufr/BufrParser/Query/QueryRunner.h
+++ b/src/bufr/BufrParser/Query/QueryRunner.h
@@ -58,7 +58,9 @@ namespace bufr {
         /// \param[in] querySet The set of queries to execute against the BUFR file.
         /// \param[in, out] resultSet The object used to store the accumulated collected data.
         /// \param[in] dataProvider The BUFR data provider to use.
-        QueryRunner(const QuerySet& querySet, ResultSet& resultSet, const DataProvider& dataProvider);
+        QueryRunner(const QuerySet& querySet,
+                    ResultSet& resultSet,
+                    const DataProvider& dataProvider);
         void query();
 
         Targets getTargets()

--- a/src/bufr/BufrParser/Query/QueryRunner.h
+++ b/src/bufr/BufrParser/Query/QueryRunner.h
@@ -61,7 +61,7 @@ namespace bufr {
         QueryRunner(const QuerySet& querySet,
                     ResultSet& resultSet,
                     const DataProvider& dataProvider);
-        void query();
+        void accumulate();
 
         Targets getTargets()
         {

--- a/src/bufr/BufrParser/Query/QuerySet.cpp
+++ b/src/bufr/BufrParser/Query/QuerySet.cpp
@@ -7,6 +7,8 @@
 
 #include "QuerySet.h"
 
+#include <algorithm>
+#include <iostream>
 
 namespace Ingester {
 namespace bufr {
@@ -37,6 +39,36 @@ namespace bufr {
         }
 
         return includesSubset;
+    }
+
+    void QuerySet::limitSubsets(std::vector<std::string> subsets)
+    {
+        auto subsetsSet = std::set<std::string>(subsets.begin(), subsets.end());
+        if (includesAllSubsets_)
+        {
+            includedSubsets_ = subsetsSet;
+
+        }
+        else
+        {
+            for(auto& s : includedSubsets_) std::cout << s << " ";
+            std::cout << std::endl;
+
+            std::vector<std::string> newSubsets;
+            std::set_intersection(subsetsSet.begin(),
+                                  subsetsSet.end(),
+                                  includedSubsets_.begin(),
+                                  includedSubsets_.end(),
+                                  std::back_inserter(newSubsets));
+
+            includedSubsets_ = std::set<std::string>(newSubsets.begin(),
+                                                     newSubsets.end());
+
+            for(auto& s : includedSubsets_) std::cout << s << " ";
+            std::cout << std::endl;
+        }
+
+        includesAllSubsets_ = false;
     }
 
     std::vector<std::string> QuerySet::names() const

--- a/src/bufr/BufrParser/Query/QuerySet.cpp
+++ b/src/bufr/BufrParser/Query/QuerySet.cpp
@@ -24,7 +24,7 @@ namespace bufr {
     void QuerySet::add(const std::string& name, const std::string& queryStr)
     {
         std::vector<Query> queries;
-        for (const auto &query: QueryParser::parse(queryStr))
+        for (const auto &query : QueryParser::parse(queryStr))
         {
             if (limitSubsets_.empty())
             {

--- a/src/bufr/BufrParser/Query/QuerySet.cpp
+++ b/src/bufr/BufrParser/Query/QuerySet.cpp
@@ -11,10 +11,38 @@
 namespace Ingester {
 namespace bufr {
 
+    void QuerySet::add(const std::string& name, const std::string& queryStr)
+    {
+        std::vector<Query> queries;
+        for (const auto& query : QueryParser::parse(queryStr))
+        {
+            if (query.subset == "*")
+            {
+                includesAllSubsets_ = true;
+            }
+
+            includedSubsets_.emplace(query.subset);
+            queries.emplace_back(query);
+        }
+
+        queryMap_[name] = queries;
+    }
+
+    bool QuerySet::includesSubset(const std::string& subset) const
+    {
+        bool includesSubset = true;
+        if (!includesAllSubsets_)
+        {
+            includesSubset = (includedSubsets_.find(subset) != includedSubsets_.end());
+        }
+
+        return includesSubset;
+    }
+
     std::vector<std::string> QuerySet::names() const
     {
         std::vector<std::string> names;
-        for (auto const& query : queryList_)
+        for (auto const& query : queryMap_)
         {
             names.push_back(query.first);
         }

--- a/src/bufr/BufrParser/Query/QuerySet.h
+++ b/src/bufr/BufrParser/Query/QuerySet.h
@@ -7,8 +7,12 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
+#include <set>
 #include <string>
+
+#include "QueryParser.h"
 
 namespace Ingester {
 namespace bufr
@@ -23,30 +27,25 @@ namespace bufr
         /// \brief Add a new query to the collection.
         /// \param[in] name The name of the query.
         /// \param[in] query The query string.
-        void add(const std::string& name, const std::string& query)
-        {
-            queryList_.push_back({name, query});
-        }
+        void add(const std::string& name, const std::string& query);
 
         /// \brief Returns the size of the collection.
-        size_t size() const { return queryList_.size(); }
-
-        /// \brief Returns the name of the query at the specified index.
-        /// \param[in] idx The index of the query..
-        /// \return The name of the query.
-        std::string nameAt(size_t idx) const { return queryList_.at(idx).first; }
-
-        /// \brief Returns the query string at the specified index.
-        /// \param[in] idx The index of the query.
-        /// \return The query string.
-        std::string queryAt(size_t idx) const { return queryList_.at(idx).second; }
+        size_t size() const { return queryMap_.size(); }
 
         /// \brief Returns the names of all the queries.
         /// \return A vector of the names of all the queries.
         std::vector<std::string> names() const;
 
+        /// \brief Returns a list of subsets.
+        /// \return A vector of the names of all the queries.
+        bool includesSubset(const std::string& subset) const;
+
+        std::vector<Query> queriesFor(const std::string& name) const { return queryMap_.at(name); }
+
      private:
-        std::vector<std::pair<std::string, std::string>> queryList_;
+        std::unordered_map<std::string, std::vector<Query>> queryMap_;
+        bool includesAllSubsets_;
+        std::set<std::string> includedSubsets_;
     };
 }  // namespace bufr
 }  // namespace Ingester

--- a/src/bufr/BufrParser/Query/QuerySet.h
+++ b/src/bufr/BufrParser/Query/QuerySet.h
@@ -40,6 +40,10 @@ namespace bufr
         /// \return A vector of the names of all the queries.
         bool includesSubset(const std::string& subset) const;
 
+        /// \brief Limit the subsets to the ones presented.
+        /// \param[in] subsets A vector of subsets.
+        void limitSubsets(std::vector<std::string> subsets);
+
         std::vector<Query> queriesFor(const std::string& name) const { return queryMap_.at(name); }
 
      private:

--- a/src/bufr/BufrParser/Query/QuerySet.h
+++ b/src/bufr/BufrParser/Query/QuerySet.h
@@ -17,11 +17,13 @@
 namespace Ingester {
 namespace bufr
 {
+    typedef std::set<std::string> Subsets;
+
     /// \brief Manages a collection of queries.
     class QuerySet
     {
      public:
-        QuerySet() = default;
+        explicit QuerySet(const std::vector<std::string>& subsets);
         ~QuerySet() = default;
 
         /// \brief Add a new query to the collection.
@@ -40,16 +42,13 @@ namespace bufr
         /// \return A vector of the names of all the queries.
         bool includesSubset(const std::string& subset) const;
 
-        /// \brief Limit the subsets to the ones presented.
-        /// \param[in] subsets A vector of subsets.
-        void limitSubsets(std::vector<std::string> subsets);
-
         std::vector<Query> queriesFor(const std::string& name) const { return queryMap_.at(name); }
 
      private:
         std::unordered_map<std::string, std::vector<Query>> queryMap_;
         bool includesAllSubsets_;
-        std::set<std::string> includedSubsets_;
+        Subsets limitSubsets_;
+        Subsets presentSubsets_;
     };
 }  // namespace bufr
 }  // namespace Ingester

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -43,8 +43,8 @@ list(APPEND _ingester_srcs
   BufrParser/Query/VectorMath.h
   BufrParser/Query/QuerySet.h
   BufrParser/Query/QuerySet.cpp
-  BufrParser/Query/Query.h
-  BufrParser/Query/Query.cpp
+        BufrParser/Query/QueryRunner.h
+        BufrParser/Query/QueryRunner.cpp
   BufrParser/Query/QueryParser.h
   BufrParser/Query/QueryParser.cpp
   BufrParser/Query/ResultSet.h

--- a/src/bufr/DataObject.h
+++ b/src/bufr/DataObject.h
@@ -110,9 +110,9 @@ namespace Ingester
         /// \return Float data.
         virtual float getAsFloat(const Location& loc) const = 0;
 
-        /// \brief Get the data at the index as an float.
+        /// \brief Get the data at the index as an int.
         /// \return Float data.
-        virtual float getAsFloat(size_t idx) const = 0;
+        virtual int getAsInt(size_t idx) const = 0;
 
         /// \brief Get the data at the Location as an string.
         /// \return String data.
@@ -177,7 +177,7 @@ namespace Ingester
     {
      public:
         typedef T value_type;
-        constexpr T missingValue() const { return std::numeric_limits<T>::max(); }
+        static constexpr T missingValue() { return std::numeric_limits<T>::max(); }
 
         /// \brief Constructor.
         /// \param dimensions The dimensions of the data object.
@@ -315,7 +315,7 @@ namespace Ingester
         /// \brief Get the data at the location as an integer.
         /// \param loc The coordinate for the data point (ex: if data 2d then loc {2,4} gets data
         ///            at that coordinate).
-        /// \return Integer data.
+        /// \return Int data.
         int getAsInt(const Location& loc) const final { return _getAsInt(loc); }
 
         /// \brief Get the data at the location as a float.
@@ -330,12 +330,12 @@ namespace Ingester
         /// \return String data.
         std::string getAsString(const Location& loc) const final { return _getAsString(loc); }
 
-        /// \brief Get the data at the index into the internal 1d array as a float. This function
+        /// \brief Get the data at the index into the internal 1d array as a int. This function
         ///        gives you direct access to the internal data and doesn't account for dimensional
-        ///        information (its up to the user). Note: getAsFloat(const Location&) is safer.
+        ///        information (its up to the user). Note: getAsInt(const Location&) is safer.
         /// \param idx The idx into the internal 1d array.
-        /// \return Float data.
-        float getAsFloat(size_t idx) const final { return _getAsFloat(idx); }
+        /// \return Int data.
+        int getAsInt(size_t idx) const final { return _getAsInt(idx); }
 
         /// \brief Slice the dta object according to a list of indices.
         /// \param rows The indices to slice the data object by.
@@ -477,23 +477,22 @@ namespace Ingester
             return get(loc);
         }
 
-        /// \brief Get the data at the index as a float for numeric data.
-        /// \return Float data.
+        /// \brief Get the data at the index as a int for numeric data.
+        /// \return Int data.
         template<typename U = void>
-        float _getAsFloat(size_t idx,
+        int _getAsInt(size_t idx,
             typename std::enable_if<std::is_arithmetic<T>::value, U>::type* = nullptr) const
         {
-            return static_cast<float>(data_[idx]);
+            return static_cast<int>(data_[idx]);
         }
 
-        /// \brief Get the data at the index as a float for non-numeric data.
-        /// \return Float data.
+        /// \brief Get the data at the index as a int for non-numeric data.
+        /// \return Int data.
         template<typename U = void>
-        float _getAsFloat(size_t idx,
+        int _getAsInt(size_t idx,
             typename std::enable_if<!std::is_arithmetic<T>::value, U>::type* = nullptr) const
         {
             throw std::runtime_error("The stored value was is not a number");
-            return 0.0f;
         }
 
         /// \brief Set the data associated with this data object (numeric DataObject).

--- a/src/bufr/DataObject.h
+++ b/src/bufr/DataObject.h
@@ -111,8 +111,12 @@ namespace Ingester
         virtual float getAsFloat(const Location& loc) const = 0;
 
         /// \brief Get the data at the index as an int.
-        /// \return Float data.
+        /// \return Int data.
         virtual int getAsInt(size_t idx) const = 0;
+
+        /// \brief Get the data at the index as an float.
+        /// \return Float data.
+        virtual float getAsFloat(size_t idx) const = 0;
 
         /// \brief Get the data at the Location as an string.
         /// \return String data.
@@ -330,12 +334,22 @@ namespace Ingester
         /// \return String data.
         std::string getAsString(const Location& loc) const final { return _getAsString(loc); }
 
+
         /// \brief Get the data at the index into the internal 1d array as a int. This function
         ///        gives you direct access to the internal data and doesn't account for dimensional
         ///        information (its up to the user). Note: getAsInt(const Location&) is safer.
         /// \param idx The idx into the internal 1d array.
         /// \return Int data.
         int getAsInt(size_t idx) const final { return _getAsInt(idx); }
+
+
+        /// \brief idx Get the data at the index into the internal 1d array as a float. This
+        ///            function gives you direct access to the internal data and doesn't account for
+        ///            dimensional information (its up to the user). Note: getAsInt(const Location&)
+        ///            is safer.
+        /// \param idx The idx into the internal 1d array.
+        /// \return Float data.
+        float getAsFloat(const size_t idx) const final { return _getAsFloat(idx); }
 
         /// \brief Slice the dta object according to a list of indices.
         /// \param rows The indices to slice the data object by.
@@ -493,6 +507,25 @@ namespace Ingester
             typename std::enable_if<!std::is_arithmetic<T>::value, U>::type* = nullptr) const
         {
             throw std::runtime_error("The stored value is not a number");
+        }
+
+        /// \brief Get the data at the index as a float for numeric data.
+        /// \return Float data.
+        template<typename U = void>
+        float _getAsFloat(size_t idx,
+            typename std::enable_if<std::is_arithmetic<T>::value, U>::type* = nullptr) const
+        {
+            return static_cast<float>(data_[idx]);
+        }
+
+        /// \brief Get the data at the index as a float for non-numeric data.
+        /// \return Float data.
+        template<typename U = void>
+        float _getAsFloat(size_t idx,
+            typename std::enable_if<!std::is_arithmetic<T>::value, U>::type* = nullptr) const
+        {
+            throw std::runtime_error("The stored value was is not a number");
+            return 0.0f;
         }
 
         /// \brief Set the data associated with this data object (numeric DataObject).

--- a/src/bufr/DataObject.h
+++ b/src/bufr/DataObject.h
@@ -492,7 +492,7 @@ namespace Ingester
         int _getAsInt(size_t idx,
             typename std::enable_if<!std::is_arithmetic<T>::value, U>::type* = nullptr) const
         {
-            throw std::runtime_error("The stored value was is not a number");
+            throw std::runtime_error("The stored value is not a number");
         }
 
         /// \brief Set the data associated with this data object (numeric DataObject).

--- a/src/bufr/README.md
+++ b/src/bufr/README.md
@@ -55,6 +55,10 @@ Defines how to read data from the input BUFR file. Its sections are as follows:
 ```yaml
       exports:
         group_by_variable: longitude  # Optional
+        subsets:
+          - NC004001
+          - NC004002
+          - NC004003
         variables:
           timestamp:
             datetime:
@@ -99,7 +103,8 @@ ioda encoder. It has the following sections:
 
 * `group_by_variable` _(optional)_ String value that defines the name of the variable to group 
    observations by. If this field is missing then observations will not be grouped.
-
+* `subsets` _(optional)_ List of subsets that you want to process. If the field is not present then
+   all subsets will be processed in accordance with the query definitions.
 * `variables`
   * **keys** are arbitrary strings (anything you want). They can be referenced in the ioda section.
   * **values** (One of these types):

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -216,6 +216,9 @@ if( iodaconv_bufr_ENABLED )
     testinput/satwind_Insat_wmo.bufr
     testinput/vadwinds_wmoBUFR2ioda.yaml
     testinput/vadwinds_wmo_multi.bufr
+    testinput/gdas.t12z.aircft.tm00.bufr_d
+    testinput/bufr_specific_subsets_by_query.yaml
+    testinput/bufr_specifying_subsets.yaml
   )
 
   list( APPEND test_output
@@ -259,6 +262,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/satwind_Himawari.nc
     testoutput/satwind_Insat.nc
     testoutput/vadwinds_wmo_multi.nc
+    testoutput/bufr_specifying_subsets.nc
   )
 endif()
 
@@ -1214,6 +1218,24 @@ if(iodaconv_bufr_ENABLED)
                             netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_sevcsr.yaml"
                     gdas.t00z.sevcsr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_specific_subsets_by_query
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_specific_subsets_by_query.yaml"
+                    bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_specifying_subsets
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                    netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_specifying_subsets.yaml"
+                    bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
 #  FIXME: Greg Thompson

--- a/test/testinput/bufr_specific_subsets_by_query.yaml
+++ b/test/testinput/bufr_specific_subsets_by_query.yaml
@@ -1,0 +1,48 @@
+# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# # #
+# # # This software is licensed under the terms of the Apache Licence Version 2.0
+# # # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/gdas.t12z.aircft.tm00.bufr_d"
+
+      exports:
+        #MetaData
+        variables:
+          timestamp:
+            datetime:
+              year: "[NC004001/YEAR, NC004002/YEAR, NC004003/YEAR, NC004006/YEAR, NC004009/YEAR, NC004010/YEAR, NC004011/YEAR]"
+              month: "[NC004001/MNTH, NC004002/MNTH, NC004003/MNTH, NC004006/MNTH, NC004009/MNTH, NC004010/MNTH, NC004011/MNTH]"
+              day: "[NC004001/DAYS, NC004002/DAYS, NC004003/DAYS, NC004006/DAYS, NC004009/DAYS, NC004010/DAYS, NC004011/DAYS]"
+              hour: "[NC004001/HOUR, NC004002/HOUR, NC004003/HOUR, NC004006/HOUR, NC004009/HOUR, NC004010/HOUR, NC004011/HOUR]"
+              minute: "[NC004001/MINU, NC004002/MINU, NC004003/MINU, NC004006/MINU, NC004009/MINU, NC004010/MINU, NC004011/MINU]"
+          latitude:
+            query: "[NC004001/CLAT, NC004002/CLAT, NC004003/CLAT, NC004006/CLATH, NC004009/CLATH, NC004010/CLATH, NC004011/CLATH]"
+          longitude:
+            query: "[NC004001/CLON, NC004002/CLON, NC004003/CLON, NC004006/CLONH, NC004009/CLONH, NC004010/CLONH, NC004011/CLONH]"
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/bufr_specific_subsets_by_query.nc"
+
+      #MetaData
+      variables:
+        - name: "MetaData/dateTime"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]

--- a/test/testinput/bufr_specific_subsets_by_query.yaml
+++ b/test/testinput/bufr_specific_subsets_by_query.yaml
@@ -26,7 +26,7 @@ observations:
 
     ioda:
       backend: netcdf
-      obsdataout: "./testrun/bufr_specific_subsets_by_query.nc"
+      obsdataout: "./testrun/bufr_specifying_subsets.nc"
 
       #MetaData
       variables:

--- a/test/testinput/bufr_specifying_subsets.yaml
+++ b/test/testinput/bufr_specifying_subsets.yaml
@@ -1,0 +1,57 @@
+# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# # #
+# # # This software is licensed under the terms of the Apache Licence Version 2.0
+# # # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/gdas.t12z.aircft.tm00.bufr_d"
+
+      exports:
+        subsets:
+          - NC004001
+          - NC004002
+          - NC004003
+          - NC004006
+          - NC004009
+          - NC004010
+          - NC004011
+
+        #MetaData
+        variables:
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+          latitude:
+            query: "[*/CLATH, */CLAT]"
+          longitude:
+            query: "[*/CLONH, */CLON]"
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/bufr_specifying_subsets.nc"
+
+      #MetaData
+      variables:
+        - name: "MetaData/dateTime"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]

--- a/test/testinput/gdas.t12z.aircft.tm00.bufr_d
+++ b/test/testinput/gdas.t12z.aircft.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41b1ee8552c02f8015a32fe3eea1708fa3fd39c8bf02bd5cd4a7a42d50c2adf9
+size 123088

--- a/test/testoutput/bufr_specifying_subsets.nc
+++ b/test/testoutput/bufr_specifying_subsets.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f3b86786b014bf39de2abaa815688ee982a32aadebe50149ea016acadf5646f
+size 24062


### PR DESCRIPTION
## Description

This pull request does several things:

- Filters the data down to only the data for the subsets that are included in the queries as in the example in the following file: test/testinput/bufr_specific_subsets_by_query.yaml.
- Adds a new section in exports called subsets. (see the following: test/testinput/bufr_specifying_subsets.yaml)
- Fixed some issues in the DatetimeVaraibles with regard to the interpretation of missing values.
- Includes some refactoring. The QuerySet now uses the QueryParser and queries are parsed into Query objects. The queryset can now tell you if a subset is one that needs to be processed or not.

### Issue(s) addressed

- https://github.com/JCSDA-internal/ioda-converters/issues/1047

## Acceptance Criteria (Definition of Done)

- YAML file supports new exports field called subsets which can be used to limit the subsets that will be processed.
-  Only subsets that are specified in queries will be processed (* means everything).
- Fixes bugs with DatetimeVariable object.

## Dependencies

- https://github.com/JCSDA-internal/ioda-converters/pull/1055

