### PR TITLE
fix to using zero tolerances

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -337,7 +337,7 @@ endforeach(FILENAME)
 # iodaconv_comp.sh test.
 #
 # For a converter that is generating new data, use a non-zero tolerance.
-set(IODA_CONV_COMP_TOL_ZERO "0.0")
+set(IODA_CONV_COMP_TOL_ZERO "1.e-7")
 set(IODA_CONV_COMP_TOL "0.5e-4")
 
 # The ioda-engines CMake configuration has set the file target _ioda_python to


### PR DESCRIPTION
## Description

Some of the ctests are failing due to the tolerances being set to zero. This PR will hopefully fix this by assigning a small but non-zero tolerance from these tests.

### Issue(s) addressed
-fixes #1063  

## Acceptance Criteria (Definition of Done)

  ctests that should fail will hopefully fail but those with small errors due to compiler differences will pass.

## Dependencies

None
