### PR TITLE
Extended code to expose type override for query python.

### DIFF
--- a/src/bufr/BufrParser/Query/ResultSet.cpp
+++ b/src/bufr/BufrParser/Query/ResultSet.cpp
@@ -81,9 +81,10 @@ namespace bufr {
 
 #ifdef BUILD_PYTHON_BINDING
         py::array ResultSet::getNumpyArray(const std::string& fieldName,
-                                           const std::string& groupByFieldName) const
+                                           const std::string& groupByFieldName,
+                                           const std::string& overrideType) const
         {
-            auto dataObj = get(fieldName, groupByFieldName);
+            auto dataObj = get(fieldName, groupByFieldName, overrideType);
             return dataObj->getNumpyArray();
         }
 
@@ -567,11 +568,11 @@ namespace bufr {
         {
             object = std::make_shared<DataObject<int32_t>>();
         }
-        else if (overrideType == "float")
+        else if (overrideType == "float" || overrideType == "float32")
         {
             object = std::make_shared<DataObject<float>>();
         }
-        else if (overrideType == "double")
+        else if (overrideType == "double" || overrideType == "float64")
         {
             object = std::make_shared<DataObject<double>>();
         }
@@ -582,6 +583,14 @@ namespace bufr {
         else if (overrideType == "int64")
         {
             object = std::make_shared<DataObject<int64_t>>();
+        }
+        else if (overrideType == "uint64")
+        {
+            object = std::make_shared<DataObject<uint64_t>>();
+        }
+        else if (overrideType == "uint32" || overrideType == "uint")
+        {
+            object = std::make_shared<DataObject<uint32_t>>();
         }
         else
         {

--- a/src/bufr/BufrParser/Query/ResultSet.h
+++ b/src/bufr/BufrParser/Query/ResultSet.h
@@ -127,8 +127,11 @@ namespace bufr {
         /// name grouped by the optional groupByFieldName.
         /// \param fieldName The name of the field to get the data for.
         /// \param groupByFieldName The name of the field to group the data by.
+        /// \param type The name of the type to convert the data to. Possible values are int, uint,
+        /// int32, uint32, int64, uint64, float, double
         py::array getNumpyArray(const std::string& fieldName,
-                                const std::string& groupByFieldName = "") const;
+                                const std::string& groupByFieldName = "",
+                                const std::string& overrideType = "") const;
 
         /// \brief Gets a numpy array of datetime objects for the resulting data for a specific
         /// field with a given name grouped by the optional groupByFieldName.

--- a/src/bufr/BufrParser/Query/python_bindings.cpp
+++ b/src/bufr/BufrParser/Query/python_bindings.cpp
@@ -46,8 +46,10 @@ namespace bufr {
             .def("get", &ResultSet::getNumpyArray,
                         py::arg("field_name"),
                         py::arg("group_by") = std::string(""),
+                        py::arg("type") = std::string(""),
                         "Get a numpy array of the specified field name. If the group_by "
-                        "field is specified, the array is grouped by the specified field.")
+                        "field is specified, the array is grouped by the specified field."
+                        "It is also possible to specify a type to override the default type.")
             .def("get_datetime", &ResultSet::getNumpyDatetimeArray,
                         py::arg("year"),
                         py::arg("month"),

--- a/test/testinput/bufr_query_python_test.py
+++ b/test/testinput/bufr_query_python_test.py
@@ -59,6 +59,31 @@ def test_string_field():
     assert (np.all(borg[0][0:3] == ['KWBC', 'KWBC', 'KAWN']))
 
 
+def test_type_override():
+    DATA_PATH = './testinput/gdas.t00z.1bhrs4.tm00.bufr_d'
+
+    # Make the QuerySet for all the data we want
+    q = bufr.QuerySet()
+    q.add('day', '*/DAYS')
+    q.add('longitude', '*/CLAT')
+
+    # Open the BUFR file and execute the QuerySet
+    with bufr.File(DATA_PATH) as f:
+        r = f.execute(q)
+
+    day = r.get('day')
+    day_float = r.get('day', type='float')
+
+    assert day.dtype == 'int32'
+    assert day_float.dtype == 'float32'
+
+    lat = r.get('longitude')
+    lat_int = r.get('longitude', type='int')
+
+    assert lat.dtype == 'float32'
+    assert lat_int.dtype == 'int32'
+    assert lat_int.fill_value == 2147483647  # the max int32 value
+
 def test_invalid_query():
     q = bufr.QuerySet()
 
@@ -70,7 +95,9 @@ def test_invalid_query():
     assert False, "Didn't throw exception for invalid query."
 
 
+
 if __name__ == '__main__':
     test_basic_query()
     test_string_field()
+    test_type_override()
     test_invalid_query()


### PR DESCRIPTION
## Description

Make it possible to do type override when doing resultSet get in python code. Example:

```python
    q = bufr.QuerySet()
    q.add('day', '*/DAYS')
    q.add('longitude', '*/CLAT')

    # Open the BUFR file and execute the QuerySet
    with bufr.File(DATA_PATH) as f:
        r = f.execute(q)

    day_float = r.get('day', type='float')

```
## Issue(s) addressed

#1251 


