### PR TITLE
Add aids to find correct Python3 (find framework/registry last)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ set(CMAKE_FORTRAN_EXTENSIONS OFF)
 # Location of .pycodestyle for norm checking within IODA-converters
 set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+# Python-finding settings
+set(Python3_FIND_REGISTRY "LAST")
+set(Python3_FIND_FRAMEWORK "LAST")
+find_package( Python3 COMPONENTS Interpreter Development)
 
 set(pyver python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
 set(PYDIR ${pyver}/pyiodaconv)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set( IODACONV_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 # Python-finding settings
 set(Python3_FIND_REGISTRY "LAST")
 set(Python3_FIND_FRAMEWORK "LAST")
-find_package( Python3 COMPONENTS Interpreter Development)
+find_package( Python3 REQUIRED COMPONENTS Interpreter Development)
 
 set(pyver python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
 set(PYDIR ${pyver}/pyiodaconv)


### PR DESCRIPTION
## Description

Set options to find framework (macOS) and registry (Windows) Python after regular (aka "Linux-style") Python installations.

I tested this together with https://github.com/JCSDA-internal/ioda/pull/1122 on my macOS and it did find the spack-stack Python installation first.

## Issue(s) addressed

Working towards https://github.com/JCSDA-internal/jedi-docs/issues/656

## Dependencies

Merge together with https://github.com/JCSDA-internal/ioda/pull/1122 and https://github.com/JCSDA-internal/jedi-docs/pull/665 (although not strictly required)

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
