### PR TITLE
Ioda-converters for the rtma mesonet data 

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,6 +191,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/bufr_sfcshp.bufr
     testinput/ADPUPA.prepbufr
     testinput/gdas.t12z.adpupa_nc002103.tm00.bufr_d
+    testinput/rtma_ru.t00z.msonet.tm00.bufr_d
     testinput/bufr_mhs.yaml
     testinput/bufr_hrs.yaml
     testinput/bufr_query_filtering.yaml
@@ -266,6 +267,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/atms_beamwidth.txt
     testinput/bufr_query_python_test.py
     testinput/bufr_query_python_to_ioda_test.py
+    testinput/bufr_ncep_rtma_mesonet.yaml
   )
 
   list( APPEND test_output
@@ -322,6 +324,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/bufr_query_filtering.nc
     testoutput/bufr_ncep_prepbufr_adpupa.nc
     testoutput/bufr_query_python_to_ioda_test.nc
+    testoutput/rtma_ru.t00z.msonet.tm00.nc
   )
 endif()
 
@@ -1495,6 +1498,15 @@ if(iodaconv_bufr_ENABLED)
                             netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_adpupa.yaml"
                     gdas.t12z.adpupa_bufr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_mesonet2ioda
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_rtma_mesonet.yaml"
+                    rtma_ru.t00z.msonet.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_sevcsr

--- a/test/testinput/bufr_ncep_rtma_mesonet.yaml
+++ b/test/testinput/bufr_ncep_rtma_mesonet.yaml
@@ -1,0 +1,229 @@
+# (C) Copyright 2023 NOAA/NWS/NCEP/EMC
+# 
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/rtma_ru.t00z.msonet.tm00.bufr_d"
+
+      exports:
+        subsets:
+          - NC255002
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+          stationIdentification:
+            query: "*/RPID"
+          latitude:
+            query: "*/CLATH"
+          longitude:
+            query: "*/CLONH"
+          stationElevation:
+            query: "*/SELV"
+          height:
+            query: "*/HSMSL"
+          dataProviderRestricted:
+            query: "*/RSRD"
+          dataRestrictedExpiration:
+            query: "*/EXPRSRD"
+
+
+          # ObsValue/Pressure
+          pressure:
+            query: "*/MNPRESSQ/PRES"
+          altimeterSetting:
+            query: "*/MNALSESQ/ALSE"
+          snowWaterEquivalentRate:
+            query: "*/MNREQVSQ/REQV"
+
+          # ObsValue/Temperature
+          airTemperature:
+            query: "*/MNTMDBSQ/TMDB"
+          dewPointTemperature:
+            query: "*/MNTMDPSQ/TMDP"
+
+          # ObsValue/Wind
+          windDirection:
+            query: "*/MNWDIRSQ/WDIR"
+          windSpeed:
+            query: "*/MNWSPDSQ/WSPD"
+          maximumWindGustDirection:
+            query: "*/MNGUSTSQ/MXGD"
+          maximumWindGustSpeed:
+            query: "*/MNGUSTSQ/MXGS"
+
+          # ObsValue/Humidity
+          totalPrecipitation:
+            query: "*/TOPC"
+
+          # ObsValue/Visibility
+          horizontalVisibility:
+            query: "*/MNHOVISQ/HOVI"
+
+
+          # QualityMarker
+          pressureQM:
+            query: "*/QMPR"
+          airTemperatureQM:
+            query: "*/QMAT"
+          dewPointTemperatureQM:
+            query: "*/QMDD"
+          windSpeedQM:
+            query: "*/QMWN"
+
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/rtma_ru.t00z.msonet.tm00.nc"
+
+
+      variables:
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/stationIdentification"
+          coordinates: "longitude latitude"
+          source: variables/stationIdentification
+          longName: "Station Identification"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/stationElevation"
+          coordinates: "longitude latitude"
+          source: variables/stationElevation
+          longName: "Elevation of Observing Location"
+          units: "m"
+
+        - name: "MetaData/height"
+          coordinates: "longitude latitude"
+          source: variables/height
+          longName: "Height Above Mean Sea Level"
+          units: "m"
+
+        - name: "MetaData/dataProviderRestricted"
+          coordinates: "longitude latitude"
+          source: variables/dataProviderRestricted
+          longName: "Restrictions On Data Redistribution"
+
+        - name: "MetaData/dataRestrictedExpiration"
+          coordinates: "longitude latitude"
+          source: variables/dataRestrictedExpiration
+          longName: "Expiration Of Restrictions On Data Redistribution"
+
+        # ObsValue/Pressure
+        - name: "ObsValue/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/altimeterSetting"
+          coordinates: "longitude latitude"
+          source: variables/altimeterSetting
+          longName: "Altimeter Setting"
+          units: "Pa"
+  
+        - name: "ObsValue/snowWaterEquivalentRate"
+          coordinates: "longitude latitude"
+          source: variables/snowWaterEquivalentRate
+          longName: "Snow Water Equivalent Rate"
+          units: "kg m-2 s-1"
+
+        # ObsValue/Temperature
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          longName: "Air Temperature"
+          units: "K"
+
+        - name: "ObsValue/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperature
+          longName: "Dewpoint Temperature"
+          units: "K"
+
+        # ObsValue/Wind
+        - name: "ObsValue/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          longName: "Wind Direction"
+          units: "degree"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          longName: "Wind Speed"
+          units: "m s-1"
+
+        - name: "ObsValue/maximumWindGustDirection"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustDirection
+          longName: "Maximum Wind Gust Direction"
+          units: "degree"
+
+        - name: "ObsValue/maximumWindGustSpeed"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustSpeed
+          longName: "Maximum Wind Gust Speed"
+          units: "m s-1"
+
+        # ObsValue/Humidity
+        - name: "ObsValue/totalPrecipitation"
+          coordinates: "longitude latitude"
+          source: variables/totalPrecipitation
+          longName: "Total Precipitation"
+          units: "kg m-2"
+
+        # ObsValue/Visibility
+        - name: "ObsValue/horizontalVisibility"
+          coordinates: "longitude latitude"
+          source: variables/horizontalVisibility
+          longName: "Horizontal Visibility"
+          units: "m"
+
+        # QualityMarker
+        - name: "QualityMarker/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressureQM
+          longName: "Quality Indicator for Pressure"
+
+        - name: "QualityMarker/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureQM
+          longName: "Quality Indicator for Temperature"
+
+        - name: "QualityMarker/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperature
+          longName: "Quality Indicator for Moisture"
+
+        - name: "QualityMarker/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeedQM
+          longName: "Quality Indicator for Wind"
+

--- a/test/testinput/rtma_ru.t00z.msonet.tm00.bufr_d
+++ b/test/testinput/rtma_ru.t00z.msonet.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4810b10e2ba1e70f3b2aaac804ce694e3315c946ea4d3bbe9478c397e0daf385
+size 107464

--- a/test/testoutput/rtma_ru.t00z.msonet.tm00.nc
+++ b/test/testoutput/rtma_ru.t00z.msonet.tm00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e48a83d18f36588f1d2f10ede754c287cb99d204a3d829ae8a88d6fd6bba56
+size 123499


### PR DESCRIPTION
## Description

This PR adds an ioda-converters for the [3D]RTMA mesonet data using the following three files: 

- testinput/bufr_ncep_rtma_mesonet.yaml
- testinput/rtma_ru.t00z.msonet.tm00.bufr_d
- testoutput/rtma_ru.t00z.msonet.tm00.nc

This YAML will serve for the following mesonet subsets: 
255001 255002 255003 255004 255005 255006 255007 255008 255009 255010 255011 255012 255014 255015 255016 255017 255018 255019 255020 255021 255022 255023 255024 255025 255026 255027 255028 255029 255030 255031 255101

### Issue(s) addressed

Link the issues to be closed with this PR
- #1132
- #1191
- 
## Acceptance Criteria (Definition of Done)

- Good reviews
- Validation of the output results, which are performed in #1191 
- _ioda-validate.x_, the following results were obtained using ObsSpace.ymal from #https://github.com/JCSDA-internal/ioda/pull/986
Final results:
errors:      0
warnings:    0

## Dependencies

There are no dependencies.

## Impact

None
