### PR TITLE
 change from two composition related ctest to nonzero tolerances

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -927,7 +927,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2_tropo
                           -i testinput/tropomi_no2.nc
                           -o testrun/tropomi_no2_tropo.nc
                           -c tropo"
-                          tropomi_no2_tropo.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          tropomi_no2_tropo.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
                   TYPE    SCRIPT
@@ -963,7 +963,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_aeronet_aod
 		          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/aeronet_aod2ioda.py
                           -i testinput/aeronet_aod.dat
                           -o testrun/aeronet_aod.nc"
-                          aeronet_aod.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          aeronet_aod.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_aeronet_aaod
                   TYPE    SCRIPT


### PR DESCRIPTION
## Description

currently the intel compiler is having issue with non-zero tolerances for a couple of composition related ctest

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #1063 

## Acceptance Criteria (Definition of Done)

These two ctests, and all the others as well, pass:
test_iodaconv_tropomi_no2_tropo
test_iodaconv_aeronet_aod