### PR TITLE
Bugfix:  PreQC variables should have ints not floats

### DIFF
--- a/src/goes/goes_converter.py
+++ b/src/goes/goes_converter.py
@@ -382,7 +382,7 @@ class GoesConverter:
         data_array = temp_dict[0]
         for i in range(1, counter):
             data_array = np.column_stack((data_array, temp_dict[i]))
-        output_dataset.createVariable('/PreQC/reflectance_factor', 'f4', ('nlocs', 'nchans'), fill_value=-999)
+        output_dataset.createVariable('/PreQC/reflectance_factor', 'i4', ('nlocs', 'nchans'), fill_value=-999)
         output_dataset['/PreQC/reflectance_factor'][:] = data_array
         output_dataset['/PreQC/reflectance_factor'].setncattr('flag_values', '0,1,2,3')
         output_dataset['/PreQC/reflectance_factor'].setncattr('flag_meanings',
@@ -403,7 +403,7 @@ class GoesConverter:
         data_array = temp_dict[0]
         for i in range(1, counter):
             data_array = np.column_stack((data_array, temp_dict[i]))
-        output_dataset.createVariable('/PreQC/brightness_temperature', 'f4', ('nlocs', 'nchans'),
+        output_dataset.createVariable('/PreQC/brightness_temperature', 'i4', ('nlocs', 'nchans'),
                                       fill_value=-999)
         output_dataset['/PreQC/brightness_temperature'][:] = data_array
         output_dataset['/PreQC/brightness_temperature'].setncattr('flag_values', '0,1,2,3')


### PR DESCRIPTION
## Description

While creating the Skylab v3.0 files from GOES data, we noticed that PreQC variables are being assigned to floats not ints so this PR fixes the bug.  (Same change was also made into the sprint-ioda-converters feature branch that is pending merge)

### Issue(s) addressed

Quick bug fix, one was not created.

## Acceptance Criteria (Definition of Done)

Turns the float into int.  There was no ctest for this code so it was not exercised.

## Dependencies

None

## Impact

None