### PR TITLE
Add lastUpdateTime to aircraft VarBC files

### DIFF
--- a/src/gsi_varbc/GsiAircraftBiasConverter.cc
+++ b/src/gsi_varbc/GsiAircraftBiasConverter.cc
@@ -66,7 +66,8 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
   }
   ioda::Variable lastCycleUpdatedVar = ogrp.vars.createWithScales<int64_t>("lastUpdateTime",
                                             {ogrp.vars["nrecs"]});
-  lastCycleUpdatedVar.atts.add<std::string>("units", std::string("seconds since 1970-01-01T00:00:00Z"));
+  lastCycleUpdatedVar.atts.add<std::string>("units",
+                                            std::string("seconds since 1970-01-01T00:00:00Z"));
   lastCycleUpdatedVar.write(lastCycleUpdated);
 
   /// Create 2D bias coefficient variable

--- a/src/gsi_varbc/GsiAircraftBiasConverter.cc
+++ b/src/gsi_varbc/GsiAircraftBiasConverter.cc
@@ -21,13 +21,14 @@
 #include "ioda/Engines/HH.h"
 
 #include "oops/util/missingValues.h"
+#include "oops/util/DateTime.h"
 
 #include "GsiAircraftBiasReader.h"
 
 ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
                                  const std::string & coeffile,
                                  const std::vector<std::string> & tailIds,
-                                 const std::vector<int> & lastCycleUpdated,
+                                 const std::vector<int> & lastCycleUpdatedYYYYMM,
                                  const std::vector<std::string> & predictors) {
   /// Predictors
   int numPreds = predictors.size();
@@ -54,8 +55,19 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
                                      {ogrp.vars["nvars"]});
   variableVar.write(varlist);
 
-  ioda::Variable lastCycleUpdatedVar = ogrp.vars.createWithScales<int>("lastUpdateTime",
+  // need to convert the time YYYYMM to seconds sinc 1970
+  std::vector<int64_t> lastCycleUpdated;
+  oops::util::DateTime refTime(1970, 1, 1, 0, 0, 0);
+  for (size_t itime = 0; itime < lastCycleUpdatedYYYYMM.size(); ++itime) {
+    int year = lastCycleUpdated / 100;
+    int month = lastCycleUpdated % 100;
+    std::cout << year << "-" << month << std::endl;
+    oops::util::DateTime lastTime(year, month, 1, 0, 0, 0);
+    lastCycleUpdated.push_back((lastTime - refTime).toSeconds());
+  }
+  ioda::Variable lastCycleUpdatedVar = ogrp.vars.createWithScales<int64_t>("lastUpdateTime",
                                             {ogrp.vars["nrecs"]});
+  lastCycleUpdatedVar.atts.add<std::string>("units", std::string("seconds since 1970-01-01T00:00:00Z"));
   lastCycleUpdatedVar.write(lastCycleUpdated);
 
   /// Create 2D bias coefficient variable
@@ -112,7 +124,7 @@ int main(int argc, char** argv) {
   const std::vector<std::string> tailIds = findTailIds(coeffile);
 
   /// Use function to grab datetimes
-  const std::vector<int> lastCycleUpdated = findDatetimes(coeffile);
+  const std::vector<int> lastCycleUpdatedYYYYMM = findDatetimes(coeffile);
 
   /// Read from config file "output"
   std::vector<eckit::LocalConfiguration> configs = config.getSubConfigurations("output");
@@ -131,5 +143,5 @@ int main(int argc, char** argv) {
   /// Create ncfile
   ioda::Group group = ioda::Engines::HH::createFile(output_filename,
                       ioda::Engines::BackendCreateModes::Truncate_If_Exists);
-  makeObsBiasObject(group, coeffile, tailIds, lastCycleUpdated, predictors);
+  makeObsBiasObject(group, coeffile, tailIds, lastCycleUpdatedYYYYMM, predictors);
 }

--- a/src/gsi_varbc/GsiAircraftBiasConverter.cc
+++ b/src/gsi_varbc/GsiAircraftBiasConverter.cc
@@ -57,12 +57,11 @@ ioda::ObsGroup makeObsBiasObject(ioda::Group &empty_base_object,
 
   // need to convert the time YYYYMM to seconds sinc 1970
   std::vector<int64_t> lastCycleUpdated;
-  oops::util::DateTime refTime(1970, 1, 1, 0, 0, 0);
-  for (size_t itime = 0; itime < lastCycleUpdatedYYYYMM.size(); ++itime) {
-    int year = lastCycleUpdated / 100;
-    int month = lastCycleUpdated % 100;
-    std::cout << year << "-" << month << std::endl;
-    oops::util::DateTime lastTime(year, month, 1, 0, 0, 0);
+  util::DateTime refTime(1970, 1, 1, 0, 0, 0);
+  for (size_t itime = 0; itime < numIds; ++itime) {
+    int year = lastCycleUpdatedYYYYMM[itime] / 100;
+    int month = lastCycleUpdatedYYYYMM[itime] % 100;
+    util::DateTime lastTime(year, month, 1, 0, 0, 0);
     lastCycleUpdated.push_back((lastTime - refTime).toSeconds());
   }
   ioda::Variable lastCycleUpdatedVar = ogrp.vars.createWithScales<int64_t>("lastUpdateTime",

--- a/test/testoutput/varbc/acft_out.nc4
+++ b/test/testoutput/varbc/acft_out.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19a5f49da7285e6d4c5a4a26e80d6db45f12a0075eb31601b6b66036bb34c643
-size 19049
+oid sha256:94fdb7089993be9cebc87432859316849a2530421d0813c8b6594fbcee4b028b
+size 19068


### PR DESCRIPTION
## Description

This adds lastUpdateTime as an int64 seconds since 1970 that IODA can decipher (hopefully!)

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
