### PR TITLE
Fix some datetime issues.

### DIFF
--- a/test/testinput/bufr_ncep_nbd_snow2.txt
+++ b/test/testinput/bufr_ncep_nbd_snow2.txt
@@ -1,0 +1,79 @@
+# (C) Copyright 2021-2022 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/input_nbd.bufr_d"
+
+      exports:
+        variables:
+          timestamp:
+            datetime:
+              year: "*/YEAR[1]"
+              month: "*/MNTH[1]"
+              day: "*/DAYS[1]"
+              hour: "*/HOUR[1]"
+              minute: "*/MINU[1]"
+
+          longitude:
+            query: "[*/CLON, */CLONH]"
+
+          latitude:
+            query: "[*/CLAT, */CLATH]"
+
+          stationElevation:
+            query: "[*/SELV, */HSMSL]"
+
+          stationIdentification:
+            query: "*/WGOSLID"
+        
+          totalSnowDepth:
+            query: "*/TOSD"
+            transforms:
+              - scale: 1000.0
+        filters:
+          - bounding:
+              variable: totalSnowDepth
+              upperBound: 10000000
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/output_nbd_snow.nc"
+
+      variables:
+        - name: "MetaData/dateTime"
+          source: variables/timestamp
+          longName: "dateTime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/stationIdentification"
+          source: variables/stationIdentification
+          longName: "Report Number"
+
+        - name: "MetaData/latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degrees_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degrees_east"
+          range: [-180, 180]
+
+        - name: "MetaData/stationElevation"
+          coordinates: "longitude latitude"
+          source: variables/stationElevation
+          longName: "Height of Station"
+          units: "m"
+
+        - name: "ObsValue/totalSnowDepth"
+          coordinates: "longitude latitude"
+          source: variables/totalSnowDepth
+          longName: "Total Snow Depth"
+          units: "mm"

--- a/test/testinput/bufr_query_python_test.py
+++ b/test/testinput/bufr_query_python_test.py
@@ -38,7 +38,8 @@ def test_basic_query():
     assert len(rad_all.shape) == 2
 
     datetimes = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second')
-    assert datetimes[5] == np.datetime64('2020-10-26T21:00:00')
+    assert datetimes[5] == np.datetime64('2020-10-26T21:00:01')
+    assert datetimes.fill_value == np.datetime64('1970-01-01T00:00:00')
 
 
 def test_string_field():

--- a/test/testinput/input_nbd.bufr_d
+++ b/test/testinput/input_nbd.bufr_d
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:525da083c8bdd9d97bc2e137c4ffdbba7331d19277141edd55418cf45eafc762
-size 989200

--- a/test/testinput/input_nbd.bufr_d
+++ b/test/testinput/input_nbd.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:525da083c8bdd9d97bc2e137c4ffdbba7331d19277141edd55418cf45eafc762
+size 989200

--- a/test/testoutput/bufr_query_python_to_ioda_test.nc
+++ b/test/testoutput/bufr_query_python_to_ioda_test.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9277046583c3662d85dcd256f60045e78d6e34a728e7d800892ba31a2f1e9d5
-size 314066
+oid sha256:15f9fd7f4863e293933af3003af47e8cb2ff0488cac37a7f208f547a140ebd72
+size 317531


### PR DESCRIPTION
## Description

Fixes issues with the Query Python ResultSet get_datetime method. It was returning regular numpy arrays, not masked arrays. Also the minute and second components were always 0.

## Issue(s) addressed

#1260

