### PR TITLE
Use timegm instead of mktime.

### DIFF
--- a/src/bufr/BufrParser/Exports/Variables/TimeoffsetVariable.cpp
+++ b/src/bufr/BufrParser/Exports/Variables/TimeoffsetVariable.cpp
@@ -48,7 +48,6 @@ namespace Ingester
     {
         checkKeys(map);
 
-        setenv("TZ", "UTC", 1);      // Force UTC time zone
         std::tm tm{};                // zero initialise
         tm.tm_year = 1970 - 1900;    // 1970
         tm.tm_mon = 0;               // Jan=0, Feb=1, ...
@@ -57,7 +56,7 @@ namespace Ingester
         tm.tm_min = 0;
         tm.tm_sec = 0;
         tm.tm_isdst = 0;             // Not daylight saving
-        std::time_t epochDt = std::mktime(&tm);
+        std::time_t epochDt = timegm(&tm);
 
         // Convert the reference time (ISO8601 string) to time struct
         std::tm ref_time = {};
@@ -89,7 +88,7 @@ namespace Ingester
             {
                 auto obs_tm = ref_time;
                 obs_tm.tm_sec = ref_time.tm_sec + timeOffsets->getAsInt(idx);
-                auto thisTime = std::mktime(&obs_tm);
+                auto thisTime = timegm(&obs_tm);
                 diff_time = static_cast<int64_t>(difftime(thisTime, epochDt));
             }
 


### PR DESCRIPTION
## Description

This PR replaces calls to mktime (which assumes local time) with timegm (which assumes UTC). This alleviates the need to force the TZ environment variable to UTC to get the time_t value that is relative to UTC (instead of local time).

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

iodaconv ctests pass

## Dependencies

None

## Impact

None
