### PR TITLE
Radiosonde legacy/text (TAC) bugfix for knots vs m/s based on day-of-month coding per WMO manual on codes

### DIFF
--- a/src/conventional/sonde_tac2ioda.py
+++ b/src/conventional/sonde_tac2ioda.py
@@ -727,6 +727,7 @@ def getDayHour(str):
     Parse day of month and hour from the given string
     :param str: The string to parse
     :return: (day, hour)
+    When the day is coded as day+50, windspeed is in knots, otherwise m/s.
     """
     global scale_wspd
     try:

--- a/src/conventional/sonde_tac2ioda.py
+++ b/src/conventional/sonde_tac2ioda.py
@@ -60,6 +60,10 @@ LEVEL_CODES = {
 # List of sounding data sections
 TYPES = ['TTAA', 'TTBB', 'PPBB', 'TTCC', 'TTDD', 'PPDD']
 
+# Wind speed in radiosondes could be either knots or meters per second, which
+# is determined within code if the day of month is actually day of month + 50.
+scale_wspd = 0.51444   # convert from knots to meters per second
+
 STATIONS = {}
 
 # The outgoing IODA MetaData variables, their data type, and units.
@@ -724,10 +728,12 @@ def getDayHour(str):
     :param str: The string to parse
     :return: (day, hour)
     """
+    global scale_wspd
     try:
         day = int(str[:2]) - 50
         if day < 0:
             day += 50
+            scale_wspd = 1.0
         hour = int(str[2:4])
         return (day, hour)
     except Exception:
@@ -753,7 +759,7 @@ def getWind(str):
             wdir -= 1
             wspd += 100
 
-        # wspd *= 0.51444, convert to m/s
+        wspd *= scale_wspd    # convert to m/s if needed.
 
         # calculate u and v
         md = 270 - wdir

--- a/test/testoutput/2021081612_sonde_small.nc
+++ b/test/testoutput/2021081612_sonde_small.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aad87402f4ed36ddf41aacb9348369995a6a61c5c61414570a3be5c7f83f4fd
+oid sha256:3308508e3f101fb745bedfd1e70f48d069bf67f8f98bb3aae070588886781540
 size 54512

--- a/test/testoutput/2021081612_sonde_small.nc
+++ b/test/testoutput/2021081612_sonde_small.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3afff9e03d286457e5b3dce869a235277e70d014fb1e385c6486ba7328daeaa6
-size 54622
+oid sha256:8aad87402f4ed36ddf41aacb9348369995a6a61c5c61414570a3be5c7f83f4fd
+size 54512


### PR DESCRIPTION
## Description

A bug existed for converting legacy/text (TAC) radiosonde reports with respect to how winds are sometimes in knots versus meters per second.  WMO manual on codes (chain of pages 85, 203, 211, 254) says that day of month is incremented by 50 when winds are reported in knots versus m/s.  So a new global variable `scale_wspd` was added to signify a units conversion is needed.

### Issue(s) addressed

A separate one was not created.

## Acceptance Criteria (Definition of Done)

Working ctests and approval.  I checked many sites in USA vs. Europe to see that BUFR sondes and text sondes give the same results for wind speeds.

## Dependencies

None

## Impact

None expected.