### PR TITLE
BUGFIX: incoming SSEC AMV data has wrong convention for east/western hemispheres

### DIFF
--- a/src/conventional/amv_ssec_ascii2ioda.py
+++ b/src/conventional/amv_ssec_ascii2ioda.py
@@ -89,7 +89,7 @@ known_var = {'type': ['sensorCentralFrequency', float_missing_value],
              'hms': ['dateTime', int_missing_value],
              'lat': ['latitude', float_missing_value],
              'lon': ['longitude', float_missing_value],
-             'pre': ['air_pressure', float_missing_value],
+             'pre': ['pressure', float_missing_value],
              'rff': ['sensorZenithAngle', float_missing_value],
              'qi': ['windTrackingCorrelation', float_missing_value],
              'int': ['windHeightAssignMethod', int_missing_value],
@@ -194,7 +194,7 @@ def read_file(file_name, data):
                 dtg = datetime.strptime(f"{row['day']} {row['hms']}", '%Y%m%d %H%M')
                 time_offset = np.int64(round((dtg - epoch).total_seconds()))
                 local_data['dateTime'] = np.append(local_data['dateTime'], time_offset)
-                local_data['longitude'] = np.append(local_data['longitude'], float(row['lon']))
+                local_data['longitude'] = np.append(local_data['longitude'], float(row['lon'])*-1.0)
                 local_data['latitude'] = np.append(local_data['latitude'], float(row['lat']))
 
                 pres = float(row['pre'])*100.

--- a/test/testoutput/satwinds_ssec2021080103.nc
+++ b/test/testoutput/satwinds_ssec2021080103.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:812bca662886a24c147c6a2534703d73d575885d5e8ba6f76b44b987fa14ffd8
-size 69439
+oid sha256:957052c787a170549e11e6945eecd5d45ce0f693c5058d10c771b8cf402ffcf0
+size 69447


### PR DESCRIPTION
## Description

The text data downloaded from SSEC uses positive longitudes for western hemisphere and negative longitudes for eastern hemisphere.  This PR fixes to world convention using a -1.0 multiplier for their longitudes.

### Issue(s) addressed

Rapid bug fix, a separate issue was not created.

## Acceptance Criteria (Definition of Done)

It will be nice to see the change on experiments.jcsda.org but this was discovered by looking at experiment id=`369c00` that clearly shows the error.

## Dependencies

None

## Impact

None
