### PR TITLE
[3D]RTMA Mesonet BUFR tables

### DIFF
--- a/doc/bufr_table_samples/mesonet.nc255001.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255001.bufr.table.txt
@@ -1,0 +1,215 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255001 | A55001 | MTYP 255-001  Mesonet from MADIS: Denver Urban Drainage  |
+| NC255002 | A55002 | MTYP 255-002  Mesonet from MADIS: RAWS (NIFC)            |
+| NC255003 | A55003 | MTYP 255-003  Mesonet from MADIS: MesoWest (many subpr)  |
+| NC255004 | A55004 | MTYP 255-004  Mesonet from MADIS: APRS WeatherNet        |
+| NC255005 | A55005 | MTYP 255-005  Mesonet from MADIS: Kansas DOT             |
+| NC255006 | A55006 | MTYP 255-006  Mesonet from MADIS: Florida                |
+| NC255007 | A55007 | MTYP 255-007  Mesonet from MADIS: Iowa DOT               |
+| NC255008 | A55008 | MTYP 255-008  Mesonet from MADIS: Minnesota DOT          |
+| NC255009 | A55009 | MTYP 255-009  Mesonet from MADIS: Anything Weather       |
+| NC255010 | A55010 | MTYP 255-010  Mesonet from MADIS: NOS PORTS              |
+| NC255011 | A55011 | MTYP 255-011  Mesonet from MADIS: Aberdeen Proving Grds  |
+| NC255012 | A55012 | MTYP 255-012  Mesonet from MADIS: Weather for You        |
+| NC255013 | A55013 | MTYP 255-013  Mesonet from MADIS: NWS Cooperative Obs    |
+| NC255014 | A55014 | MTYP 255-014  Mesonet from MADIS: NWS HADS               |
+| NC255015 | A55015 | MTYP 255-015  Mesonet from MADIS: AWS                    |
+| NC255016 | A55016 | MTYP 255-016  Mesonet from MADIS: Iowa Environmental     |
+| NC255017 | A55017 | MTYP 255-017  Mesonet from MADIS: Oklahoma               |
+| NC255018 | A55018 | MTYP 255-018  Mesonet from MADIS: Colorado DOT           |
+| NC255019 | A55019 | MTYP 255-019  Mesonet from MADIS: West Texas             |
+| NC255020 | A55020 | MTYP 255-020  Mesonet from MADIS: Wisconsin DOT          |
+| NC255021 | A55021 | MTYP 255-021  Mesonet from MADIS: LSU-JSU                |
+| NC255022 | A55022 | MTYP 255-022  Mesonet from MADIS: Colorado E-470         |
+| NC255023 | A55023 | MTYP 255-023  Mesonet from MADIS: DC Net                 |
+| NC255024 | A55024 | MTYP 255-024  Mesonet from MADIS: Indiana DOT            |
+| NC255025 | A55025 | MTYP 255-025  Mesonet from MADIS: Florida DOT            |
+| NC255026 | A55026 | MTYP 255-026  Mesonet from MADIS: Alaska DOT             |
+| NC255027 | A55027 | MTYP 255-027  Mesonet from MADIS: Georgia DOT            |
+| NC255028 | A55028 | MTYP 255-028  Mesonet from MADIS: Virginia DOT           |
+| NC255029 | A55029 | MTYP 255-029  Mesonet from MADIS: MO Comm Agric. Wx Net  |
+| NC255030 | A55030 | MTYP 255-030  Mesonet from MADIS: other than above       |
+| NC255031 | A55031 | MTYP 255-031  Urbanet from MADIS: UrbaNet                |
+| NC255032 | A55032 | MTYP 255-032  Urbanet from MADIS: USouthAL               |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| FILENAME | 352004 | FILE NAME SEQUENCE                                       |
+| PRVID    | 350001 | MESONET PROVIDER ID                                      |
+| SPRVID   | 350002 | MESONET SUB-PROVIDER ID                                  |
+| MNPRESSQ | 350003 | MESONET PRESSURE SEQUENCE                                |
+| MNALSESQ | 350004 | MESONET ALTIMETER SEQUENCE                               |
+| MNTMDBSQ | 350005 | MESONET TEMPERATURE SEQUENCE                             |
+| MNTMDPSQ | 350006 | MESONET DEWPOINT TEMPERATURE SEQUENCE                    |
+| MNWDIRSQ | 350007 | MESONET WIND DIRECTION SEQUENCE                          |
+| MNWSPDSQ | 350008 | MESONET WIND SPEED SEQUENCE                              |
+| MNGUSTSQ | 350009 | MESONET WIND GUST SEQUENCE                               |
+| MNSORDSQ | 350010 | MESONET SOLAR RADIATION SEQUENCE                         |
+| MNREQVSQ | 350011 | MESONET RATE OF PRECIPITATION SEQUENCE                   |
+| MNTOPCSQ | 350012 | MESONET TOTAL PRECIPITATION SEQUENCE                     |
+| MNSOILSQ | 350013 | MESONET SOIL SEQUENCE                                    |
+| MNRDWYSQ | 350151 | MESONET ROADWAY DATA SEQUENCE                            |
+| MNHOVISQ | 350155 | MESONET HORIZONTAL VISIBILITY SEQUENCE                   |
+|          |        |                                                          |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| PRVSTG   | 058009 | MESONET PROVIDER ID STRING                               |
+| SPRVSTG  | 058010 | MESONET SUBPROVIDER ID STRING                            |
+| PRES     | 010004 | PRESSURE                                                 |
+| QCD      | 033220 | FSL "QC DATA" FLAG                                       |
+| QCA      | 033221 | FSL "QC APPLIED" FLAG                                    |
+| QCR      | 033222 | FSL "QC RESULTS" FLAG                                    |
+| ALSE     | 010052 | ALTIMETER SETTING                                        |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGD     | 011043 | MAXIMUM WIND GUST DIRECTION                              |
+| MXGS     | 011041 | MAX WIND SPEED (GUSTS)                                   |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| DFSORD   | 014029 | DIFFUSE SOLAR RADIATION, INTEGRATED OVER PERIOD SPEC     |
+| DRSORD   | 014030 | DIRECT  SOLAR RADIATION, INTEGRATED OVER PERIOD SPEC     |
+| REQV     | 013014 | RAINFALL/WATER EQUIVALENT OF SNOW (AVERAGED RATE)        |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| SLMT     | 013221 | SOIL MOISTURE TENSION                                    |
+| STEM     | 012030 | SOIL TEMPERATURE                                         |
+| RDTM     | 012213 | ROAD TEMPERATURE                                         |
+| RLFT     | 012214 | ROAD LIQUID FREEZE TEMPERATURE                           |
+| RLIP     | 020220 | ROAD LIQUID ICE PERCENT                                  |
+| RDLD     | 020221 | ROAD LIQUID DEPTH                                        |
+| RDST     | 020222 | ROAD STATE                                               |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255001 | YEAR  MNTH  DAYS  HOUR  MINU  {RCPTIM}  RSRD  EXPRSRD  RPID       |
+| NC255001 | {PRVID}  {SPRVID}  CLATH  CLONH  SELV  {FILENAME}  <MNPRESSQ>     |
+| NC255001 | QMPR  <MNALSESQ>  <MNTMDBSQ>  QMAT  <MNTMDPSQ>  QMDD  <MNWDIRSQ>  |
+| NC255001 | <MNWSPDSQ>  QMWN  <MNGUSTSQ>  <MNSOILSQ>  <MNREQVSQ>  <MNHOVISQ>  |
+| NC255001 | {MNTOPCSQ}  {MNSORDSQ}  {MNRDWYSQ}                                |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| FILENAME | FNSTG                                                             |
+|          |                                                                   |
+| PRVID    | PRVSTG                                                            |
+|          |                                                                   |
+| SPRVID   | SPRVSTG                                                           |
+|          |                                                                   |
+| MNPRESSQ | PRES  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNALSESQ | ALSE  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNTMDBSQ | TMDB  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNTMDPSQ | TMDP  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWDIRSQ | WDIR  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWSPDSQ | WSPD  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNGUSTSQ | MXGD  MXGS                                                        |
+|          |                                                                   |
+| MNSORDSQ | TPMI  DFSORD  DRSORD                                              |
+|          |                                                                   |
+| MNREQVSQ | REQV  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNTOPCSQ | TPHR  TOPC  QCD  QCA  QCR                                         |
+|          |                                                                   |
+| MNSOILSQ | SLMT  STEM                                                        |
+|          |                                                                   |
+| MNRDWYSQ | RDTM  RLFT  RLIP  RDLD  RDST                                      |
+|          |                                                                   |
+| MNHOVISQ | HOVI  QCD  QCA  QCR                                               |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PRVSTG   |    0 |           0 |  64 | CCITT IA5                |-------------|
+| SPRVSTG  |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| QCD      |    0 |           0 |   8 | CCITT IA5                |-------------|
+| QCA      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| QCR      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| ALSE     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGD     |    0 |           0 |   9 | DEGREE TRUE              |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| DFSORD   |   -2 |           0 |  16 | JOULE M**-2              |-------------|
+| DRSORD   |   -2 |           0 |  16 | JOULE M**-2              |-------------|
+| REQV     |    4 |           0 |  12 | KG M**-2 S**-1           |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| SLMT     |   -2 |      -99990 |  18 | PASCALS                  |-------------|
+| STEM     |    1 |           0 |  12 | DEGREES KELVIN           |-------------|
+| RDTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| RLFT     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| RLIP     |    0 |           0 |   7 | %                        |-------------|
+| RDLD     |    2 |           0 |  12 | METERS                   |-------------|
+| RDST     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'
+| NOTE     | The mnemonic sequences are same across all the Mesonet subsets    |
+|          | from NC255001 to NC255032                                         |
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/mesonet.nc255101.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255101.bufr.table.txt
@@ -1,0 +1,141 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255101 | A55101 | MTYP 255-101  Coop from MADIS: NEPP &  HCN-Modrnzd- NOA  |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| FILENAME | 352004 | FILE NAME SEQUENCE                                       |
+| PRVID    | 350001 | MESONET PROVIDER ID                                      |
+| MNTMDBSQ | 350005 | MESONET TEMPERATURE SEQUENCE                             |
+| MNTMDPSQ | 350006 | MESONET DEWPOINT TEMPERATURE SEQUENCE                    |
+| MNWDIRSQ | 350007 | MESONET WIND DIRECTION SEQUENCE                          |
+| MNWSPDSQ | 350008 | MESONET WIND SPEED SEQUENCE                              |
+| MNSOMTSQ | 350016 | MESONET SOIL MOISTURE AND TEMPERATURE SEQUENCE           |
+| MNTOPCSQ | 350012 | MESONET TOTAL PRECIPITATION SEQUENCE                     |
+| MNDOFSSQ | 350017 | MESONET DEPTH OF FRESH SNOW SEQUENCE                     |
+| MNTOSDSQ | 350018 | MESONET TOTAL SNOW DEPTH SEQUENCE                        |
+|          |        |                                                          |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| PRVSTG   | 058009 | MESONET PROVIDER ID STRING                               |
+| QCD      | 033220 | FSL "QC DATA" FLAG                                       |
+| QCA      | 033221 | FSL "QC APPLIED" FLAG                                    |
+| QCR      | 033222 | FSL "QC RESULTS" FLAG                                    |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| DBLS     | 007061 | DEPTH BELOW LAND SURFACE                                 |
+| WTNS     | 013220 | SOIL MOISTURE AVAILABILITY                               |
+| STEMH    | 012130 | SOIL TEMPERATURE                                         |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| PLTTYP   | 002207 | PLATFORM TYPE                                            |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255101 | YEAR  MNTH  DAYS  HOUR  MINU  {RCPTIM}  RSRD  EXPRSRD  RPID       |
+| NC255101 | {PRVID}  PLTTYP  CLATH  CLONH  SELV  {FILENAME}  <MNTMDBSQ>  QMAT |
+| NC255101 | <MNTMDPSQ>  QMDD  <MNWDIRSQ>  <MNWSPDSQ>  QMWN  {MNSOMTSQ}        |
+| NC255101 | {MNTOPCSQ}  {MNDOFSSQ}  <MNTOSDSQ>                                |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| FILENAME | FNSTG                                                             |
+|          |                                                                   |
+| PRVID    | PRVSTG                                                            |
+|          |                                                                   |
+| MNTMDBSQ | TMDB  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNTMDPSQ | TMDP  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWDIRSQ | WDIR  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWSPDSQ | WSPD  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNSOMTSQ | DBLS  202129  201130  WTNS  201000  202000  QCD  QCA  QCR  STEMH  |
+| MNSOMTSQ | QCD  QCA  QCR                                                     |
+|          |                                                                   |
+| MNTOPCSQ | TPHR  TOPC  QCD  QCA  QCR                                         |
+|          |                                                                   |
+| MNDOFSSQ | TPHR  DOFS  QCD  QCA  QCR                                         |
+|          |                                                                   |
+| MNTOSDSQ | TOSD  QCD  QCA  QCR                                               |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PRVSTG   |    0 |           0 |  64 | CCITT IA5                |-------------|
+| QCD      |    0 |           0 |   8 | CCITT IA5                |-------------|
+| QCA      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| QCR      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| DBLS     |    2 |           0 |  14 | METERS                   |-------------|
+| WTNS     |    0 |           0 |   8 | %                        |-------------|
+| STEMH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PLTTYP   |    0 |           0 |   3 | CODE TABLE               |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/mesonet.nc255102.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255102.bufr.table.txt
@@ -1,0 +1,300 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255102 | A55102 | MTYP 255-102  Coop from SHEF fmt: All NWS Coop Obs       |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| BID      | 352001 | BULLETIN ID DATA                                         |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| SHTPMOSQ | 356101 | SHEF TIME PERIOD SEQUENCE (MONTHS)                       |
+| SHTPHRSQ | 356102 | SHEF TIME PERIOD SEQUENCE (HOURS)                        |
+| SHTPMISQ | 356103 | SHEF TIME PERIOD SEQUENCE (MINUTES)                      |
+| SHPRESSQ | 356104 | SHEF PRESSURE SEQUENCE                                   |
+| SHPMSLSQ | 356105 | SHEF PRESSURE (MSL) SEQUENCE                             |
+| SHTOPCSQ | 356106 | SHEF TOTAL PRECIPITATION SEQUENCE                        |
+| SHPRTPSQ | 356107 | SHEF TYPE OF PRECIPITATION SEQUENCE                      |
+| SHDOFSSQ | 356108 | SHEF DEPTH OF FRESH SNOW SEQUENCE                        |
+| SHTOSDSQ | 356109 | SHEF TOTAL SNOW DEPTH SEQUENCE                           |
+| SHSWEMSQ | 356110 | SHEF SNOW WATER EQUIVALENT SEQUENCE                      |
+| SHTMDBSQ | 356111 | SHEF TEMPERATURE SEQUENCE                                |
+| SHMXTMSQ | 356112 | SHEF MAXIMUM TEMPERATURE SEQUENCE                        |
+| SHMITMSQ | 356113 | SHEF MINIMUM TEMPERATURE SEQUENCE                        |
+| SHWATMSQ | 356114 | SHEF WATER TEMPERATURE SEQUENCE                          |
+| SHTMWBSQ | 356115 | SHEF WET BULB TEMPERATURE SEQUENCE                       |
+| SHREHUSQ | 356116 | SHEF RELATIVE HUMIDITY SEQUENCE                          |
+| SHMXRHSQ | 356117 | SHEF MAXIMUM RELATIVE HUMIDITY SEQUENCE                  |
+| SHMIRHSQ | 356118 | SHEF MINIMUM RELATIVE HUMIDITY SEQUENCE                  |
+| SHTMDPSQ | 356119 | SHEF DEW POINT TEMPERATURE SEQUENCE                      |
+| SHWDIRSQ | 356120 | SHEF WIND DIRECTION SEQUENCE                             |
+| SHWSPDSQ | 356121 | SHEF WIND SPEED SEQUENCE                                 |
+| SHMXGSSQ | 356122 | SHEF WIND SPEED (GUSTS) SEQUENCE                         |
+| SHPKWDSQ | 356123 | SHEF PEAK WIND DIRECTION SEQUENCE                        |
+| SHPKWSSQ | 356124 | SHEF PEAK WIND SPEED SEQUENCE                            |
+| SHPRWESQ | 356125 | SHEF PRESENT WEATHER SEQUENCE                            |
+| SHPSW1SQ | 356126 | SHEF PAST WEATHER (1) SEQUENCE                           |
+| SHCLAMSQ | 356127 | SHEF CLOUD AMOUNT SEQUENCE                               |
+| SHHOVISQ | 356128 | SHEF HORIZONTAL VISIBILITY SEQUENCE                      |
+| SHALBDSQ | 356129 | SHEF ALBEDO SEQUENCE                                     |
+| SHTOSHSQ | 356130 | SHEF TOTAL SUNSHINE SEQUENCE                             |
+| SHSOGRSQ | 356131 | SHEF STATE OF THE GROUND SEQUENCE                        |
+| SHRSHMSQ | 356132 | SHEF RIVER STAGE HEIGHT SEQUENCE                         |
+| SHSTM1SQ | 356133 | SHEF SOIL TEMPERATURE (DEPTH #1) SEQUENCE                |
+| SHSTM2SQ | 356134 | SHEF SOIL TEMPERATURE (DEPTH #2) SEQUENCE                |
+| SHXST1SQ | 356135 | SHEF MAXIMUM SOIL TEMPERATURE (DEPTH #1) SEQUENCE        |
+| SHXST2SQ | 356136 | SHEF MAXIMUM SOIL TEMPERATURE (DEPTH #2) SEQUENCE        |
+| SHIST1SQ | 356137 | SHEF MINIMUM SOIL TEMPERATURE (DEPTH #1) SEQUENCE        |
+| SHIST2SQ | 356138 | SHEF MINIMUM SOIL TEMPERATURE (DEPTH #2) SEQUENCE        |
+| SHWACNSQ | 356139 | SHEF WATER CONDUCTIVITY SEQUENCE                         |
+| SHTLLWSQ | 356140 | SHEF TIDE HEIGHT SEQUENCE                                |
+|          |        |                                                          |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| TPMO     | 004022 | TIME PERIOD OR DISPLACEMENT                              |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| CLAT     | 005002 | LATITUDE (COARSE ACCURACY)                               |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLON     | 006002 | LONGITUDE (COARSE ACCURACY)                              |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| HSMSL    | 007030 | HEIGHT OF STATION GROUND ABOVE MSL                       |
+| DBLS     | 007061 | DEPTH BELOW LAND SURFACE                                 |
+| RSHM     | 007198 | RIVER STAGE HEIGHT (GAGE HEIGHT)                         |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| PRES     | 010004 | PRESSURE                                                 |
+| PMSL     | 010051 | PRESSURE REDUCED TO MSL                                  |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAX WIND SPEED (GUSTS)                                   |
+| PKWDDR   | 011202 | PEAK WIND DIRECTION                                      |
+| PKWDSP   | 011203 | PEAK WIND SPEED                                          |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| TMWB     | 012102 | WET BULB TEMPERATURE                                     |
+| TMDP     | 012103 | DEW POINT TEMPERATURE                                    |
+| MXTM     | 012111 | MAXIMUM TEMPERATURE                                      |
+| MITM     | 012112 | MINIMUM TEMPERATURE                                      |
+| STEMH    | 012130 | SOIL TEMPERATURE                                         |
+| MXSTH    | 012211 | MAXIMUM SOIL TEMPERATURE                                 |
+| MISTH    | 012212 | MINIMUM SOIL TEMPERATURE                                 |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| MIRH     | 013007 | MINIMUM RELATIVE HUMIDITY                                |
+| MXRH     | 013008 | MAXIMUM RELATIVE HUMIDITY                                |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| WACN     | 013081 | WATER CONDUCTIVITY                                       |
+| WATM     | 013082 | WATER TEMPERATURE                                        |
+| SWEM     | 013210 | SNOW WATER EQUIVALENT                                    |
+| DCHG     | 013214 | DISCHARGE                                                |
+| SRMK     | 013228 | SNOW REPORT REMARKS                                      |
+| ALBD     | 014027 | ALBEDO                                                   |
+| TOSH     | 014032 | TOTAL SUNSHINE                                           |
+| SRADF    | 014035 | SOLAR RADIATION FLUX                                     |
+| HOVI     | 020001 | HORIZONTAL VISIBILITY                                    |
+| PRWE     | 020003 | PRESENT WEATHER                                          |
+| PSW1     | 020004 | PAST WEATHER (1)                                         |
+| CLAM     | 020011 | CLOUD AMOUNT                                             |
+| PRTP     | 020021 | TYPE OF PRECIPITATION                                    |
+| SOGR     | 020062 | STATE OF THE GROUND                                      |
+| TLLW     | 022226 | TIDE ELEV. WITH RESPECT TO MEAN LOWER LOW WATER          |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+| SHRV     | 033230 | SHEF DATA REVISION FLAG                                  |
+| SHQL     | 033231 | SHEF DATA QUALIFIER FLAG                                 |
+| BUHD     | 035021 | BULLETIN BEING MONITORED (TTAAii)                        |
+| BULTIM   | 035022 | BULLETIN BEING MONITORED (YYGGgg)                        |
+| BORG     | 035023 | BULLETIN BEING MONITORED (CCCC)                          |
+| BBB      | 035194 | BULLETIN BEING MONITORED (BBB)                           |
+| SEQNUM   | 035195 | CHANNEL SEQUENCE NUMBER                                  |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255102 | YYMMDD  HHMM  <SHTPMOSQ>  <SHTPHRSQ>  <SHTPMISQ>  BID  RCPTIM     |
+| NC255102 | RPID  CLAT  CLON  HSMSL  <SHPRESSQ>  QMPR  <SHPMSLSQ>  <SHTOPCSQ> |
+| NC255102 | <SHPRTPSQ>  <SHDOFSSQ>  <SHTOSDSQ>  <SHSWEMSQ>  <SHTMDBSQ>  QMAT  |
+| NC255102 | <SHMXTMSQ>  <SHMITMSQ>  <SHWATMSQ>  <SHTMWBSQ>  <SHREHUSQ>        |
+| NC255102 | <SHMXRHSQ>  <SHMIRHSQ>  <SHTMDPSQ>  QMDD  <SHWACNSQ>  <SHWDIRSQ>  |
+| NC255102 | <SHWSPDSQ>  QMWN  <SHMXGSSQ>  <SHPKWDSQ>  <SHPKWSSQ>  <SHPRWESQ>  |
+| NC255102 | <SHPSW1SQ>  <SHCLAMSQ>  <SHHOVISQ>  <SHALBDSQ>  <SHTOSHSQ>        |
+| NC255102 | <SHSOGRSQ>  <SHRSHMSQ>  <SHTLLWSQ>  <SHSTM1SQ>  <SHSTM2SQ>        |
+| NC255102 | <SHXST1SQ>  <SHXST2SQ>  <SHIST1SQ>  <SHIST2SQ>                    |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| BID      | SEQNUM  BUHD  BORG  BULTIM  BBB                                   |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| SHTPMOSQ | TPMO                                                              |
+|          |                                                                   |
+| SHTPHRSQ | TPHR                                                              |
+|          |                                                                   |
+| SHTPMISQ | TPMI                                                              |
+|          |                                                                   |
+| SHPRESSQ | PRES  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPMSLSQ | PMSL  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOPCSQ | TOPC  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPRTPSQ | PRTP  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHDOFSSQ | DOFS  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOSDSQ | TOSD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSWEMSQ | SWEM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMDBSQ | TMDB  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXTMSQ | MXTM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMITMSQ | MITM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWATMSQ | WATM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMWBSQ | TMWB  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHREHUSQ | REHU  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXRHSQ | MXRH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMIRHSQ | MIRH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTMDPSQ | TMDP  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWDIRSQ | WDIR  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHWSPDSQ | WSPD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHMXGSSQ | MXGS  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPKWDSQ | PKWDDR  SHRV  SHQL                                                |
+|          |                                                                   |
+| SHPKWSSQ | PKWDSP  SHRV  SHQL                                                |
+|          |                                                                   |
+| SHPRWESQ | PRWE  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHPSW1SQ | PSW1  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHCLAMSQ | CLAM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHHOVISQ | HOVI  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHALBDSQ | ALBD  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHTOSHSQ | TOSH  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSOGRSQ | SOGR  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHRSHMSQ | RSHM  SHRV  SHQL                                                  |
+|          |                                                                   |
+| SHSTM1SQ | DBLS  STEMH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHSTM2SQ | DBLS  STEMH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHXST1SQ | DBLS  MXSTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHXST2SQ | DBLS  MXSTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHIST1SQ | DBLS  MISTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHIST2SQ | DBLS  MISTH  SHRV  SHQL                                           |
+|          |                                                                   |
+| SHWACNSQ | 207001  WACN  207000  SHRV  SHQL                                  |
+|          |                                                                   |
+| SHTLLWSQ | TLLW  SHRV  SHQL                                                  |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| TPMO     |    0 |       -1024 |  11 | MONTH                    |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| CLAT     |    2 |       -9000 |  15 | DEGREES                  |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLON     |    2 |      -18000 |  16 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| HSMSL    |    1 |       -4000 |  17 | METERS                   |-------------|
+| DBLS     |    2 |           0 |  14 | METERS                   |-------------|
+| RSHM     |    3 |           0 |  15 | METERS                   |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| PRES     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| PMSL     |   -1 |           0 |  14 | PASCALS                  |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXGS     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| PKWDDR   |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| PKWDSP   |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMWB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| TMDP     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| STEMH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MXSTH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MISTH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| MIRH     |    0 |           0 |   7 | %                        |-------------|
+| MXRH     |    0 |           0 |   7 | %                        |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| WACN     |    3 |           0 |  14 | SIEMENS/M                |-------------|
+| WATM     |    1 |           0 |  12 | DEGREES KELVIN           |-------------|
+| SWEM     |    2 |           0 |  18 | KG/(M**2)                |-------------|
+| DCHG     |    2 |    -8450000 |  25 | METERS**3/SECOND         |-------------|
+| SRMK     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| ALBD     |    0 |           0 |   7 | %                        |-------------|
+| TOSH     |    0 |           0 |  10 | HOUR                     |-------------|
+| SRADF    |    1 |           0 |  14 | WATT M**-2               |-------------|
+| HOVI     |   -1 |           0 |  13 | METERS                   |-------------|
+| PRWE     |    0 |           0 |   9 | CODE TABLE               |-------------|
+| PSW1     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| CLAM     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| PRTP     |    0 |           0 |  30 | FLAG TABLE               |-------------|
+| SOGR     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| TLLW     |    3 |       -9999 |  15 | METERS                   |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| SHRV     |    0 |           0 |   2 | CODE TABLE               |-------------|
+| SHQL     |    0 |           0 |   5 | CODE TABLE               |-------------|
+| BUHD     |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BULTIM   |    0 |           0 |  48 | CCITT IA5                |-------------|
+| BORG     |    0 |           0 |  32 | CCITT IA5                |-------------|
+| BBB      |    0 |           0 |  48 | CCITT IA5                |-------------|
+| SEQNUM   |    0 |           0 |  32 | CCITT IA5                |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/mesonet.nc255111.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255111.bufr.table.txt
@@ -1,0 +1,151 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255111 | A55111 | MTYP 255-111  Mesonet from MADIS: Climate Refrnce Netwk  |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| FILENAME | 352004 | FILE NAME SEQUENCE                                       |
+| PRVID    | 350001 | MESONET PROVIDER ID                                      |
+| MNTMDBSQ | 350005 | MESONET TEMPERATURE SEQUENCE                             |
+| MNREHUSQ | 350152 | MESONET RELATIVE HUMIDITY SEQUENCE                       |
+| MNWDIRSQ | 350007 | MESONET WIND DIRECTION SEQUENCE                          |
+| MNWSPDSQ | 350008 | MESONET WIND SPEED SEQUENCE                              |
+| MNGUSTSQ | 350009 | MESONET WIND GUST SEQUENCE                               |
+| MNSORFSQ | 350153 | MESONET SOLAR RADIATION FLUX SEQUENCE                    |
+| MNREQVSQ | 350011 | MESONET RATE OF PRECIPITATION SEQUENCE                   |
+| CNTOPCSQ | 350154 | Climate Refrnce Netwk TOTAL PRECIPITATION SEQUENCE       |
+| MNSOMTSQ | 350016 | MESONET SOIL MOISTURE AND TEMPERATURE SEQUENCE           |
+|          |        |                                                          |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| PRVSTG   | 058009 | MESONET PROVIDER ID STRING                               |
+| SPRVSTG  | 058010 | MESONET SUBPROVIDER ID STRING                            |
+| QCD      | 033220 | FSL "QC DATA" FLAG                                       |
+| QCA      | 033221 | FSL "QC APPLIED" FLAG                                    |
+| QCR      | 033222 | FSL "QC RESULTS" FLAG                                    |
+| TMDB     | 012101 | TEMPERATURE/DRY BULB TEMPERATURE                         |
+| REHU     | 013003 | RELATIVE HUMIDITY                                        |
+| WDIR     | 011001 | WIND DIRECTION                                           |
+| WSPD     | 011002 | WIND SPEED                                               |
+| MXGS     | 011041 | MAX WIND SPEED (GUSTS)                                   |
+| MXGD     | 011043 | MAXIMUM WIND GUST DIRECTION                              |
+| SRADF    | 014035 | SOLAR RADIATION FLUX                                     |
+| REQV     | 013014 | RAINFALL/WATER EQUIVALENT OF SNOW (AVERAGED RATE)        |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| TPMI     | 004025 | TIME PERIOD OR DISPLACEMENT                              |
+| TOPC     | 013011 | TOTAL PRECIPITATION/TOTAL WATER EQUIVALENT               |
+| DBLS     | 007061 | DEPTH BELOW LAND SURFACE                                 |
+| WTNS     | 013220 | SOIL MOISTURE AVAILABILITY                               |
+| STEMH    | 012130 | SOIL TEMPERATURE                                         |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| PLTTYP   | 002207 | PLATFORM TYPE                                            |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| QMAT     | 033193 | SDMEDIT QUALITY MARK FOR TEMPERATURE                     |
+| QMDD     | 033194 | SDMEDIT QUALITY MARK FOR MOISTURE                        |
+| QMWN     | 033195 | SDMEDIT QUALITY MARK FOR WIND                            |
+| QMPR     | 033207 | SDMEDIT QUALITY MARK FOR PRESSURE                        |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255111 | YEAR  MNTH  DAYS  HOUR  MINU  {RCPTIM}  RSRD  EXPRSRD  RPID       |
+| NC255111 | {PRVID}  PLTTYP  CLATH  CLONH  SELV  {FILENAME}  <MNTMDBSQ>  QMAT |
+| NC255111 | <MNREHUSQ>  QMDD  <MNWDIRSQ>  <MNWSPDSQ>  QMWN  <MNGUSTSQ>        |
+| NC255111 | <MNSORFSQ>  <MNREQVSQ>  {CNTOPCSQ}  {MNSOMTSQ}                    |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| FILENAME | FNSTG                                                             |
+|          |                                                                   |
+| PRVID    | PRVSTG                                                            |
+|          |                                                                   |
+| MNTMDBSQ | TMDB  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNREHUSQ | REHU  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWDIRSQ | WDIR  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNWSPDSQ | WSPD  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| MNGUSTSQ | MXGD  MXGS                                                        |
+|          |                                                                   |
+| MNSORFSQ | SRADF  QCD  QCA  QCR                                              |
+|          |                                                                   |
+| MNREQVSQ | REQV  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| CNTOPCSQ | TPHR  TPMI  TOPC  QCD  QCA  QCR                                   |
+|          |                                                                   |
+| MNSOMTSQ | DBLS  202129  201130  WTNS  201000  202000  QCD  QCA  QCR  STEMH  |
+| MNSOMTSQ | QCD  QCA  QCR                                                     |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PRVSTG   |    0 |           0 |  64 | CCITT IA5                |-------------|
+| QCD      |    0 |           0 |   8 | CCITT IA5                |-------------|
+| QCA      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| QCR      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| TMDB     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| REHU     |    0 |           0 |   7 | %                        |-------------|
+| WDIR     |    0 |           0 |   9 | DEGREES TRUE             |-------------|
+| WSPD     |    1 |           0 |  12 | METERS/SECOND            |-------------|
+| MXTM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| MITM     |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| SRADF    |    1 |           0 |  14 | WATT M**-2               |-------------|
+| REQV     |    4 |           0 |  12 | KG M**-2 S**-1           |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| TPMI     |    0 |       -2048 |  12 | MINUTE                   |-------------|
+| TOPC     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| DBLS     |    2 |           0 |  14 | METERS                   |-------------|
+| WTNS     |    0 |           0 |   8 | %                        |-------------|
+| STEMH    |    2 |           0 |  16 | DEGREES KELVIN           |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PLTTYP   |    0 |           0 |   3 | CODE TABLE               |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| QMAT     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMDD     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMWN     |    0 |           0 |   4 | CODE TABLE               |-------------|
+| QMPR     |    0 |           0 |   4 | CODE TABLE               |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/mesonet.nc255131.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255131.bufr.table.txt
@@ -1,0 +1,120 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255131 | A55131 | MTYP 255-131  Hydro from MADIS: Denver Urban Drainage    |
+| NC255160 | A55160 | MTYP 255-160  Hydro from MADIS: other than above         |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| PRVID    | 350001 | MESONET PROVIDER ID                                      |
+| FILENAME | 352004 | FILE NAME SEQUENCE                                       |
+| HYPCP5SQ | 352150 | HYDRO DATA - 5-MIN PRECIP SEQUENCE                       |
+| HYPCP1SQ | 352151 | HYDRO DATA - 1-HR PRECIP SEQUENCE                        |
+| HYPCP3SQ | 352152 | HYDRO DATA - 3-HR PRECIP SEQUENCE                        |
+| HYPCP6SQ | 352153 | HYDRO DATA - 6-HR PRECIP SEQUENCE                        |
+| HYPC12SQ | 352154 | HYDRO DATA - 12-HR PRECIP SEQUENCE                       |
+| HYPC24SQ | 352155 | HYDRO DATA - 24-HR PRECIP SEQUENCE                       |
+|          |        |                                                          |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| PRVSTG   | 058009 | MESONET PROVIDER ID STRING                               |
+| QCD      | 033220 | FSL "QC DATA" FLAG                                       |
+| QCA      | 033221 | FSL "QC APPLIED" FLAG                                    |
+| QCR      | 033222 | FSL "QC RESULTS" FLAG                                    |
+| TP5M     | 013199 | TOTAL PRECIPITATION PAST 5 MINUTES                       |
+| TP01     | 013019 | TOTAL PRECIPITATION PAST 1 HOUR                          |
+| TP03     | 013020 | TOTAL PRECIPITATION PAST 3 HOURS                         |
+| TP06     | 013021 | TOTAL PRECIPITATION PAST 6 HOURS                         |
+| TP12     | 013022 | TOTAL PRECIPITATION PAST 12 HOURS                        |
+| TP24     | 013023 | TOTAL PRECIPITATION PAST 24 HOURS                        |
+| RSRD     | 035200 | RESTRICTIONS ON REDISTRIBUTION                           |
+| EXPRSRD  | 035201 | EXPIRATION OF RESTRICTIONS ON REDISTRIBUTION             |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| RSHM     | 007198 | RIVER STAGE HEIGHT (GAGE HEIGHT)                         |
+| DCHG     | 013214 | DISCHARGE                                                |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255131 | YEAR  MNTH  DAYS  HOUR  MINU  {RCPTIM}  RSRD  EXPRSRD  RPID       |
+| NC255131 | {PRVID}  CLATH  CLONH  SELV  RSHM  DCHG  {FILENAME}  <HYPCP5SQ>   |
+| NC255131 | <HYPCP1SQ>  <HYPCP3SQ>  <HYPCP6SQ>  <HYPC12SQ>  <HYPC24SQ>        |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| PRVID    | PRVSTG                                                            |
+|          |                                                                   |
+| FILENAME | FNSTG                                                             |
+|          |                                                                   |
+| HYPCP5SQ | TP5M  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| HYPCP1SQ | TP01  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| HYPCP3SQ | TP03  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| HYPCP6SQ | TP06  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| HYPC12SQ | TP12  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| HYPC24SQ | TP24  QCD  QCA  QCR                                               |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| PRVSTG   |    0 |           0 |  64 | CCITT IA5                |-------------|
+| QCD      |    0 |           0 |   8 | CCITT IA5                |-------------|
+| QCA      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| QCR      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| TP5M     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP01     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP03     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP06     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP12     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| TP24     |    1 |          -1 |  14 | KG/METER**2              |-------------|
+| RSRD     |    0 |           0 |   9 | FLAG TABLE               |-------------|
+| EXPRSRD  |    0 |           0 |   8 | HOURS                    |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| RSHM     |    3 |           0 |  15 | METERS                   |-------------|
+| DCHG     |    2 |    -8450000 |  25 | METERS**3/SECOND         |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'
+| NOTE     | The mnemonic sequences are same for NC255160 as well              |
+`------------------------------------------------------------------------------'

--- a/doc/bufr_table_samples/mesonet.nc255161.bufr.table.txt
+++ b/doc/bufr_table_samples/mesonet.nc255161.bufr.table.txt
@@ -1,0 +1,97 @@
+.------------------------------------------------------------------------------.
+| ------------   USER DEFINITIONS FOR TABLE-A TABLE-B TABLE D   -------------- |
+|------------------------------------------------------------------------------|
+| MNEMONIC | NUMBER | DESCRIPTION                                              |
+|----------|--------|----------------------------------------------------------|
+|          |        |                                                          |
+| NC255161 | A55161 | MTYP 255-161  Snow data from MADIS: many different prov  |
+|          |        |                                                          |
+| YYMMDD   | 301011 | DATE -- YEAR, MONTH, DAY                                 |
+| HHMM     | 301012 | TIME -- HOUR, MINUTE                                     |
+| RCPTIM   | 352003 | REPORT RECEIPT TIME DATA                                 |
+| FILENAME | 352004 | FILE NAME SEQUENCE                                       |
+| SPRVID   | 350002 | MESONET SUB-PROVIDER ID                                  |
+| MNTOSDSQ | 350018 | MESONET TOTAL SNOW DEPTH SEQUENCE                        |
+| SNSWEMSQ | 350019 | SNOW DATA - SNOW WATER EQUIVALENT SEQUENCE               |
+| MNDOFSSQ | 350017 | MESONET DEPTH OF FRESH SNOW SEQUENCE                     |
+|          |        |                                                          |
+| YEAR     | 004001 | YEAR                                                     |
+| MNTH     | 004002 | MONTH                                                    |
+| DAYS     | 004003 | DAY                                                      |
+| HOUR     | 004004 | HOUR                                                     |
+| MINU     | 004005 | MINUTES                                                  |
+| RCTS     | 008202 | RECEIPT TIME SIGNIFICANCE                                |
+| RCYR     | 004200 | YEAR   - TIME OF RECEIPT                                 |
+| RCMO     | 004201 | MONTH  - TIME OF RECEIPT                                 |
+| RCDY     | 004202 | DAY    - TIME OF RECEIPT                                 |
+| RCHR     | 004203 | HOUR   - TIME OF RECEIPT                                 |
+| RCMI     | 004204 | MINUTE - TIME OF RECEIPT                                 |
+| SPRVSTG  | 058010 | MESONET SUBPROVIDER ID STRING                            |
+| FNSTG    | 050002 | FILE NAME STRING                                         |
+| QCD      | 033220 | FSL "QC DATA" FLAG                                       |
+| QCA      | 033221 | FSL "QC APPLIED" FLAG                                    |
+| QCR      | 033222 | FSL "QC RESULTS" FLAG                                    |
+| RPID     | 001198 | REPORT IDENTIFIER                                        |
+| CLATH    | 005001 | LATITUDE (HIGH ACCURACY)                                 |
+| CLONH    | 006001 | LONGITUDE (HIGH ACCURACY)                                |
+| SELV     | 007001 | HEIGHT OF STATION                                        |
+| SRMK     | 013228 | SNOW REPORT REMARKS                                      |
+| TOSD     | 013013 | TOTAL SNOW DEPTH                                         |
+| TPHR     | 004024 | TIME PERIOD OR DISPLACEMENT                              |
+| SWEM     | 013210 | SNOW WATER EQUIVALENT                                    |
+| DOFS     | 013012 | DEPTH OF FRESH SNOW                                      |
+|          |        |                                                          |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SEQUENCE                                                          |
+|----------|-------------------------------------------------------------------|
+|          |                                                                   |
+| NC255161 | YEAR  MNTH  DAYS  HOUR  MINU  {RCPTIM}  RPID  {SPRVID}  CLATH     |
+| NC255161 | CLONH  SELV  SRMK  {FILENAME}  <MNTOSDSQ>  {SNSWEMSQ}  {MNDOFSSQ} |
+|          |                                                                   |
+| YYMMDD   | YEAR  MNTH  DAYS                                                  |
+|          |                                                                   |
+| HHMM     | HOUR  MINU                                                        |
+|          |                                                                   |
+| RCPTIM   | RCTS  RCYR  RCMO  RCDY  RCHR  RCMI                                |
+|          |                                                                   |
+| SPRVID   | SPRVSTG                                                           |
+|          |                                                                   |
+| FILENAME | FNSTG                                                             |
+|          |                                                                   |
+| MNTOSDSQ | TOSD  QCD  QCA  QCR                                               |
+|          |                                                                   |
+| SNSWEMSQ | TPHR  SWEM  QCD  QCA  QCR                                         |
+|          |                                                                   |
+| MNDOFSSQ | TPHR  DOFS  QCD  QCA  QCR                                         |
+|          |                                                                   |
+|------------------------------------------------------------------------------|
+| MNEMONIC | SCAL | REFERENCE   | BIT | UNITS                    |-------------|
+|----------|------|-------------|-----|--------------------------|-------------|
+|          |      |             |     |                          |-------------|
+| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|
+| MNTH     |    0 |           0 |   4 | MONTH                    |-------------|
+| DAYS     |    0 |           0 |   6 | DAY                      |-------------|
+| HOUR     |    0 |           0 |   5 | HOUR                     |-------------|
+| MINU     |    0 |           0 |   6 | MINUTES                  |-------------|
+| RCTS     |    0 |           0 |   6 | CODE TABLE               |-------------|
+| RCYR     |    0 |           0 |  12 | YEAR                     |-------------|
+| RCMO     |    0 |           0 |   4 | MONTH                    |-------------|
+| RCDY     |    0 |           0 |   6 | DAY                      |-------------|
+| RCHR     |    0 |           0 |   5 | HOUR                     |-------------|
+| RCMI     |    0 |           0 |   6 | MINUTE                   |-------------|
+| SPRVSTG  |    0 |           0 |  64 | CCITT IA5                |-------------|
+| FNSTG    |    0 |           0 |  64 | CCITT IA5                |-------------|
+| QCD      |    0 |           0 |   8 | CCITT IA5                |-------------|
+| QCA      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| QCR      |    0 |           0 |  11 | FLAG TABLE               |-------------|
+| RPID     |    0 |           0 |  64 | CCITT IA5                |-------------|
+| CLATH    |    5 |    -9000000 |  25 | DEGREES                  |-------------|
+| CLONH    |    5 |   -18000000 |  26 | DEGREES                  |-------------|
+| SELV     |    0 |        -400 |  15 | METERS                   |-------------|
+| SRMK     |    0 |           0 |   3 | CODE TABLE               |-------------|
+| TOSD     |    2 |          -2 |  16 | METERS                   |-------------|
+| TPHR     |    0 |       -2048 |  12 | HOUR                     |-------------|
+| SWEM     |    2 |           0 |  18 | KG/(M**2)                |-------------|
+| DOFS     |    2 |          -2 |  12 | METERS                   |-------------|
+|          |      |             |     |                          |-------------|
+`------------------------------------------------------------------------------'


### PR DESCRIPTION
## Description

This PR provides BUFR tables for each Mesonet data subset, which are described below:

- NC255001 --> MTYP 255-001  Mesonet from MADIS: Denver Urban Drainage  
- NC255002 --> MTYP 255-002  Mesonet from MADIS: RAWS (NIFC)            
- NC255003 --> MTYP 255-003  Mesonet from MADIS: MesoWest (many subpr)  
- NC255004 --> MTYP 255-004  Mesonet from MADIS: APRS WeatherNet        
- NC255005 --> MTYP 255-005  Mesonet from MADIS: Kansas DOT             
- NC255006 --> MTYP 255-006  Mesonet from MADIS: Florida                
- NC255007 --> MTYP 255-007  Mesonet from MADIS: Iowa DOT               
- NC255008 --> MTYP 255-008  Mesonet from MADIS: Minnesota DOT          
- NC255009 --> MTYP 255-009  Mesonet from MADIS: Anything Weather       
- NC255010 --> MTYP 255-010  Mesonet from MADIS: NOS PORTS              
- NC255011 --> MTYP 255-011  Mesonet from MADIS: Aberdeen Proving Grds  
- NC255012 --> MTYP 255-012  Mesonet from MADIS: Weather for You        
- NC255013 --> MTYP 255-013  Mesonet from MADIS: NWS Cooperative Obs    
- NC255014 --> MTYP 255-014  Mesonet from MADIS: NWS HADS               
- NC255015 --> MTYP 255-015  Mesonet from MADIS: AWS                    
- NC255016 --> MTYP 255-016  Mesonet from MADIS: Iowa Environmental     
- NC255017 --> MTYP 255-017  Mesonet from MADIS: Oklahoma               
- NC255018 --> MTYP 255-018  Mesonet from MADIS: Colorado DOT           
- NC255019 --> MTYP 255-019  Mesonet from MADIS: West Texas             
- NC255020 --> MTYP 255-020  Mesonet from MADIS: Wisconsin DOT          
- NC255021 --> MTYP 255-021  Mesonet from MADIS: LSU-JSU                
- NC255022 --> MTYP 255-022  Mesonet from MADIS: Colorado E-470         
- NC255023 --> MTYP 255-023  Mesonet from MADIS: DC Net                 
- NC255024 --> MTYP 255-024  Mesonet from MADIS: Indiana DOT            
- NC255025 --> MTYP 255-025  Mesonet from MADIS: Florida DOT            
- NC255026 --> MTYP 255-026  Mesonet from MADIS: Alaska DOT             
- NC255027 --> MTYP 255-027  Mesonet from MADIS: Georgia DOT            
- NC255028 --> MTYP 255-028  Mesonet from MADIS: Virginia DOT           
- NC255029 --> MTYP 255-029  Mesonet from MADIS: MO Comm Agric. Wx Net  
- NC255030 --> MTYP 255-030  Mesonet from MADIS: other than above       
- NC255031 --> MTYP 255-031  Urbanet from MADIS: UrbaNet                
- NC255032 --> MTYP 255-032  Urbanet from MADIS: USouthAL               
- NC255101 --> MTYP 255-101  Coop from MADIS: NEPP &  HCN-Modrnzd- NOA  
- NC255102 --> MTYP 255-102  Coop from SHEF fmt: All NWS Coop Obs       
- NC255111 --> MTYP 255-111  Mesonet from MADIS: Climate Refrnce Netwk  
- NC255131 --> MTYP 255-131  Hydro from MADIS: Denver Urban Drainage    
- NC255160 --> MTYP 255-160  Hydro from MADIS: other than above         
- NC255161 --> MTYP 255-161  Snow data from MADIS: many different prov  

**New BUFR tables:** 
There are a total of thirty-eight mesonet subsets. A total of six BUFR tables are created to cover all of these subsets.  The following six files are added to the following directory: /doc/bufr_table_samples

- mesonet.nc255001.bufr.table.txt (for first 32 subsets nc255001 - nc255032)
- mesonet.nc255101.bufr.table.txt
- mesonet.nc255102.bufr.table.txt
- mesonet.nc255111.bufr.table.txt
- mesonet.nc255131.bufr.table.txt (for subsets nc255131 and nc255160)
- mesonet.nc255161.bufr.table.txt

Information for the mnemonics, units, and their descriptions, etc. is provided. 

### Issue(s) addressed
The following issue is addressed partially #1132, which belongs to the OBS Team pipeline. 

## Acceptance Criteria (Definition of Done)
It will be done once all-important mnemonics are determined and documented.

## Dependencies
None

## Impact
None
