### PR TITLE
replacing tropics ctest files with smaller data case

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@
 ################################################################################
 
 list( APPEND test_input
-  testinput/TROPICS01.L1B.V03-04.ST20220216-012443.ET20220216-025955.nc
+  testinput/tropics_2022021600.nc
   testinput/amsr2_gcom-w1_20220216.h5
   testinput/gmi_gpm_20220216.h5
   testinput/icethk_coperl4.nc
@@ -918,7 +918,7 @@ ecbuild_add_test( TARGET  test_iodaconv_tropics
                   ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                           netcdf
                   "${CMAKE_BINARY_DIR}/bin/tropics_2ioda.py
-                  -i testinput/TROPICS01.L1B.V03-04.ST20220216-012443.ET20220216-025955.nc
+                  -i testinput/tropics_2022021600.nc
                   -o testrun/20220216T00Z_PT3H_tms_tropics-01.nc4
                   -d 2022021600"
                   20220216T00Z_PT3H_tms_tropics-01.nc4 ${IODA_CONV_COMP_TOL})

--- a/test/testinput/TROPICS01.L1B.V03-04.ST20220216-012443.ET20220216-025955.nc
+++ b/test/testinput/TROPICS01.L1B.V03-04.ST20220216-012443.ET20220216-025955.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96a2c79f7777656caad403e4260b19c807bcd9e99f821c3bff4c92dbbe8327a7
-size 389748

--- a/test/testinput/tropics_2022021600.nc
+++ b/test/testinput/tropics_2022021600.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2972c5c704b37206106685ffc836af0a1316591f0dee493c40b58edb36cdec8
+size 51562

--- a/test/testoutput/20220216T00Z_PT3H_tms_tropics-01.nc4
+++ b/test/testoutput/20220216T00Z_PT3H_tms_tropics-01.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6897507533ae828e750826b9f49fd9e82dfcbc3db148a5177487ae8caf32cee9
-size 64570
+oid sha256:3bf6537f55024fe0b2c3ecb3ed58e3d25378fc0f70c3a0a740389fd3f4d9b273
+size 22560


### PR DESCRIPTION
A new `ufo ctest` was made for `tropics`, but the `geovals` file needed for that test was too large. The raw data was reduced and converted and then run in `skylab` to generate smaller geovals files. In order to keep the workflow consistent using the `ioda ctest` `testoutput` file as the `testinput` file for the `ufo ctest`, the `ioda-converter` test files needed to be replaced.

The `iodaconv ctest` passes with the new files, by running `ctest -R test_iodaconv_tropics -VV` in the `build` directory. 

## Issue(s) addressed
Resolves #<issue_number>

## Checklist

- [x] I have performed a self-review of my own code
- [x] The `ctest` passes with new files
