### PR TITLE
bug fix to make QCPath values out of 0 to 31 valid

### DIFF
--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -99,6 +99,7 @@ class AOD(object):
             vals = ncd.variables['AOD550'][:].ravel()
             errs = ncd.variables['Residual'][:].ravel()
             qcpath = ncd.variables['QCPath'][:].ravel()
+            qcpath = np.where(qcpath>-1,qcpath,np.nan)
             qcall = ncd.variables['QCAll'][:].ravel().astype('int32')
             obs_time = np.full(np.shape(qcall), base_datetime, dtype=object)
             if self.mask == "maskout":

--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -98,8 +98,13 @@ class AOD(object):
             lats = ncd.variables['Latitude'][:].ravel()
             vals = ncd.variables['AOD550'][:].ravel()
             errs = ncd.variables['Residual'][:].ravel()
-            qcpath = ncd.variables['QCPath'][:].ravel()
-            qcpath = np.where(qcpath>-1, qcpath, np.nan)
+
+            # QCPath is the flag for retrieval path. The valid range is 0-127 in the
+            # ATBD: https://www.star.nesdis.noaa.gov/jpss/documents/ATBD/ATBD_EPS_Aerosol_AOD_v3.4.pdf.
+            # QCPath's valid range in the input file is not correct, so we define the valid range here.
+            qcpath = ncd.variables['QCPath'][:].data.ravel()
+            qcpath = np.ma.masked_array(qcpath, np.logical_or(qcpath < 0, qcpath > 127))
+
             qcall = ncd.variables['QCAll'][:].ravel().astype('int32')
             obs_time = np.full(np.shape(qcall), base_datetime, dtype=object)
             if self.mask == "maskout":

--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -99,7 +99,7 @@ class AOD(object):
             vals = ncd.variables['AOD550'][:].ravel()
             errs = ncd.variables['Residual'][:].ravel()
             qcpath = ncd.variables['QCPath'][:].ravel()
-            qcpath = np.where(qcpath>-1,qcpath,np.nan)
+            qcpath = np.where(qcpath>-1, qcpath, np.nan)
             qcall = ncd.variables['QCAll'][:].ravel().astype('int32')
             obs_time = np.full(np.shape(qcall), base_datetime, dtype=object)
             if self.mask == "maskout":

--- a/test/testoutput/viirs_aod.nc
+++ b/test/testoutput/viirs_aod.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b20ef47567288c23913bd1768e4cb39c061e584b39a076af5d16e6b01a1e9508
+oid sha256:9e44cadb8e1b55c333ee01338afafe83cbd73bc0637b42917dc0cf1e0e3d0025
 size 14272


### PR DESCRIPTION
## Description
In the the VIIRS AOD Level 2 data file, QCPath is set with a valid range of 0-31. The values out of 0-31 are not read in properly by the converters, so that the retrieval surface is not correctly identified. This PR is to fix this minor bug in reading QCPath, so that values out of 0-31 are valid. 

## Dependencies

List the other PRs that this PR is dependent on:
- None.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
