### PR TITLE
Fix retrieval surface and obs error in viirs_aod2ioda.py

### DIFF
--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -126,7 +126,7 @@ class AOD(object):
 
             # defined surface type and uncertainty
             if self.method == "nesdis":
-                errs[:] = 0.111431 + 0.128699*vals    # over land (dark)
+                errs = 0.111431 + 0.128699*vals    # over land (dark)
                 errs[qcpath % 2 == 1] = 0.00784394 + 0.219923*vals[qcpath % 2 == 1]  # over ocean
                 errs[qcpath % 4 == 2] = 0.0550472 + 0.299558*vals[qcpath % 4 == 2]   # over bright land
 

--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -126,9 +126,9 @@ class AOD(object):
 
             # defined surface type and uncertainty
             if self.method == "nesdis":
-                errs = 0.00784394 + 0.219923*vals
-                errs[qcpath == 1] = 0.0550472 + 0.299558*vals[qcpath == 1]
-                errs[qcpath != 1] = 0.111431 + 0.128699*vals[qcpath != 1]
+                errs[:] = 0.111431 + 0.128699*vals    # over land (dark)
+                errs[qcpath % 2 == 1] = 0.00784394 + 0.219923*vals[qcpath % 2 == 1]  # over ocean
+                errs[qcpath % 4 == 2] = 0.0550472 + 0.299558*vals[qcpath % 4 == 2]   # over bright land
 
             #  Write out data
             self.outdata[('latitude', metaDataName)] = np.append(self.outdata[('latitude', metaDataName)], np.array(lats, dtype=np.float32))

--- a/test/testoutput/viirs_aod.nc
+++ b/test/testoutput/viirs_aod.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcdb3fa827b1bfa1fd923e087c6f030df7c4791043ea644055506718dece68b1
+oid sha256:b20ef47567288c23913bd1768e4cb39c061e584b39a076af5d16e6b01a1e9508
 size 14272


### PR DESCRIPTION
## Description

This PR fixed the VIIRS AOD obs error estimation based on retrieval surface (QCPath) in viirs_aod2ioda.py

The QCPath are 8-bit integers and should be interpreted bit by bit. Briefly, if the right most bit equals 1, the data is retrieved from water; if the second right most position equals 1, the data is retrieved from bright land; otherwise (both equal 0), it is from dark land.


### Issue(s) addressed

Link the issues to be closed with this PR
- Correct obs error estimation based on surface type in viirs_aod2ioda.py ##<[1201](https://github.com/JCSDA-internal/ioda-converters/issues/1201)>

## Acceptance Criteria (Definition of Done)

Good reviews.

## Dependencies
None.

## Impact
None.