### PR TITLE
Ioda-converters for the [3D]-RTMA ADPSFC data

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,6 +210,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/ADPUPA.prepbufr
     testinput/gdas.t12z.adpupa_nc002103.tm00.bufr_d
     testinput/rtma_ru.t00z.msonet.tm00.bufr_d
+    testinput/rtma_ru.t0000z.adpsfc_nc000101.tm00.bufr_d
     testinput/bufr_mhs.yaml
     testinput/bufr_hrs.yaml
     testinput/bufr_query_filtering.yaml
@@ -291,6 +292,7 @@ if( iodaconv_bufr_ENABLED )
     testinput/bufr_query_python_to_ioda_test.py
     testinput/bufr_query_fieldname_validation.py
     testinput/bufr_ncep_rtma_mesonet.yaml
+    testinput/bufr_ncep_rtma_adpsfc.yaml
   )
 
   list( APPEND test_output
@@ -351,6 +353,7 @@ if( iodaconv_bufr_ENABLED )
     testoutput/prepbufr_adpupa_api.nc
     testoutput/bufr_query_python_to_ioda_test.nc
     testoutput/rtma_ru.t00z.msonet.tm00.nc
+    testoutput/rtma_ru.t0000z.adpsfc_nc000101.tm00.nc
   )
 endif()
 
@@ -1592,6 +1595,15 @@ if(iodaconv_bufr_ENABLED)
                             netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_rtma_mesonet.yaml"
                     rtma_ru.t00z.msonet.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    DEPENDS bufr2ioda.x )
+
+  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_rtma_adpsfc2ioda
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                    "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_rtma_adpsfc.yaml"
+                    rtma_ru.t0000z.adpsfc_nc000101.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
                     DEPENDS bufr2ioda.x )
 
  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_sevcsr

--- a/test/testinput/bufr_ncep_rtma_adpsfc.yaml
+++ b/test/testinput/bufr_ncep_rtma_adpsfc.yaml
@@ -1,0 +1,297 @@
+# (C) Copyright 2023 NOAA/NWS/NCEP/EMC
+# #
+# # This software is licensed under the terms of the Apache Licence Version 2.0
+# # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/rtma_ru.t0000z.adpsfc_nc000101.tm00.bufr_d"
+
+      exports:
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR[1]"
+              month: "*/MNTH[1]"
+              day: "*/DAYS[1]"
+              hour: "*/HOUR[1]"
+              minute: "*/MINU[1]"
+          receipttime:
+            datetime:
+              year: "[*/RCYR, NC000007/RCPTIM/RCYR]"
+              month: "[*/RCMO, NC000007/RCPTIM/RCMO]"
+              day: "[*/RCDY, NC000007/RCPTIM/RCDY]"
+              hour: "[*/RCHR, NC000007/RCPTIM/RCHR]"
+              minute: "[*/RCMI, NC000007/RCPTIM/RCMI]"
+          latitude:
+            query: "[*/CLAT, */CLATH]"
+          longitude:
+            query: "[*/CLON, */CLONH]"
+          stationIdentification:
+            query: "*/RPID"
+          stationElevation:
+            query: "[*/SELV, */HSMSL]"
+          waterTemperatureMethod:
+            query: "*/MSST"
+          dataProviderRestricted:
+            query: "*/RSRD"
+          dataRestrictedExpiration:
+            query: "*/EXPRSRD"
+
+          # ObsValue
+          pressure:
+            query: "*/PRES"
+          pressureReducedToMeanSeaLevel:
+            query: "*/PMSL"
+          altimeterSetting:
+            query: "*/ALSE"
+          airTemperature:
+            query: "*/TMDB"
+          dewPointTemperature:
+            query: "*/TMDP"
+          windDirection:
+            query: "*/WDIR"
+          windSpeed:
+            query: "*/WSPD"
+
+          # ObsValue - ocean
+          waterTemperature:
+            query: "*/SST1"
+          heightOfWaves:
+            query: "*/WAVSQ1/HOWV"
+
+          # ObsValue - cloud, visibility, gust wind, weather
+          cloudCoverTotal:
+            query: "*/TOCC"
+            type: float
+            transforms:
+              - scale: 0.01
+          cloudAmount:
+            query: "[*/CLDSQ1/CLAM, */MTRCLD/CLAM, NC000100/CLAM, NC000101/CLAM, NC000102/CLAM]"
+          heightOfBaseOfCloud:
+            query: "[*/CLDSQ1/HOCB, */MTRCLD/HOCB, NC000100/HOCB, NC000101/HOCB, NC000102/HOCB]"
+          verticalSignificance:
+            query: "[*/CLDSQ1/VSSO, */MTRCLD/VSSO, NC000100/VSSO[1], NC000101/VSSO[1], NC000102/VSSO[1]]"
+          verticalVisibility:
+            query: "[*/RPSEC3/VTVI, */VTVI]"
+          horizontalVisibility:
+            query: "*/HOVI"
+          maximumWindGustSpeed:
+            query: "[*/WNDSQ2/MXGS, */MTGUST/MXGS, */BSYWND2/MXGS]"
+          maximumWindGustDirection:
+            query: "*/BSYWND2/MXGD"
+          presentWeather:
+            query: "[*/PPWSQ1/PRWE, */MTRPRW/PRWE, */PWEATHER/PRWE]"
+
+          # QualityMarker
+          airTemperatureQM:
+            query: "*/QMAT"
+          dewPointTemperatureQM:
+            query: "*/QMDD"
+          pressureQM:
+            query: "*/QMPR"
+          windQM:
+            query: "*/QMWN"
+
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testrun/rtma_ru.t0000z.adpsfc_nc000101.tm00.nc"
+
+      dimensions:
+        - name: CloudSequence
+          path: "*/CLDSQ1"
+        - name: MaxMinTemperatureSequence
+          path: "*/MTTPSQ"
+        - name: SynopticWindSequence 
+          path: "*/BSYWND2"
+        - name: PresentWeatherSequence
+          path: "*/MTRPRW"
+
+      variables:
+
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/dataReceiptTime"
+          coordinates: "longitude latitude"
+          source: variables/receipttime
+          longName: "Data Receipt Time"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/stationIdentification"
+          coordinates: "longitude latitude"
+          source: variables/stationIdentification
+          longName: "Station Identification"
+
+        - name: "MetaData/stationElevation"
+          coordinates: "longitude latitude"
+          source: variables/stationElevation
+          longName: "Elevation of Observing Location"
+          units: "m"
+
+        - name: "MetaData/waterTemperatureMethod"
+          coordinates: "longitude latitude"
+          source: variables/waterTemperatureMethod
+          longName: "Method of Water Temperature Measurement"
+
+        - name: "MetaData/dataProviderRestricted"
+          coordinates: "longitude latitude"
+          source: variables/dataProviderRestricted
+          longName: "Restrictions On Data Redistribution"
+
+        - name: "MetaData/dataRestrictedExpiration"
+          coordinates: "longitude latitude"
+          source: variables/dataRestrictedExpiration
+          longName: "Expiration Of Restrictions On Data Redistribution"
+
+        # ObsValue
+        - name: "ObsValue/altimeterSetting"
+          coordinates: "longitude latitude"
+          source: variables/altimeterSetting
+          longName: "Altimeter Setting"
+          units: "Pa"
+
+        - name: "ObsValue/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/pressureReducedToMeanSeaLevel"
+          coordinates: "longitude latitude"
+          source: variables/pressureReducedToMeanSeaLevel
+          longName: "Mean Sea-Level Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          longName: "Air Temperature"
+          units: "K"
+
+        - name: "ObsValue/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperature
+          longName: "Dewpoint Temperature"
+          units: "K"
+
+        - name: "ObsValue/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          longName: "Wind Direction"
+          units: "degree"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          longName: "Wind Speed"
+          units: "m s-1"
+
+        # ObsValue - ocean
+        - name: "ObsValue/waterTemperature"
+          coordinates: "longitude latitude"
+          source: variables/waterTemperature
+          longName: "Water Temperature"
+          units: "K"
+
+        - name: "ObsValue/heightOfWaves"
+          coordinates: "longitude latitude"
+          source: variables/heightOfWaves
+          longName: "Height of Waves"
+          units: "m"
+
+        # ObsValue - cloud, visibility, gust wind, weather
+        - name: "ObsValue/cloudCoverTotal"
+          coordinates: "longitude latitude"
+          source: variables/cloudCoverTotal
+          longName: "Total Cloud Coverage"
+          units: "1"
+
+        - name: "ObsValue/cloudAmount"
+          coordinates: "longitude latitude"
+          source: variables/cloudAmount
+          longName: "Description of Cloud Amount"
+          units: "1"
+
+        - name: "ObsValue/heightOfBaseOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/heightOfBaseOfCloud
+          longName: "Cloud Base Altitude"
+          units: "m"
+
+        - name: "ObsValue/verticalSignificance"
+          coordinates: "longitude latitude"
+          source: variables/verticalSignificance
+          longName: "Description of Vertical Significance (Surface Observations)"
+
+        - name: "ObsValue/horizontalVisibility"
+          coordinates: "longitude latitude"
+          source: variables/horizontalVisibility
+          longName: "Horizontal Visibility"
+          units: "m"
+
+        - name: "ObsValue/verticalVisibility"
+          coordinates: "longitude latitude"
+          source: variables/verticalVisibility
+          longName: "Vertical Visibility"
+          units: "m"
+
+        - name: "ObsValue/maximumWindGustSpeed"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustSpeed
+          longName: "Maximum Wind Gust Speed"
+          units: "m s-1"
+
+        - name: "ObsValue/maximumWindGustDirection"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustDirection
+          longName: "Maximum Wind Gust Direction"
+          units: "degree"
+
+        - name: "ObsValue/presentWeather"
+          coordinates: "longitude latitude"
+          source: variables/presentWeather
+          longName: "Description of Present Weather"
+
+        # QualityMarker
+        - name: "QualityMarker/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureQM
+          longName: "Quality Indicator for Atmospheric Temperature"
+
+        - name: "QualityMarker/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperatureQM
+          longName: "Quality Indicator for Dewpoint Temperature"
+
+        - name: "QualityMarker/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressureQM
+          longName: "Quality Indicator for Pressure"
+
+        - name: "QualityMarker/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windQM
+          longName: "Quality Indicator for Wind Direction"

--- a/test/testinput/rtma_ru.t0000z.adpsfc_nc000101.tm00.bufr_d
+++ b/test/testinput/rtma_ru.t0000z.adpsfc_nc000101.tm00.bufr_d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1311a31b33ea213f0e0aaa0049e3ab2e238182598a991fed4d7a5dff9a7c857f
+size 234112

--- a/test/testoutput/rtma_ru.t0000z.adpsfc_nc000101.tm00.nc
+++ b/test/testoutput/rtma_ru.t0000z.adpsfc_nc000101.tm00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea411bfad75ea66081a42f38ec0142958686da68ca30e40712d09635e173e3bd
+size 199925


### PR DESCRIPTION
## Description
This PR adds an ioda-converters for the [3D]-RTMA adpsfc data using the following three files:

- testinput/bufr_ncep_rtma_adpsfc.yaml
- testinput/rtma_ru.t0000z.adpsfc_nc000101.tm00.bufr_d
- testoutput/rtma_ru.t0000z.adpsfc_nc000101.tm00.nc

## Issue(s) addressed
- Resolves #1314 #1315 #1318 

## Acceptance Criteria (Definition of Done)
- Good reviews
- Validation of the output results, which are performed in #1318 
- ioda-validate.x, the following results were obtained using ObsSpace.ymal from #1315 

**Final results:**
_errors:      0
warnings:    0_

## Dependencies
- There are no dependencies.

## Impact
- None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
