### PR TITLE
Import ioda_obs_space from pyioda.

### DIFF
--- a/src/gsi_ncdiag/combine_obsspace.py
+++ b/src/gsi_ncdiag/combine_obsspace.py
@@ -4,7 +4,7 @@
 import netCDF4 as nc
 import numpy as np
 import argparse
-import ioda_obs_space as ios
+from pyioda import ioda_obs_space as ios
 from collections import defaultdict, OrderedDict
 
 import pyiodaconv.ioda_conv_engines as iconv


### PR DESCRIPTION
Somehow, I have to add the source "pyioda" of "ioda_obs_space" in order to combine conventional IODA files. Not sure it has any impact to other users.

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
