### PR TITLE
[Bug fix] a variable that was used before it was assigned `target_number`

### DIFF
--- a/src/conventional/synop_bufr2ioda.py
+++ b/src/conventional/synop_bufr2ioda.py
@@ -374,6 +374,7 @@ def read_bufr_message(f, count, start_pos, data):
     except ecc.KeyValueNotFoundError:
         nsubsets = 1
         pass
+    target_number = nsubsets
 
     # Are the data compressed or uncompressed?  If the latter, then when nsubsets>1, we
     # have to do things differently.
@@ -452,7 +453,6 @@ def read_bufr_message(f, count, start_pos, data):
     ecc.codes_release(bufr)
 
     # Transfer the meta data from its temporary vector into final its meta data var.
-    target_number = nsubsets
     empty = []
     for k, v in metaDataKeyList.items():
         meta_data[k] = assign_missing_meta(empty, k, target_number, 0)


### PR DESCRIPTION
## Description

The SYNOP bufr2ioda converter had a piece of code that wasn't exercised previously and when re-decoding the "golden months" of data, it was discovered there was an unassigned variable `target_number` that was used.  The code change is just one line moved up higher in the code so it is now assigned.

## Issue(s) addressed

A separate one was not created.

## Dependencies

None

## Impact

None

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
