### PR TITLE
Longitude/latitude displacement addition to the high-resolution radiosonde YAML

### DIFF
--- a/test/testinput/bufr_ncep_highRes_sonde.yaml
+++ b/test/testinput/bufr_ncep_highRes_sonde.yaml
@@ -26,12 +26,8 @@ observations:
             query: "*/RPID"
           latitude:
             query: "*/CLATH"
-          levelLatitudeDisplacement:
-            query: "*/UARLVB/LATDH"
           longitude:
             query: "*/CLONH"
-          levelLongitudeDisplacement:
-            query: "*/UARLVB/LONDH"
           stationElevation:
             query: "*/HSMSL"
           stationWIGOSId:
@@ -90,24 +86,10 @@ observations:
           units: "degree_north"
           range: [-90, 90]
 
-        - name: "MetaData/levelLatitudeDisplacement"
-          coordinates: "longitude latitude"
-          source: variables/levelLatitudeDisplacement
-          longName: "Latitude Displacement"
-          units: "degree_north"
-          range: [-90, 90]
-
         - name: "MetaData/longitude"
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degree_east"
-          range: [-180, 180]
-
-        - name: "MetaData/levelLongitudeDisplacement"
-          coordinates: "longitude latitude"
-          source: variables/levelLongitudeDisplacement
-          longName: "Longitude Displacement"
           units: "degree_east"
           range: [-180, 180]
 

--- a/test/testinput/bufr_ncep_highRes_sonde.yaml
+++ b/test/testinput/bufr_ncep_highRes_sonde.yaml
@@ -26,8 +26,12 @@ observations:
             query: "*/RPID"
           latitude:
             query: "*/CLATH"
+          levelLatitudeDisplacement:
+            query: "*/UARLVB/LATDH"
           longitude:
             query: "*/CLONH"
+          levelLongitudeDisplacement:
+            query: "*/UARLVB/LONDH"
           stationElevation:
             query: "*/HSMSL"
 
@@ -36,7 +40,7 @@ observations:
             query: "*/UARLVB/PRLC"
           airTemperature:
             query: "*/UARLVB/UATMP/TMDB"
-          dewpointTemperature:
+          dewPointTemperature:
             query: "*/UARLVB/UATMP/TMDP"
           windDirection:
             query: "*/UARLVB/UAWND/WDIR"
@@ -54,7 +58,7 @@ observations:
             query: "*/UARLVB/QMPR"
           airTemperatureQM:
             query: "*/UARLVB/UATMP/QMAT"
-          dewpointTemperatureQM:
+          dewPointTemperatureQM:
             query: "*/UARLVB/UATMP/QMDD"
           windSpeedQM:
             query: "*/UARLVB/UAWND/QMWN"
@@ -84,10 +88,24 @@ observations:
           units: "degree_north"
           range: [-90, 90]
 
+        - name: "MetaData/levelLatitudeDisplacement"
+          coordinates: "longitude latitude"
+          source: variables/levelLatitudeDisplacement
+          longName: "Latitude Displacement"
+          units: "degree_north"
+          range: [-90, 90]
+
         - name: "MetaData/longitude"
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/levelLongitudeDisplacement"
+          coordinates: "longitude latitude"
+          source: variables/levelLongitudeDisplacement
+          longName: "Longitude Displacement"
           units: "degree_east"
           range: [-180, 180]
 
@@ -110,9 +128,9 @@ observations:
           longName: "Air Temperature"
           units: "K"
 
-        - name: "ObsValue/dewpointTemperature"
+        - name: "ObsValue/dewPointTemperature"
           coordinates: "longitude latitude"
-          source: variables/dewpointTemperature
+          source: variables/dewPointTemperature
           longName: "Dewpoint Temperature"
           units: "K"
 
@@ -151,9 +169,9 @@ observations:
           source: variables/airTemperatureQM
           longName: "Quality Indicator for Temperature"
 
-        - name: "QualityMarker/dewpointTemperature"
+        - name: "QualityMarker/dewPointTemperature"
           coordinates: "longitude latitude"
-          source: variables/dewpointTemperatureQM
+          source: variables/dewPointTemperatureQM
           longName: "Quality Indicator for Moisture"
 
         - name: "QualityMarker/windSpeed"

--- a/test/testinput/bufr_ncep_highRes_sonde.yaml
+++ b/test/testinput/bufr_ncep_highRes_sonde.yaml
@@ -34,6 +34,8 @@ observations:
             query: "*/UARLVB/LONDH"
           stationElevation:
             query: "*/HSMSL"
+          stationWIGOSId:
+            query: "*/WGOSLID"
 
           # ObsValue
           pressure:
@@ -114,6 +116,11 @@ observations:
           source: variables/stationElevation
           longName: "Station Elevation"
           units: "m"
+
+        - name: "MetaData/stationWIGOSId"
+          coordinates: "longitude latitude"
+          source: variables/stationWIGOSId
+          longName: "WIGOS Station Identifier"
 
         # ObsValue
         - name: "ObsValue/pressure"

--- a/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
+++ b/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e93dd069a0aa417e6e14ede319c7f1f62d47547e8d35acd40d070ce1b73f6b7d
-size 1941676
+oid sha256:b1f73dd60ae1b8b725e04b744f7d1355f90974ba208be85fd3eb3147883ae57d
+size 1984936

--- a/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
+++ b/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba867f8c514f6e13a03f04eaa5786b7bd5a5b2511333f833968cb25f35db8283
-size 3647573
+oid sha256:28fc9a64ab3f16b48254ac5ed70ec5ba39eb548fa7ddf6966056b6fd173cd1e0
+size 3604074

--- a/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
+++ b/test/testoutput/gdas.t12z.adpupa_bufr_nc002103.tm00.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1f73dd60ae1b8b725e04b744f7d1355f90974ba208be85fd3eb3147883ae57d
-size 1984936
+oid sha256:ba867f8c514f6e13a03f04eaa5786b7bd5a5b2511333f833968cb25f35db8283
+size 3647573


### PR DESCRIPTION
## Description

This PR adds the longitude/latitude displacement and WIGOSID to the existing high-resolution radiosonde YAML, which is required by both global and regional users, and also replaces dewpointTemperature with dewPointTemperature.

### Issue(s) addressed

This PR partially addresses the following issue #1184. 

## Acceptance Criteria (Definition of Done)

Good reviews and pass the ctest.

## Dependencies

None

## Impact

None
