### PR TITLE
Validate field names in ResultSet::get

### DIFF
--- a/src/bufr/BufrParser/Query/ResultSet.cpp
+++ b/src/bufr/BufrParser/Query/ResultSet.cpp
@@ -38,6 +38,23 @@ namespace bufr {
                        const std::string& groupByFieldName,
                        const std::string& overrideType) const
     {
+        if (dataFrames_.empty())
+        {
+            throw eckit::BadValue("This ResultSet is empty (doesn't contain any data).");
+        }
+
+        if (!dataFrames_[0].hasFieldNamed(fieldName))
+        {
+            throw eckit::BadValue("This ResultSet does not contain a field named " +
+                                  fieldName);
+        }
+
+        if (!groupByFieldName.empty() && !dataFrames_[0].hasFieldNamed(groupByFieldName))
+        {
+            throw eckit::BadValue("This ResultSet does not contain a field named " +
+                                  groupByFieldName);
+        }
+
         std::vector<double> data;
         std::vector<int> dims;
         std::vector<Query> dimPaths;
@@ -139,11 +156,6 @@ namespace bufr {
                                  std::vector<Query>& dimPaths,
                                  TypeInfo& info) const
     {
-        if (dataFrames_.empty())
-        {
-            throw eckit::BadValue("This ResultSet is empty (doesn't contain any data).");
-        }
-
         // Find the dims based on the largest sequence counts in the fields
         // Compute Dims
         std::vector<int> dimsList;

--- a/src/bufr/BufrParser/Query/ResultSet.h
+++ b/src/bufr/BufrParser/Query/ResultSet.h
@@ -79,6 +79,13 @@ namespace bufr {
             return result;
         }
 
+        /// \brief Check the availability of the field with the given name.
+        /// \param name The name of the field to check.
+        bool hasFieldNamed(const std::string& name) const
+        {
+            return fieldIndexForNodeNamed(name) != -1;
+        }
+
      private:
         std::vector<DataField> fields_;
     };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -266,6 +266,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/atms_beamwidth.txt
     testinput/bufr_query_python_test.py
     testinput/bufr_query_python_to_ioda_test.py
+    testinput/bufr_query_fieldname_validation.py
   )
 
   list( APPEND test_output
@@ -1666,13 +1667,13 @@ endif()
 
 if ( iodaconv_bufr_python_ENABLED )
 
-    ecbuild_add_test( TARGET  test_iodaconv_bufr_query_python_test
+    ecbuild_add_test( TARGET  test_iodaconv_bufr_query_python
                       TYPE    SCRIPT
                       ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
                       COMMAND "${Python3_EXECUTABLE}"
                       ARGS "${PROJECT_SOURCE_DIR}/test/testinput/bufr_query_python_test.py" )
 
-    ecbuild_add_test( TARGET  test_iodaconv_bufr_query_python_to_ioda_test
+    ecbuild_add_test( TARGET  test_iodaconv_bufr_query_python_to_ioda
                       TYPE    SCRIPT
                       ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
                       COMMAND bash
@@ -1680,6 +1681,12 @@ if ( iodaconv_bufr_python_ENABLED )
                       netcdf
                       "${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/testinput/bufr_query_python_to_ioda_test.py"
                       bufr_query_python_to_ioda_test.nc ${IODA_CONV_COMP_TOL_ZERO})
+
+    ecbuild_add_test( TARGET  test_iodaconv_bufr_query_fieldname_validation
+                      TYPE    SCRIPT
+                      ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                      COMMAND "${Python3_EXECUTABLE}"
+                      ARGS "${PROJECT_SOURCE_DIR}/test/testinput/bufr_query_fieldname_validation.py" )
 
 endif()
 

--- a/test/testinput/bufr_query_fieldname_validation.py
+++ b/test/testinput/bufr_query_fieldname_validation.py
@@ -1,0 +1,48 @@
+# (C) Copyright 2023 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import bufr
+
+
+def test_field_val():
+    DATA_PATH = './testinput/gdas.t00z.1bhrs4.tm00.bufr_d'
+
+    # Make the QuerySet for all the data we want
+    q = bufr.QuerySet()
+    q.add('latitude', '*/CLON')
+
+    # Open the BUFR file and execute the QuerySet
+    with bufr.File(DATA_PATH) as f:
+        r = f.execute(q)
+
+    try:
+        r.get('lattittude')
+    except Exception as e:
+        return  # Success!
+
+    assert False, "Didn't throw exception for invalid field name."
+
+def test_groupby_field_val():
+    DATA_PATH = './testinput/gdas.t00z.1bhrs4.tm00.bufr_d'
+
+    # Make the QuerySet for all the data we want
+    q = bufr.QuerySet()
+    q.add('latitude', '*/CLON')
+
+    # Open the BUFR file and execute the QuerySet
+    with bufr.File(DATA_PATH) as f:
+        r = f.execute(q)
+
+    try:
+        r.get('latitude', 'latittude')
+    except Exception as e:
+        return  # Success!
+
+    assert False, "Didn't throw exception for invalid groupby field name."
+
+
+if __name__ == '__main__':
+    test_field_val()
+    test_groupby_field_val()


### PR DESCRIPTION
## Description

Python interface would crash the interpreter if ResultSet::get was given an invalid field name. This PR adds exceptions to prevent this and gives the user more useful feedback.

### Issue(s) addressed

#1248 

## Acceptance Criteria (Definition of Done)

New test **test_iodaconv_bufr_query_fieldname_validation** passes.

