### PR TITLE
remove unused netCDF4 import

### DIFF
--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -10,7 +10,6 @@
 from __future__ import print_function
 import sys
 import argparse
-import netCDF4 as nc
 from datetime import datetime, timedelta
 import dateutil.parser
 from concurrent.futures import ProcessPoolExecutor
@@ -268,7 +267,6 @@ def get_obs_data(bufr, profile_meta_data, add_qc, record_number=None):
 
 
 def quality_control(profile_meta_data, heights, lats, lons):
-    print('Performing QC Checks')
 
     good = (heights > 0.) & (heights < 100000.) & (abs(lats) < 90.) & (abs(lons) < 360.)
 


### PR DESCRIPTION
## Description

converter does not use netCDF4 and dependency should be removed

### Issue(s) addressed

- fixes #1107 

## Acceptance Criteria (Definition of Done)

converter behaves as before
