### PR TITLE
Ctest for the existing bufr_ncep_adpupa.yaml

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/gdas.t00z.atms.tm00.bufr_d
     testinput/gdas.t12z.esmhs.tm00.bufr_d
     testinput/gdas.t12z.mtiasi.tm00.bufr_d
+    testinput/gdas.t12z.adpupa.tm00.bufr_d
     testinput/gdas.t18z.1bmhs.tm00.bufr_d
     testinput/gdas.t00z.1bhrs4.tm00.bufr_d
     testinput/gdas.t00z.sevcsr.tm00.bufr_d
@@ -222,6 +223,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/bufr_simple_groupby.yaml
     testinput/bufr_empty_fields.yaml
     testinput/bufr_sfcshp.yaml
+    testinput/bufr_ncep_adpupa.yaml
     testinput/adpupa_prepbufr.yaml
     testinput/aircar_BUFR2ioda.yaml
     testinput/gdas.aircar.t00z.20210801.bufr
@@ -270,6 +272,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/gdas.t12z.1bmhs.metop-b.tm00.nc
     testoutput/gdas.t12z.esmhs.noaa-19.tm00.nc
     testoutput/gdas.t12z.adpsfc.prepbufr.nc
+    testoutput/gdas.t12z.adpupa_bufr.tm00.nc
     testoutput/gdas.t12z.adpsfc.tm00.nc
     testoutput/gdas.t06z.adpsfc_snow.tm00.nc
     testoutput/gdas.t12z.aircar.tm00.nc
@@ -1432,6 +1435,15 @@ if(iodaconv_bufr_ENABLED)
                             netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/adpupa_prepbufr.yaml"
                     adpupa_prepbufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_adpupa2ioda
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_adpupa.yaml"
+                            gdas.t12z.adpupa_bufr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_sevcsr

--- a/test/testinput/bufr_ncep_adpupa.yaml
+++ b/test/testinput/bufr_ncep_adpupa.yaml
@@ -7,7 +7,7 @@ observations:
   - obs space:
       name: bufr
 
-      obsdatain: "./gdas.t12z.adpupa.tm00.bufr_d"
+      obsdatain: "./testinput/gdas.t12z.adpupa.tm00.bufr_d"
 
       exports:
         group_by_variable: pressure
@@ -58,7 +58,7 @@ observations:
 
     ioda:
       backend: netcdf
-      obsdataout: "../testoutput/gdas.t12z.adpupa_bufr.tm00.nc"
+      obsdataout: "./testrun/gdas.t12z.adpupa_bufr.tm00.nc"
 
       dimensions:
         - name: RadiosondeReportLevelData


### PR DESCRIPTION
## Description
There was no ctest in ioda-converets for the existing ADPUPA BUFR YAML, bufr_ncep_adpupa.yaml. This PR adds a new ctest, test_iodaconv_bufr_ncep_adpupa2ioda, for this YAML. 

### Issue(s) addressed
- fixes #1183 

## Acceptance Criteria (Definition of Done)
The ctest should pass.

## Dependencies
merge #1174  first

## Impact
None
