### PR TITLE
Save observational errors, subtype, duplicate factor from GEOS tests.

### DIFF
--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -940,11 +940,11 @@ class Conv(BaseGSI):
                                 tmp[tmp > 4e4] = self.INT_FILL
                             else:
                                 if value != 'GsiAdjustObsError' and value != 'GsiInputObsError':
-                                   tmp[tmp > 4e8] = self.FLOAT_FILL
+                                    tmp[tmp > 4e8] = self.FLOAT_FILL
                             outdata[gvname] = tmp
                             if gvname[1] != 'PreUseFlag' and gvname[1] != 'ObsType' and gvname[1] != 'GsiUseFlag' and gvname[1] != 'GsiQCWeight':
                                 varAttrs[gvname]['units'] = units_values[gvname[0]]
-                    # if Error_Adjust exists, save it as GsiAdjustObsError. 
+                    # if Error_Adjust exists, save it as GsiAdjustObsError.
                     for key, value in gsivars.items():
                         if key in self.df.variables:
                             df_key = self.var(key)

--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -181,13 +181,11 @@ conv_gsivarnames = {
 
 gsi_add_vars_allsky = {
     'Observation_Type': 'ObsType',
-    'Observation_Subtype': 'ObsSubType',
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
-    'Error_Adjust': 'GsiAdjustObsError',
+    'Errinv_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
-    'Error_input': 'GsiInputObsError',
     'Forecast_adjusted': 'GsiHofXBc',
     'Forecast_unadjusted': 'GsiHofX',
     'Forecast_unadjusted_clear': 'GsiHofXClr',
@@ -208,7 +206,8 @@ gsi_add_qcvars_allsky = {
     'Inverse_Observation_Error_sdoei': 'GsiObsError_sdoei',
     'Inverse_Observation_Error_grosschk': 'GsiObsError_grosschk',
 }
-
+# Save Errinv_Input and Errinv_Adjust if Error_Input and Error_Adjust
+# are unavailable in GSI nc_diag files, respectively.
 gsi_add_vars = {
     'ObsBias': 'GsiObsBias',
     'Observation_Type': 'ObsType',
@@ -216,8 +215,10 @@ gsi_add_vars = {
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
+    'Errinv_Adjust': 'GsiAdjustObsError',
     'Error_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
+    'Errinv_Input': 'GsiInputObsError',
     'Error_Input': 'GsiInputObsError',
     'Dupobs_Factor': 'Dupobs_Factor',
     'Obs_Minus_Forecast_adjusted': 'GsiHofXBc',
@@ -251,8 +252,10 @@ gsi_add_vars_uv = {
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
+    'Errinv_Adjust': 'GsiAdjustObsError',
     'Error_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
+    'Errinv_Input': 'GsiInputObsError',
     'Error_Input': 'GsiInputObsError',
     'Dupobs_Factor': 'Dupobs_Factor',
     'u_Forecast_adjusted': 'GsiHofXBc',
@@ -941,6 +944,14 @@ class Conv(BaseGSI):
                             outdata[gvname] = tmp
                             if gvname[1] != 'PreUseFlag' and gvname[1] != 'ObsType' and gvname[1] != 'GsiUseFlag' and gvname[1] != 'GsiQCWeight':
                                 varAttrs[gvname]['units'] = units_values[gvname[0]]
+                    # if Error_Adjust exists, save it as GsiAdjustObsError. 
+                    for key, value in gsivars.items():
+                        if key in self.df.variables:
+                            df_key = self.var(key)
+                            gvname = outvars[o], value
+                            if "Error_Adjust" in key:
+                                tmp = df_key[idx]
+                                outdata[gvname] = tmp
                     # create a GSI effective QC variable
                     gsiqcname = outvars[o], 'GsiEffectiveQC'
                     errname = outvars[o], 'GsiFinalObsError'

--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -181,11 +181,13 @@ conv_gsivarnames = {
 
 gsi_add_vars_allsky = {
     'Observation_Type': 'ObsType',
+    'Observation_Subtype': 'ObsSubType',
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
-    'Errinv_Adjust': 'GsiAdjustObsError',
+    'Error_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
+    'Error_input': 'GsiInputObsError',
     'Forecast_adjusted': 'GsiHofXBc',
     'Forecast_unadjusted': 'GsiHofX',
     'Forecast_unadjusted_clear': 'GsiHofXClr',
@@ -210,11 +212,14 @@ gsi_add_qcvars_allsky = {
 gsi_add_vars = {
     'ObsBias': 'GsiObsBias',
     'Observation_Type': 'ObsType',
+    'Observation_Subtype': 'ObsSubType',
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
-    'Errinv_Adjust': 'GsiAdjustObsError',
+    'Error_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
+    'Error_Input': 'GsiInputObsError',
+    'Dupobs_Factor': 'Dupobs_Factor',
     'Obs_Minus_Forecast_adjusted': 'GsiHofXBc',
     'Obs_Minus_Forecast_unadjusted': 'GsiHofX',
     'Forecast_adjusted': 'GsiHofXBc',
@@ -242,12 +247,14 @@ gsi_add_qcvars = {
 
 gsi_add_vars_uv = {
     'Observation_Type': 'ObsType',
+    'Observation_Subtype': 'ObsSubType',
     'Prep_Use_Flag': 'PreUseFlag',
     'Analysis_Use_Flag': 'GsiUseFlag',
     'Nonlinear_QC_Rel_Wgt': 'GsiQCWeight',
-    'Errinv_Adjust': 'GsiAdjustObsError',
+    'Error_Adjust': 'GsiAdjustObsError',
     'Errinv_Final': 'GsiFinalObsError',
-    'Errinv_Input': 'GsiInputObsError',
+    'Error_Input': 'GsiInputObsError',
+    'Dupobs_Factor': 'Dupobs_Factor',
     'u_Forecast_adjusted': 'GsiHofXBc',
     'u_Forecast_unadjusted': 'GsiHofX',
     'v_Forecast_adjusted': 'GsiHofXBc',
@@ -273,6 +280,7 @@ gsiint = [
     'PreUseFlag',
     'GsiUseFlag',
     'ObsType',
+    'ObsSubType',
     'Observation_Subtype',
     'observationTypeNum',
     'observationSubTypeNum',
@@ -411,6 +419,7 @@ geovals_vars = {
     'seas4': 'seas4',
     'dbzges': 'equivalent_reflectivity_factor',
     'upward_air_velocity': 'upward_air_velocity',
+    'dup_kx_vector': 'dup_kx_vector',
 }
 
 obsdiag_vars = {
@@ -862,13 +871,17 @@ class Conv(BaseGSI):
                         if np.median(obsdata) < 1100.:
                             obsdata = obsdata * 100.  # convert to Pa from hPa
                         obsdata[obsdata > 4e8] = self.FLOAT_FILL  # 1e11 is fill value for surface_pressure
-                    obserr = self.var('Errinv_Input')[idx]
-                    mask = obserr < self.EPSILON
-                    obserr[~mask] = 1.0 / obserr[~mask]
-                    # below is a temporary hack until missing ObsError support returns to IODA/UFO
-                    obserr[mask] = 1e8
-                    # obserr[mask] = self.FLOAT_FILL
-                    # obserr[obserr > 4e8] = self.FLOAT_FILL
+                    try:
+                        # All original observation errors are saved as "Error_Input". J.Jin 10/24/2022.
+                        obserr = self.var('Error_Input')[idx]
+                    except BaseException:
+                        obserr = self.var('Errinv_Input')[idx]
+                        mask = obserr < self.EPSILON
+                        obserr[~mask] = 1.0 / obserr[~mask]
+                        # below is a temporary hack until missing ObsError support returns to IODA/UFO
+                        obserr[mask] = 1e8
+                        # obserr[mask] = self.FLOAT_FILL
+                        # obserr[obserr > 4e8] = self.FLOAT_FILL
                     # convert surface_pressure error to Pa from hPa
                     if v == 'ps' and np.nanmin(obserr) < 10:
                         obserr = obserr * 100
@@ -923,7 +936,8 @@ class Conv(BaseGSI):
                                 tmp = tmp.astype(np.int32)
                                 tmp[tmp > 4e4] = self.INT_FILL
                             else:
-                                tmp[tmp > 4e8] = self.FLOAT_FILL
+                                if value != 'GsiAdjustObsError' and value != 'GsiInputObsError':
+                                   tmp[tmp > 4e8] = self.FLOAT_FILL
                             outdata[gvname] = tmp
                             if gvname[1] != 'PreUseFlag' and gvname[1] != 'ObsType' and gvname[1] != 'GsiUseFlag' and gvname[1] != 'GsiQCWeight':
                                 varAttrs[gvname]['units'] = units_values[gvname[0]]

--- a/test/testoutput/satwind_obs_2018041500.nc4
+++ b/test/testoutput/satwind_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef098e6c8d12f6ac41b9068f8b3164bcc352ca2ddec18923a2b63f7dfd4737b7
-size 53661
+oid sha256:99aad05a8f6540ec1a2ebdca13ad805979c191d53b39162d1eb4231048f505e6
+size 55526

--- a/test/testoutput/sfc_tv_obs_2018041500.nc4
+++ b/test/testoutput/sfc_tv_obs_2018041500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:818f83e72837622382a3c0118ff0da34185abf50e57fee6d6efbc14bdebaff8c
-size 28567
+oid sha256:4f83c7ea1f3ba5abfddf19059bb480a5a3ef5647d99868a1b7b5232fcef70e8e
+size 29574


### PR DESCRIPTION
Save GsiInputObsError, GsiAdjustObsError,ObsSubType, Dupobs_Factor, and dup_kx_vector which contains ObsType (kx) numbers for duplicated observations.  These values are used in GMAO's JEDI/UFO configurations and tests.