### PR TITLE
Improved BUFR python example (IODA vars need params)

### DIFF
--- a/test/testinput/bufr_query_python_to_ioda_test.py
+++ b/test/testinput/bufr_query_python_to_ioda_test.py
@@ -31,6 +31,19 @@ def test_bufr_to_ioda():
 
 
     # Write the data to an IODA file
+
+    # Create the variable creation parameters. Make sure to set the fill value and set one on
+    # each variable. Otherwise, the "missing" will be set to 0.0.
+
+    pfloat = ioda.VariableCreationParameters()
+    pfloat.setFillValue.float(rad.fill_value)
+    pfloat.compressWithGZIP()
+
+    # pint = ioda.VariableCreationParameters()
+    # pint.setFillValue.int(int_var.fill_value)
+    # pint.compressWithGZIP()
+
+
     g = ioda.Engines.HH.createFile(name=OUTPUT_PATH,
                                    mode=ioda.Engines.BackendCreateModes.Truncate_If_Exists)
 
@@ -45,21 +58,17 @@ def test_bufr_to_ioda():
     dim_channel.scales.setIsScale('Channel')
 
     # Create the variables
-    longitude = g.vars.create('MetaData/Longitude', ioda.Types.float, scales=[dim_location])
+    longitude = g.vars.create('MetaData/Longitude', ioda.Types.float, scales=[dim_location], params=pfloat)
     longitude.atts.create('valid_range', ioda.Types.float, [2]).writeVector.float([-180, 180])
     longitude.atts.create('units', ioda.Types.str).writeVector.str(['degrees_east'])
     longitude.atts.create('long_name', ioda.Types.str).writeVector.str(['Longitude'])
 
-    latitude = g.vars.create('MetaData/Latitude', ioda.Types.float,  scales=[dim_location])
+    latitude = g.vars.create('MetaData/Latitude', ioda.Types.float,  scales=[dim_location], params=pfloat)
     latitude.atts.create('valid_range', ioda.Types.float, [2]).writeVector.float([-90, 90])
     latitude.atts.create('units', ioda.Types.str).writeVector.str(['degrees_north'])
     latitude.atts.create('long_name', ioda.Types.str).writeVector.str(['Latitude'])
 
-    p1 = ioda.VariableCreationParameters()
-    p1.setFillValue.float(rad.fill_value)
-    p1.compressWithGZIP()
-
-    tb = g.vars.create('ObsValue/brightnessTemperature', ioda.Types.float, scales=[dim_location, dim_channel], params=p1)
+    tb = g.vars.create('ObsValue/brightnessTemperature', ioda.Types.float, scales=[dim_location, dim_channel], params=pfloat)
     tb.atts.create('valid_range', ioda.Types.float, [2]).writeVector.float([100, 500])
     tb.atts.create('units', ioda.Types.str).writeVector.str(['K'])
     tb.atts.create('long_name', ioda.Types.str).writeVector.str(['ATMS Observed (Uncorrected) Brightness Temperature'])

--- a/test/testinput/bufr_query_python_to_ioda_test.py
+++ b/test/testinput/bufr_query_python_to_ioda_test.py
@@ -39,6 +39,8 @@ def test_bufr_to_ioda():
     pfloat.setFillValue.float(rad.fill_value)
     pfloat.compressWithGZIP()
 
+    # Create a separate paremeter for each type you need to use
+
     # pint = ioda.VariableCreationParameters()
     # pint.setFillValue.int(int_var.fill_value)
     # pint.compressWithGZIP()

--- a/test/testoutput/bufr_query_python_to_ioda_test.nc
+++ b/test/testoutput/bufr_query_python_to_ioda_test.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e4eea0a127b20ae9ac0404280a20a7d7c97b7532f7f19d306b32dbdbf10431c
-size 322240
+oid sha256:e9277046583c3662d85dcd256f60045e78d6e34a728e7d800892ba31a2f1e9d5
+size 314066


### PR DESCRIPTION
## Description

This pull request improves an testinput BUFR python example that writes data into an IODA Netcdf4 file. It turns out that if you don't set the parameter on each variable it (ioda) will pick **0** to represent the fill_value (treated as missing value by Netcdf). 

**Note**: this pull request only affects an example test file and associated output data.

## Associated Bug
https://github.com/JCSDA-internal/ioda/issues/989