### PR TITLE
Added proper PYTHONPATH setting to the airnow ctest.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1081,6 +1081,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_aeronet_aaod
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow
                   TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
                   COMMAND bash
                   ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                           netcdf


### PR DESCRIPTION
## Description

Fix for issue with airnow test where the python ioda_obs_space package is not found. The fix is to add a PYTHONPATH setting to the test setup.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

airnow test passes

## Dependencies

None

## Impact

None