### PR TITLE
Install pyiodaconv according to python conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,12 @@ include( iodaconv_compiler_flags )
 # Location of .pycodestyle for norm checking within IODA-converters
 set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 
+set(pyver python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
+set(PYDIR ${pyvers}/pyiodaconv)
+
 # Location of installed python iodaconv libraries
-set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/pyiodaconv )
-set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pyiodaconv )
+set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/${PYDIR} )
+set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PYDIR} )
 
 ## Dependencies
 


### PR DESCRIPTION
## Description

This PR will install the python package pyiodaconv in /lib/python{VERSION}/pyiodaconv instead of /lib/pyiodaconv. Doing t
This is reduces settting PYTHON_PATH by one directory and eventually will make skylab as a whole easier to use.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #1211


## Acceptance Criteria (Definition of Done)


Python components are installed correctly without ctests failing for ioda-converters and any downstream packages.


## Dependencies

None