### PR TITLE
enable multiple files at input for csv metar decoder

### DIFF
--- a/src/conventional/def_jedi_utils.py
+++ b/src/conventional/def_jedi_utils.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# (C) Copyright 2019-2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+
+import numpy as np
+
+def concat_obs_dict(obs_data, append_obs_data):
+    # For now we are assuming that the obs_data dictionary has the "golden" list
+    # of variables. If one is missing from append_obs_data, the obs_data variable
+    # will be extended using fill values.
+    #
+    # Use the first key in the append_obs_data dictionary to determine how
+    # long to make the fill value vector.
+    append_keys = list(append_obs_data.keys())
+    append_length = len(append_obs_data[append_keys[0]])
+    for gv_key in obs_data.keys():
+        if gv_key in append_keys:
+            obs_data[gv_key] = np.append(obs_data[gv_key], append_obs_data[gv_key])
+        else:
+            if obs_data[gv_key].dtype == float:
+                fill_data = np.repeat(float_missing_value, append_length, dtype=ioda_float_type)
+            elif obs_data[gv_key].dtype == int:
+                fill_data = np.repeat(int_missing_value, append_length, dtype=ioda_int_type)
+            elif obs_data[gv_key].dtype == object:
+                # string type, extend with empty strings
+                fill_data = np.repeat("", append_length, dtype=object)
+            obs_data[gv_key] = np.append(obs_data[gv_key], fill_data)
+
+


### PR DESCRIPTION
## Description

enable the comma separated value file of surface metar reports to have multiple files provided as input

### Issue(s) addressed

- fixes #1115 

## Acceptance Criteria (Definition of Done)

convert can read multiple files and output single IODA file
