### PR TITLE
Change temperature output of ASPUPA converter to virtual temperature only

### DIFF
--- a/test/testinput/bufr_ncep_prepbufr_adpupa.py
+++ b/test/testinput/bufr_ncep_prepbufr_adpupa.py
@@ -81,10 +81,10 @@ def test_bufr_to_ioda(DATA_PATH, OUTPUT_PATH, date):
     pob_ps   = np.where(cat == 0, pob, pob_ps)  
     tob = r.get('airTemperature')
     tob += 273.15
-    tsen = np.full(tob.shape, tob.fill_value) # Extract sensible temperature from tob, which belongs to TPC=1
-    tsen = np.where(tpc == 1, tob, tsen)
+    tsen = np.full(tob.shape, tob.fill_value)
+    tsen = np.where(tpc == 1, tob, tsen) # Extract sensible temperature from tob, which belongs to TPC=1
     tvo   = np.full(tob.shape, tob.fill_value) # Extract virtual temperature from tob, which belongs to TPC <= 8 and TPC>1
-    tvo   = np.where(((tpc <= 8) & (tpc > 1)), tob, tvo)
+    tvo   = np.where(((tpc <= 8) & (tpc > 1)), tob, tvo) # virtual temperature is output as tob (below) assuming tvo == tsen where moisture is low
     qob = r.get('specificHumidity', type='float')
     qob *= 1.0e-6
     uob = r.get('windEastward')
@@ -172,9 +172,9 @@ def test_bufr_to_ioda(DATA_PATH, OUTPUT_PATH, date):
     stationpressure.atts.create('units', ioda.Types.str).writeVector.str(['Pa'])
     stationpressure.atts.create('long_name', ioda.Types.str).writeVector.str(['Station Pressure'])
 
-    airtemperature = g.vars.create('ObsValue/airTemperature', ioda.Types.float, scales=[dim_location], params=pfloat)
-    airtemperature.atts.create('units', ioda.Types.str).writeVector.str(['K'])
-    airtemperature.atts.create('long_name', ioda.Types.str).writeVector.str(['Temperature'])
+#   airtemperature = g.vars.create('ObsValue/airTemperature', ioda.Types.float, scales=[dim_location], params=pfloat)
+#   airtemperature.atts.create('units', ioda.Types.str).writeVector.str(['K'])
+#   airtemperature.atts.create('long_name', ioda.Types.str).writeVector.str(['Temperature'])
 
     virtualtemperature = g.vars.create('ObsValue/virtualTemperature', ioda.Types.float, scales=[dim_location], params=pfloat)
     virtualtemperature.atts.create('units', ioda.Types.str).writeVector.str(['K'])
@@ -209,9 +209,9 @@ def test_bufr_to_ioda(DATA_PATH, OUTPUT_PATH, date):
     stationpressureqm.atts.create('units', ioda.Types.str).writeVector.str(['1'])
     stationpressureqm.atts.create('long_name', ioda.Types.str).writeVector.str(['Station Pressure Quality Marker'])
 
-    airtemperatureqm = g.vars.create('QualityMarker/airTemperature', ioda.Types.int, scales=[dim_location], params=pint)
-    airtemperatureqm.atts.create('units', ioda.Types.str).writeVector.str(['1'])
-    airtemperatureqm.atts.create('long_name', ioda.Types.str).writeVector.str(['Air Temperature Quality Marker'])
+#   airtemperatureqm = g.vars.create('QualityMarker/airTemperature', ioda.Types.int, scales=[dim_location], params=pint)
+#   airtemperatureqm.atts.create('units', ioda.Types.str).writeVector.str(['1'])
+#   airtemperatureqm.atts.create('long_name', ioda.Types.str).writeVector.str(['Air Temperature Quality Marker'])
 
     virtualtemperatureqm = g.vars.create('QualityMarker/virtualTemperature', ioda.Types.int, scales=[dim_location], params=pint)
     virtualtemperatureqm.atts.create('units', ioda.Types.str).writeVector.str(['1'])
@@ -242,8 +242,8 @@ def test_bufr_to_ioda(DATA_PATH, OUTPUT_PATH, date):
     pressure.writeNPArray.float(pob.flatten())
  
     stationpressure.writeNPArray.float(pob_ps.flatten())
-    airtemperature.writeNPArray.float(tsen.flatten())
-    virtualtemperature.writeNPArray.float(tvo.flatten())
+#   airtemperature.writeNPArray.float(tob.flatten())
+    virtualtemperature.writeNPArray.float(tob.flatten())
     specifichumidity.writeNPArray.float(qob.flatten())
     windeastward.writeNPArray.float(uob.flatten())
     windnorthward.writeNPArray.float(vob.flatten())
@@ -251,7 +251,7 @@ def test_bufr_to_ioda(DATA_PATH, OUTPUT_PATH, date):
 
     pressureqm.writeNPArray.int(pobqm.flatten())
     stationpressureqm.writeNPArray.int(pob_psqm.flatten())
-    airtemperatureqm.writeNPArray.int(tsenqm.flatten())
+#   airtemperatureqm.writeNPArray.int(tsenqm.flatten())
     virtualtemperatureqm.writeNPArray.int(tvoqm.flatten())
     specifichumidityqm.writeNPArray.int(qobqm.flatten())
     windeastwardqm.writeNPArray.int(uobqm.flatten())

--- a/test/testoutput/prepbufr_adpupa_api.nc
+++ b/test/testoutput/prepbufr_adpupa_api.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:095831d83836995f84dc8e87d37e5419b63d8edf5796eb828ca02803b3ddc675
-size 1716569
+oid sha256:a58e5dae0df040d5d75be9aa2eb3e9c9365b97edf14daf55804fe5b0fb96c4d7
+size 1714449


### PR DESCRIPTION
## Description

Temperature observations are more easily handled by skylab when the temperature profile is either T or Tv throughout the entire profile. Assuming Tv=T where moisture is low, and T has been converted to Tv in the ADPUPA prepbufr file where it is not, output a full profile of Tv

## Issue(s) addressed

Resolves #1376 

## Dependencies

none

## Impact

none

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
