### PR TITLE
Specify C++14 standard for C++ compiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 include( iodaconv_extra_macros )
 include( iodaconv_compiler_flags )
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Location of .pycodestyle for norm checking within IODA-converters
 set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/cmake/compiler_flags_Clang_CXX.cmake
+++ b/cmake/compiler_flags_Clang_CXX.cmake
@@ -7,25 +7,25 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -Wall -Wno-c++11-extensions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g -Wall -Wno-c++14-extensions")
 
 ####################################################################
 # RELEASE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 
 ####################################################################
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_DEBUG "-O0")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0")
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_BIT "-O2")
+set(CMAKE_CXX_FLAGS_BIT "${CMAKE_CXX_FLAGS} -O2 -ffp-model=strict")
 
 ####################################################################
 # LINK FLAGS

--- a/cmake/compiler_flags_GNU_CXX.cmake
+++ b/cmake/compiler_flags_GNU_CXX.cmake
@@ -7,25 +7,25 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -Wall -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g -Wall -Wno-deprecated-declarations")
 
 ####################################################################
 # RELEASE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_FXX_FLAGS} -O3")
 
 ####################################################################
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_DEBUG "-O0")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_FXX_FLAGS} -O0")
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_BIT "-O2")
+set(CMAKE_CXX_FLAGS_BIT "${CMAKE_FXX_FLAGS} -O2 -ffp-model=strict")
 
 ####################################################################
 # LINK FLAGS

--- a/cmake/compiler_flags_Intel_CXX.cmake
+++ b/cmake/compiler_flags_Intel_CXX.cmake
@@ -7,31 +7,31 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14 -g -traceback")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g -traceback")
 
 ####################################################################
 # RELEASE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 
 ####################################################################
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fp-trap=common")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -fp-trap=common")
 
 ####################################################################
 # RELEASE WITH DEBUG INFO (DEFAULT)
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -O2 -DNDEBUG")
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_BIT "-O2")
+set(CMAKE_CXX_FLAGS_BIT "${CMAKE_CXX_FLAGS} -O2")
 
 ####################################################################
 # LINK FLAGS

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -87,9 +87,6 @@ if ( iodaconv_bufr_ENABLED )
                        INSTALL_HEADERS LISTED
     )
 
-  set_property(TARGET atms_lib PROPERTY CXX_STANDARD 14)
-  target_compile_features(atms_lib PUBLIC cxx_std_14)
-
   list(APPEND _ingester_deps
               Eigen3::Eigen
               eckit
@@ -106,9 +103,6 @@ if ( iodaconv_bufr_ENABLED )
                        LINKER_LANGUAGE CXX
     )
 
-  set_property(TARGET ingester PROPERTY CXX_STANDARD 14)
-  target_compile_features(ingester PUBLIC cxx_std_14)
-
   target_link_libraries(ingester PUBLIC ${_ingester_deps})
 
   target_include_directories(ingester PUBLIC
@@ -123,8 +117,6 @@ if ( iodaconv_bufr_ENABLED )
   ecbuild_add_executable( TARGET  bufr2ioda.x
                           SOURCES bufr2ioda.cpp
                           LIBS    ingester )
-  set_property(TARGET bufr2ioda.x PROPERTY CXX_STANDARD 14)
-  target_compile_features(bufr2ioda.x PUBLIC cxx_std_14)
 
   ecbuild_add_test( TARGET  ${PROJECT_NAME}_bufr_coding_norms
                     TYPE    SCRIPT
@@ -183,8 +175,6 @@ if ( iodaconv_bufr_python_ENABLED )
                            ARCHIVE_OUTPUT_DIRECTORY "${PYIODACONV_BUILD_LIBDIR}"
                            LIBRARY_OUTPUT_DIRECTORY "${PYIODACONV_BUILD_LIBDIR}"
     )
-  set_property(TARGET bufr PROPERTY CXX_STANDARD 14)
-  target_compile_features(bufr PUBLIC cxx_std_14)
 
   install (TARGETS bufr DESTINATION ${PYIODACONV_INSTALL_LIBDIR})
 

--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -87,6 +87,9 @@ if ( iodaconv_bufr_ENABLED )
                        INSTALL_HEADERS LISTED
     )
 
+  set_property(TARGET atms_lib PROPERTY CXX_STANDARD 14)
+  target_compile_features(atms_lib PUBLIC cxx_std_14)
+
   list(APPEND _ingester_deps
               Eigen3::Eigen
               eckit
@@ -103,6 +106,9 @@ if ( iodaconv_bufr_ENABLED )
                        LINKER_LANGUAGE CXX
     )
 
+  set_property(TARGET ingester PROPERTY CXX_STANDARD 14)
+  target_compile_features(ingester PUBLIC cxx_std_14)
+
   target_link_libraries(ingester PUBLIC ${_ingester_deps})
 
   target_include_directories(ingester PUBLIC
@@ -117,6 +123,8 @@ if ( iodaconv_bufr_ENABLED )
   ecbuild_add_executable( TARGET  bufr2ioda.x
                           SOURCES bufr2ioda.cpp
                           LIBS    ingester )
+  set_property(TARGET bufr2ioda.x PROPERTY CXX_STANDARD 14)
+  target_compile_features(bufr2ioda.x PUBLIC cxx_std_14)
 
   ecbuild_add_test( TARGET  ${PROJECT_NAME}_bufr_coding_norms
                     TYPE    SCRIPT
@@ -175,6 +183,8 @@ if ( iodaconv_bufr_python_ENABLED )
                            ARCHIVE_OUTPUT_DIRECTORY "${PYIODACONV_BUILD_LIBDIR}"
                            LIBRARY_OUTPUT_DIRECTORY "${PYIODACONV_BUILD_LIBDIR}"
     )
+  set_property(TARGET bufr PROPERTY CXX_STANDARD 14)
+  target_compile_features(bufr PUBLIC cxx_std_14)
 
   install (TARGETS bufr DESTINATION ${PYIODACONV_INSTALL_LIBDIR})
 


### PR DESCRIPTION
## Description

This PR contains cmake configuration changes that explicitly specify using the C++14 standard for C++ compiler calls. This is being done to fix issues with Mac builds where, in some cases, the C++11 standard was being used.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

The feature/query_python branch compiles successfully on the Mac.

## Dependencies

None

## Impact

None
