### PR TITLE
Bugfix:  found times when converters crashed when testing with dozens of input files

### DIFF
--- a/src/conventional/sonde_bufr2ioda.py
+++ b/src/conventional/sonde_bufr2ioda.py
@@ -692,16 +692,6 @@ def read_bufr_message(f, count, start_pos, data):
             meta_data['geopotentialHeight'][0] = float_missing_value
             meta_data['pressure'][0] = float_missing_value
 
-        # Very rarely the first level is way up high then followed by at surface. Toss first values.
-        if len(meta_data['pressure']) > 2:
-            if (meta_data['pressure'][0] < 60000 and meta_data['pressure'][1] > meta_data['pressure'][0]):
-                meta_data['pressure'][0] = float_missing_value
-                meta_data['geopotentialHeight'][0] = float_missing_value
-                temp_data['windDirection'][0] = float_missing_value
-                temp_data['windSpeed'][0] = float_missing_value
-                temp_data['airTemperature'][0] = float_missing_value
-                temp_data['dewpointTemperature'][0] = float_missing_value
-
         # And now processing the observed variables we care about.
         nbad = 0
         for variable in raw_obsvars:
@@ -749,7 +739,7 @@ def read_bufr_message(f, count, start_pos, data):
         for n, dewpoint in enumerate(vals['dewpointTemperature']):
             pres = meta_data['pressure'][n]
             if dewpoint and pres:
-                if (dewpoint > 50 and dewpoint < 325 and pres > 100 and pres < 109900):
+                if (dewpoint > 196 and dewpoint < 325 and pres > 100 and pres < 109900):
                     spfh[n] = met_utils.specific_humidity(dewpoint, pres)
 
         airt = np.full(target_number, float_missing_value)
@@ -761,7 +751,7 @@ def read_bufr_message(f, count, start_pos, data):
         tvirt = np.full(target_number, float_missing_value)
         for n, temp in enumerate(airt):
             pres = meta_data['pressure'][n]
-            if (temp != float_missing_value and spfh[n] and pres < 108000 and pres > 10000):
+            if (temp != float_missing_value and spfh[n] != float_missing_value and pres < 108000 and pres > 10000):
                 qvapor = max(1.0e-12, spfh[n]/(1.0-spfh[n]))
                 tvirt[n] = temp*(1.0 + 0.61*qvapor)
 

--- a/src/lib-python/meteo_sounding_utils.py
+++ b/src/lib-python/meteo_sounding_utils.py
@@ -115,6 +115,8 @@ def p_interp(temp_lower, temp_upper, pres_lower, pres_upper, hght_lower, hght_up
         s = G / (Rd * (temp_lower + CTOK))
         pm1 = pres_lower * math.exp(s * (hght_lower - height))
         pm2 = pres_upper * math.exp(s * (hght_upper - height))
+    elif hght_lower == hght_upper:
+        return pres_lower
     else:
         tl = temp_lower + CTOK
         tu = temp_upper + CTOK
@@ -156,6 +158,9 @@ def z_interp(temp_lower, temp_upper, pres_lower, pres_upper, pressure, hght_lowe
         s = Rd * (temp_lower + CTOK) / G
         z1 = hght_lower - s * math.log(pressure / pres_lower)
         z2 = hght_upper + s * math.log(pres_upper / pressure)
+    elif hght_lower == hght_upper:
+        z1 = hght_lower
+        z2 = hght_upper
     else:
         tl = temp_lower + CTOK
         tu = temp_upper + CTOK

--- a/test/testoutput/2021081612_sonde_small.nc
+++ b/test/testoutput/2021081612_sonde_small.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b83099bb032ab09ce3001f0cad1413af66fb8535e686fd9985591f0e15e315a9
-size 54512
+oid sha256:7d738fb86b3923b7f99ceb9f9770032bb20697c0009840ced8a505a285ab1ea1
+size 50416

--- a/test/testoutput/wmo_raob_double.nc4
+++ b/test/testoutput/wmo_raob_double.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0fb5fc19fc9aa392c2ece3eb67826fae64662f6ff44591773c61770a8a149d4
+oid sha256:e95ee21296f4b3ad1c7142ca8702c4cfb6d54fe6173fea0f16b8a29a68ac1fce
 size 151037


### PR DESCRIPTION
## Description

When running an entire month of files through the radiosonde converters (BUFR and TAC input), they would sometimes crash.  So this PR is bug fixing.  Also, since the saturation water vapor pressure code is unreliable at super low temperatures (less than about -78C), the specificHumidity variable is limited to when dewpointTemperature is greater than -77C as a precaution.

### Issue(s) addressed

A separate one was not created.

## Acceptance Criteria (Definition of Done)

Approvals. The existing test data did not contain the kind of data that caused failure so no pre-existing ctest found the error.

## Dependencies

None

## Impact

None expected.
