### PR TITLE
Radiosondes: BUFR incoming data (from LDM), skip duplicates

### DIFF
--- a/test/testoutput/wmo_raob_double.nc4
+++ b/test/testoutput/wmo_raob_double.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76c154bb6c514751fbd67bf5875cd6c92d890eea2e40018beb6976b10c7c1f86
-size 202605
+oid sha256:b0fb5fc19fc9aa392c2ece3eb67826fae64662f6ff44591773c61770a8a149d4
+size 151037


### PR DESCRIPTION
## Description

BUFR radiosonde files (picked up with LDM in real-time) often contain duplicates - sometimes as many as three duplicates of the first message, more often only one dupe.  This PR causes the converter to capture which stations are found and skip past any subsequent soundings from the same site.  For a real-time example file, the output file size was decreased by 2/3rds when doing the skipping.

### Issue(s) addressed

A separate one was not created.

## Acceptance Criteria (Definition of Done)

Positive reviews and working ctests.

## Dependencies

None

## Impact

None
