### PR TITLE
Split Pibal from Sondes

### DIFF
--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -41,6 +41,7 @@ conv_platforms = {
         'sfc',
         'aircraft',
         'sondes',
+        'pibal',
         'vadwind',
         'windprof',
         'sfcship',
@@ -59,7 +60,8 @@ conv_platforms = {
 # bufr codes
 uv_bufrtypes = {
     "aircraft": [230, 231, 233, 235],  # 234 is TAMDAR; always rstprod
-    "sondes": range(220, 223),
+    "sondes": [220,222],
+    "pibal": [221],
     "satwind": range(240, 261),
     "vadwind": [224],
     "windprof": range(227, 230),
@@ -1079,7 +1081,7 @@ class Conv(BaseGSI):
                             #     tmp = hgt
                             outdata[(loc_mdata_name, 'MetaData')] = tmp
                             varAttrs[(loc_mdata_name, 'MetaData')]['units'] = 'm'
-                        elif p == 'sondes' or p == 'aircraft' or p == 'satwind':
+                        elif p == 'sondes' or p == 'aircraft' or p == 'satwind' or p == 'pibal':
                             tmp = self.var(lvar)[idx]
                             tmp[tmp > 4e8] = self.FLOAT_FILL  # 1e11 is fill value for sondes, etc.
                             outdata[(loc_mdata_name, 'MetaData')] = tmp

--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -753,7 +753,7 @@ class Conv(BaseGSI):
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + '_geoval_' + \
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
-                if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind'):
+                if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind' or p == 'pibal'):
                     outname = OutDir + '/' + p + '_geoval_' + \
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:
@@ -876,7 +876,7 @@ class Conv(BaseGSI):
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + '_obs_' + \
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
-                if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind'):
+                if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind' or p == 'pibal'):
                     outname = OutDir + '/' + p + '_obs_' + \
                         self.validtime.strftime("%Y%m%d%H") + '.nc4'
                 if not clobber:

--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -60,7 +60,7 @@ conv_platforms = {
 # bufr codes
 uv_bufrtypes = {
     "aircraft": [230, 231, 233, 235],  # 234 is TAMDAR; always rstprod
-    "sondes": [220,222],
+    "sondes": [220, 222],
     "pibal": [221],
     "satwind": range(240, 261),
     "vadwind": [224],


### PR DESCRIPTION
## Description

It has become clear that for folks interested in replicating the GSI, and thus users of gsi_ncdiag.py, it would not be possible to handle Pibal and Sonde winds using the same observation operator in UFO. This PR makes it such that the converters will output a separate pibal file and no longer include kx=221 in the sondes file.

## Issue(s) addressed

N/A

## Dependencies

N/A

## Impact

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
