### PR TITLE
adding back in mopitt_co test and file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,8 +39,7 @@ list( APPEND test_input
   testinput/b001xx007.20200310.bufr
   testinput/viirs_aod.nc
   testinput/tropomi_no2.nc
-# remove this for now
-#  testinput/mopitt_co.he5
+  testinput/mopitt_co.he5
   testinput/tropess_cris_co.nc
   testinput/modis_aod.hdf
   testinput/imssnow_24km.grib2
@@ -1143,17 +1142,17 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2_tropo
                           tropomi_no2_tropo.nc ${IODA_CONV_COMP_TOL})
 
 # disable this test 
-#ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
-#                  TYPE    SCRIPT
-#                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
-#                  COMMAND bash
-#                  ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
-#                          netcdf
-#                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/mopitt_co_nc2ioda.py
-#                          -i testinput/mopitt_co.he5
-#                          -o testrun/mopitt_co.nc
-#                          -r 2021092903 2021092921"
-#                  mopitt_co.nc ${IODA_CONV_COMP_TOL_ZERO})
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
+                  TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                  COMMAND bash
+                  ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                          netcdf
+                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/mopitt_co_nc2ioda.py
+                          -i testinput/mopitt_co.he5
+                          -o testrun/mopitt_co.nc
+                          -r 2021092903 2021092921"
+                  mopitt_co.nc ${IODA_CONV_COMP_TOL_ZERO})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropess_cris_co
                   TYPE    SCRIPT

--- a/test/testinput/mopitt_co.he5
+++ b/test/testinput/mopitt_co.he5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12696d027639c08289565a7244b40fa56b50c0fd6c885875624bc149ba5bd2af
+size 3921053


### PR DESCRIPTION
## Description

Adding back in mopitt_co.he5. This was taken out due to the git-lfs problem with this file.
