### PR TITLE
Bugfix/install raob

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ add_subdirectory( src )
 add_subdirectory( tools )
 add_subdirectory( test )
 add_subdirectory( doc )
-
+add_subdirectory( share )
 # Package Config
 
 ecbuild_install_project( NAME ${PROJECT_NAME} )

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+
+install(FILES raob_stations.json raob_stations_small.json DIRECTORY $(CMAKE_INSTALL_DIR)/share)

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 
-install(FILES raob_stations.json raob_stations_small.json DIRECTORY $(CMAKE_INSTALL_DIR)/share)
+install(FILES raob_stations.json raob_stations_small.json DESTINATION ${CMAKE_INSTALL_PREFIX}/share)


### PR DESCRIPTION
## Description

The PR allows the raob data files to be installed when doing make install. The source directory can then be deleted without loss. of functionality.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #1209 


## Acceptance Criteria (Definition of Done)

One should be able to run iodaconv from an installation. 

## Dependencies

None