### PR TITLE
Set a consistent, non-zero tolerance for comparing floating point values

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -453,7 +453,7 @@ endforeach()
 #===============================================================================
 
 # Tolerence (relative percent difference) for comparing floating point numbers.
-set(IODA_CONV_COMP_TOL "1.0e-3")
+set(IODA_CONV_COMP_TOL "5.0e-4")
 
 # The ioda-engines CMake configuration has set the file target _ioda_python to
 # the full path to the library file containing the python bindings created

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -438,7 +438,7 @@ endforeach()
 #===============================================================================
 # The following tests use odb compare or nccmp to check the difference between the output
 #  file, and the reference copy of what the ouput file should look like.
-# The first rgument to the script, is what the output file type is (netcdf or odb)
+# The first argument to the script, is what the output file type is (netcdf or odb)
 # The second rgument to the script, wrapped in quotes, is the command to execute
 #  the ioda converter.
 # The third argument is the name of the output file to compare (one copy to be
@@ -446,13 +446,8 @@ endforeach()
 #  testoutput/)
 #===============================================================================
 
-# Typically, a converter is simply doing a format change (ie, copying data directly
-# from the input file). For these cases, use a tolerance of zero for the
-# iodaconv_comp.sh test.
-#
-# For a converter that is generating new data, use a non-zero tolerance.
-set(IODA_CONV_COMP_TOL_ZERO "0.0")
-set(IODA_CONV_COMP_TOL "0.5e-4")
+# Tolerence (relative percent difference) for comparing floating point numbers.
+set(IODA_CONV_COMP_TOL "1.0e-3")
 
 # The ioda-engines CMake configuration has set the file target _ioda_python to
 # the full path to the library file containing the python bindings created
@@ -501,7 +496,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_nsidc_l4cdr_icec
                           -i testinput/nsidc_l4_icec.nc
                           -o testrun/nsidc_l4_icec.nc
                           -d 2019010112"
-                          nsidc_l4_icec.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          nsidc_l4_icec.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l4icethk
                   TYPE    SCRIPT
@@ -512,7 +507,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l4icethk
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/copernicus_l4icethk2ioda.py
                           -i testinput/icethk_coperl4.nc
                           -o testrun/icethk_coperl4.nc -d 2019011500"
-                          icethk_coperl4.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          icethk_coperl4.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_amsr2_l2icec
                   TYPE    SCRIPT
@@ -524,7 +519,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_amsr2_l2icec
                           -i testinput/amsr2_icec_l2p.nc
                           -o testrun/amsr2_icec_l2p.nc
                           -d 2021080112"
-                          amsr2_icec_l2p.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          amsr2_icec_l2p.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gds2_sst_l2p
                   TYPE    SCRIPT
@@ -537,7 +532,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gds2_sst_l2p
                           -o testrun/gds2_sst_l2p.nc
                           -d 2018041512
                           -t 0.5"
-                          gds2_sst_l2p.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          gds2_sst_l2p.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gds2_sst_l3u
                   TYPE    SCRIPT
@@ -550,7 +545,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gds2_sst_l3u
                           -o testrun/gds2_sst_l3u.nc
                           -d 2018041512
                           -t 0.5"
-                          gds2_sst_l3u.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          gds2_sst_l3u.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap_sss
                   TYPE    SCRIPT
@@ -562,7 +557,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap_sss
                           -i testinput/smap_sss_rss.nc
                           -o testrun/smap_sss_rss.nc
                           -d 2018041512"
-                          smap_sss_rss.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          smap_sss_rss.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_rads_adt
                   TYPE    SCRIPT
@@ -574,7 +569,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_rads_adt
                           -i testinput/rads_adt.nc
                           -o testrun/rads_adt.nc
                           -d 2018041512"
-                          rads_adt.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          rads_adt.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_prof
                   TYPE    SCRIPT
@@ -586,7 +581,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_prof
                           -i testinput/godae_prof.bin
                           -o testrun/godae_prof.nc
                           -d 1998092212"
-                          godae_prof.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          godae_prof.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_ship
                   TYPE    SCRIPT
@@ -598,7 +593,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_ship
                           -i testinput/godae_ship.bin
                           -o testrun/godae_ship.nc
                           -d 1998090112"
-                          godae_ship.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          godae_ship.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_trak
                   TYPE    SCRIPT
@@ -610,7 +605,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_trak
                           -i testinput/godae_trak.bin
                           -o testrun/godae_trak.nc
                           -d 2004070812"
-                          godae_trak.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          godae_trak.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_adt
                   TYPE    SCRIPT
@@ -622,7 +617,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_adt
                           -i testinput/hgodas_adt.nc
                           -o testrun/hgodas_adt.nc
                           -d 2018041512"
-                          hgodas_adt.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          hgodas_adt.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_insitu
                   TYPE    SCRIPT
@@ -634,7 +629,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_insitu
                           -i testinput/hgodas_insitu.nc
                           -o testrun/hgodas_insitu.nc
                           -d 2018041512"
-                          hgodas_insitu.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          hgodas_insitu.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_sst
                   TYPE    SCRIPT
@@ -646,7 +641,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hgodas_sst
                           -i testinput/hgodas_sst.nc
                           -o testrun/hgodas_sst.nc
                           -d 2018041512"
-                          hgodas_sst.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          hgodas_sst.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_glider
                   TYPE    SCRIPT
@@ -659,7 +654,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_glider
                           -o testrun/test_glider.nc
                           -d 2016080412
                           -y testinput/glider.yaml"
-                          test_glider.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          test_glider.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hfradar
                   TYPE    SCRIPT
@@ -671,7 +666,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_hfradar
                           -i testinput/ndbc_hfradar_in.nc
                           -o testrun/ndbc_hfradar_out.nc
                           -d 2020072012"
-                          ndbc_hfradar_out.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ndbc_hfradar_out.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_argoclim
                   TYPE    SCRIPT
@@ -683,7 +678,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_argoclim
                           -i testinput/argoclim_test.nc
                           -o testrun/argoclim.nc
                           -d 2004010200"
-                          argoclim.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          argoclim.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_cryosat2
                   TYPE    SCRIPT
@@ -695,7 +690,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_cryosat2
                           -i testinput/cryosat2_L2_test.nc
                           -o testrun/cryosat2_L2.nc
                           -d 2019092112"
-                          cryosat2_L2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          cryosat2_L2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_emc_ice
                   TYPE    SCRIPT
@@ -707,7 +702,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_emc_ice
                           -i testinput/emc_ice.nc
                           -o testrun/emc_ice_ioda2.nc
                           -d 2015082812"
-                          emc_ice_ioda2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          emc_ice_ioda2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smos_sss
                   TYPE    SCRIPT
@@ -719,7 +714,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smos_sss
                           -i testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
                           -o testrun/smos_sss_l2.nc
                           -d 2010060100"
-                          smos_sss_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          smos_sss_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l4adt
                   TYPE    SCRIPT
@@ -730,7 +725,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l4adt
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/copernicus_l4adt2ioda.py
                           -i testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
                           -o testrun/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc -d 20190101"
-                          ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l3swh
                   TYPE    SCRIPT
@@ -741,7 +736,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_copernicus_l3swh
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/copernicus_l3swh2ioda.py
                           -i testinput/global_vavh_l3_rt_s3a_20210930T18.nc
                           -o testrun/ioda_global_vavh_l3_rt_s3a_20210930T18.nc"
-                          ioda_global_vavh_l3_rt_s3a_20210930T18.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ioda_global_vavh_l3_rt_s3a_20210930T18.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_swot_l2adt
                   TYPE    SCRIPT
@@ -752,7 +747,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_swot_l2adt
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/swot_l2adt2ioda.py
                           -i testinput/SWOT_L2_SSHA.nc
                           -o testrun/SWOT_L2_ADT.nc"
-                          SWOT_L2_ADT.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          SWOT_L2_ADT.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_sst_ostia
                   TYPE    SCRIPT
@@ -763,7 +758,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_sst_ostia
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/ostia_l4sst2ioda.py
                           -i testinput/sst_ostia.nc
                           -o testrun/sst_ostia.nc"
-                          sst_ostia.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          sst_ostia.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_avhrr_radiance
                   TYPE    SCRIPT
@@ -775,7 +770,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_avhrr_radiance
                           -i testinput/avhrr_radiance.nc
                           -o testrun/avhrr_radiance.nc
                           -d 2015010100"
-                          avhrr_radiance.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          avhrr_radiance.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_pace_oc_l2
                   TYPE    SCRIPT
@@ -788,7 +783,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_pace_oc_l2
                           -o testrun/pace_oc_l2.nc
                           -d 2019032112
                           -t 0.5"
-                          pace_oc_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          pace_oc_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_pace_radiance_L1B
                   TYPE    SCRIPT
@@ -800,7 +795,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_pace_radiance_L1B
                           -i testinput/pace_radiance_L1B.nc
                           -o testrun/pace_radiance_L1B.nc
                           -d 2019032112"
-                          pace_radiance_L1B.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          pace_radiance_L1B.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_water_leaving_radiance_L2                                               
                   TYPE    SCRIPT                                                                               
@@ -812,7 +807,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_water_leaving_radiance_L2
                           -i testinput/modis_aqua_Rrs_OC_L2.nc                                                    
                           -o testrun/modis_water_leaving_radiance_L2.nc                                                      
                           -d 2021080112"
-                          modis_water_leaving_radiance_L2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          modis_water_leaving_radiance_L2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mls_o3_l2
                   TYPE    SCRIPT
@@ -827,7 +822,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mls_o3_l2
                           -m 06
                           -d 21
                           -z 12"
-                          mls_o3_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          mls_o3_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omi_o3_l2
                   TYPE    SCRIPT
@@ -842,7 +837,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omi_o3_l2
                           -m 12
                           -d 15
                           -z 12"
-                          omi_o3_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          omi_o3_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ompsnm_o3_l2
                   TYPE    SCRIPT
@@ -857,7 +852,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ompsnm_o3_l2
                           -m 12
                           -d 15
                           -z 12"
-                          ompsnm_o3_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ompsnm_o3_l2.nc ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # Conventional data, Sat-winds atmospheric motion vectors NESDIS ftp server
@@ -873,7 +868,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satwinds
                           -i testinput/satwinds_ssec2021080103.txt
                           -o testrun/satwinds_ssec2021080103.nc
                           -d 2021080103"
-                          satwinds_ssec2021080103.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          satwinds_ssec2021080103.nc ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # Conventional data, surface Obs - METAR converter
@@ -889,7 +884,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_metar
                           -i testinput/2020100106_metars_small.csv
                           -o testrun/2020100106_metars_small.nc
                           -d 2020100106"
-                          2020100106_metars_small.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          2020100106_metars_small.nc ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # Conventional data, radiosonde, text/alpha (legacy) converter
@@ -906,7 +901,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_sondetac
                           -o testrun/2021081612_sonde_small.nc
                           -t share/raob_stations_small.json
                           --date 2021-08-16T12:00:00Z --netcdf"
-                          2021081612_sonde_small.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          2021081612_sonde_small.nc ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # MISC converters
@@ -959,7 +954,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_jpss1_oc_l2
                           -o testrun/viirs_jpss1_oc_l2.nc
                           -d 2018041512
                           -t 0.5"
-                          viirs_jpss1_oc_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          viirs_jpss1_oc_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_aqua_oc_l2
                   TYPE    SCRIPT
@@ -972,7 +967,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_aqua_oc_l2
                           -o testrun/modis_aqua_oc_l2.nc
                           -d 2018041512
                           -t 0.5"
-                          modis_aqua_oc_l2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          modis_aqua_oc_l2.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_jpss1_oc_l3
                   ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
@@ -984,7 +979,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_jpss1_oc_l3
                           -i testinput/viirs_jpss1_oc_l3.nc
                           -o testrun/viirs_jpss1_oc_l3.nc
                           -d 2018041512"
-                          viirs_jpss1_oc_l3.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          viirs_jpss1_oc_l3.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_bgc_argo
                   TYPE    SCRIPT
@@ -996,7 +991,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_bgc_argo
                           -i testinput/godae_bgc_argo.nc
                           -o testrun/godae_bgc_argo.nc
                           -d 2018041512"
-                          godae_bgc_argo.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          godae_bgc_argo.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ncep_bufr
                   TYPE    SCRIPT
@@ -1011,7 +1006,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ncep_bufr
                           -m 5
                           -l NC001007.yaml
                           -ot NC001007"
-                          ioda.NC001007.2020031012.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ioda.NC001007.2020031012.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gen_singleob
                   TYPE    SCRIPT
@@ -1021,7 +1016,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gen_singleob
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/gen_single_ob.py
                           -y testinput/singleob.yaml"
-                          singleob.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          singleob.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_gen_aircraft_bias_csv_python
                   TYPE    SCRIPT
@@ -1030,7 +1025,7 @@ ecbuild_add_test( TARGET  test_gen_aircraft_bias_csv_python
                   ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                           ascii
                           "${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/acftbias/generate_aircraft_bias_csv.py ./testinput/gdas.t18z.abias_air ./testrun/gdas.t18z.abias_air_ascent.csv MetaData/stationIdentification string 0 BiasCoefficientValue/ascentPredictor float 3"
-                          gdas.t18z.abias_air_ascent.csv ${IODA_CONV_COMP_TOL_ZERO})
+                          gdas.t18z.abias_air_ascent.csv ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # SSEC GIIRS converters
@@ -1059,7 +1054,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_giirs_lw
                           -i testinput/giirs_fy4a-test.nc
                           -o testrun/giirs_fy4a_obs_2017030208.nc4
                           -d 2017030208"
-                          giirs_fy4a_obs_2017030208.nc4 ${IODA_CONV_COMP_TOL_ZERO})
+                          giirs_fy4a_obs_2017030208.nc4 ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # GSI ncdiag converters
@@ -1119,7 +1114,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gsidiag_rad
 #                          -i testinput/wrfdadiags_goes-16-abi_2018041500.nc
 #                          -o testrun/
 #                          -t rad"
-#                          abi_g16_obs_2018041500.nc4 ${IODA_CONV_COMP_TOL_ZERO})
+#                          abi_g16_obs_2018041500.nc4 ${IODA_CONV_COMP_TOL})
 # *DH
 
 #===============================================================================
@@ -1136,7 +1131,7 @@ if( iodaconv_gnssro_ENABLED )
                             2022090100
                             testinput/gnssro_3prof_2022090100.bufr
                             testrun/gnssro_obs_3prof_2022090100.nc4"
-                            gnssro_obs_3prof_2022090100.nc4  ${IODA_CONV_COMP_TOL_ZERO}
+                            gnssro_obs_3prof_2022090100.nc4  ${IODA_CONV_COMP_TOL}
                     DEPENDS gnssro_bufr2ioda)
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gnssro_AWSopendataNetcdf_conv
@@ -1149,7 +1144,7 @@ if( iodaconv_gnssro_ENABLED )
                             -i testinput/gnssro_refractivityRetrieval_metop_romsaf_2401.0011_metopc-G32-202108020112.nc
                             -o testrun/gnssro_obs_awsopendata_2021080200.nc4
                             -d 2021080200"
-                            gnssro_obs_awsopendata_2021080200.nc4 ${IODA_CONV_COMP_TOL_ZERO})
+                            gnssro_obs_awsopendata_2021080200.nc4 ${IODA_CONV_COMP_TOL})
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gnssaro_netcdf_conv
                     TYPE    SCRIPT
@@ -1161,7 +1156,7 @@ if( iodaconv_gnssro_ENABLED )
                             -i testinput/gnssaro_N49T_20210120_00Z.nc
                             -o testrun/gnssaro_obs_2021012000.nc
                             -d 2021012000"
-                            gnssaro_obs_2021012000.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            gnssaro_obs_2021012000.nc ${IODA_CONV_COMP_TOL})
 endif()
 
 #==============================================================================
@@ -1180,7 +1175,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_aod
                           -m nesdis
                           -k maskout
                           -n 0.0"
-                          viirs_aod.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          viirs_aod.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_viirs_aod
                   TYPE    SCRIPT
@@ -1189,7 +1184,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_satbias_viirs_aod
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/viirs_biaswriter.py
                           -o testrun/viirs_bias.nc"
-                          viirs_bias.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          viirs_bias.nc ${IODA_CONV_COMP_TOL})
 
 foreach (coltype total tropo)
         ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_no2_${coltype}
@@ -1203,7 +1198,7 @@ foreach (coltype total tropo)
                                   -o testrun/tropomi_no2_${coltype}.nc
                                   -v no2
                                   -c ${coltype}"
-                                  tropomi_no2_${coltype}.nc ${IODA_CONV_COMP_TOL_ZERO})
+                                  tropomi_no2_${coltype}.nc ${IODA_CONV_COMP_TOL})
 endforeach()
 
 foreach (coltype total troposphere stratosphere)
@@ -1238,7 +1233,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_mopitt_co
                           -i testinput/mopitt_co.he5
                           -o testrun/mopitt_co.nc
                           -r 2021092903 2021092921"
-                          mopitt_co.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          mopitt_co.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropess_cris_co
                   TYPE    SCRIPT
@@ -1263,7 +1258,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_modis_aod
                           -t 2021080100
                           -p Terra
                           -o testrun/modis_aod.nc"
-                          modis_aod.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          modis_aod.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_aeronet_aod
                   TYPE    SCRIPT
@@ -1286,7 +1281,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_aeronet_aaod
                           -c testinput/aeronet_cad.dat
                           -t testinput/aeronet_tab.dat
                           -o testrun/aeronet_aaod.nc"
-                          aeronet_aaod.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          aeronet_aaod.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow
                   TYPE    SCRIPT
@@ -1298,7 +1293,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow
                           -i testinput/airnow_2020081306.dat
                           -s testinput/airnow_sites.dat
                           -o testrun/airnow_2020081306.nc"
-                          airnow_2020081306.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          airnow_2020081306.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_co_total
                   TYPE    SCRIPT
@@ -1312,7 +1307,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_co_total
                           -v co
                           -q 0.5
                           -c total"
-                          tropomi_co_total.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          tropomi_co_total.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omps_o3_nm
                   TYPE    SCRIPT
@@ -1325,7 +1320,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omps_o3_nm
                              testinput/OMPS-NPP_NMTO3-L2_v2.1_2020m0903t180544_small.h5
                           -o testrun/omps_o3_nm.nc
                           -q 128"
-                          omps_o3_nm.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          omps_o3_nm.nc ${IODA_CONV_COMP_TOL})
 
 #==============================================================================
 # Bufr Ingester tests
@@ -1344,7 +1339,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_mhs.yaml"
-                            gdas.t18z.1bmhs.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t18z.1bmhs.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_hrs2ioda
@@ -1353,7 +1348,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_hrs.yaml"
-                            gdas.t00z.1bhrs4.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t00z.1bhrs4.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_query_filtering
@@ -1362,7 +1357,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_query_filtering.yaml"
-                            bufr_query_filtering.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_query_filtering.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_filtering
@@ -1371,7 +1366,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_filtering.yaml"
-                            gdas.t18z.1bmhs.tm00.filtering.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t18z.1bmhs.tm00.filtering.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_splitting
@@ -1380,7 +1375,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_splitting.yaml"
-                            gdas.t18z.1bmhs.tm00.15.seven.split.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t18z.1bmhs.tm00.15.seven.split.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_filter_split
@@ -1389,7 +1384,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_filter_split.yaml"
-                            gdas.t18z.1bmhs.tm00.15.7.filter_split.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t18z.1bmhs.tm00.15.7.filter_split.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_1bamua2ioda
@@ -1398,7 +1393,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_1bamua_ta.yaml"
-                            gdas.t12z.amsua_metop-c_ta.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.amsua_metop-c_ta.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_1bamua2ioda_n15
@@ -1407,7 +1402,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_1bamua_n15.yaml"
-                            gdas.t12z.amsua_n15.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.amsua_n15.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_esamua2ioda
@@ -1416,7 +1411,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_esamua.yaml"
-                            gdas.t12z.esamua_n18.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.esamua_n18.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_1bmhs2ioda
@@ -1425,7 +1420,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_1bmhs.yaml"
-                            gdas.t12z.1bmhs.metop-b.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.1bmhs.metop-b.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_esmhs2ioda
@@ -1434,7 +1429,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_esmhs.yaml"
-                            gdas.t12z.esmhs.noaa-19.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.esmhs.noaa-19.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_adpsfc2ioda
@@ -1443,7 +1438,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_adpsfc.yaml"
-                            gdas.t12z.adpsfc.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.adpsfc.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_api_adpsfc2ioda
@@ -1453,7 +1448,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${Python3_EXECUTABLE} testinput/prepbufr_adpsfc_api.py"
-                            prepbufr_adpsfc_api.nc ${IODA_CONV_COMP_TOL_ZERO} )
+                            prepbufr_adpsfc_api.nc ${IODA_CONV_COMP_TOL} )
 
   ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_api_sfcshp2ioda
                     TYPE    SCRIPT
@@ -1462,7 +1457,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${Python3_EXECUTABLE} testinput/prepbufr_sfcshp_api.py"
-                            prepbufr_sfcshp_api.nc ${IODA_CONV_COMP_TOL_ZERO} )
+                            prepbufr_sfcshp_api.nc ${IODA_CONV_COMP_TOL} )
 
   ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_adpsfc2ioda
                     TYPE    SCRIPT
@@ -1470,7 +1465,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_adpsfc.yaml"
-                            gdas.t12z.adpsfc.prepbufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.adpsfc.prepbufr.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_snowadpsfc2ioda
@@ -1479,7 +1474,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_snow_adpsfc.yaml"
-                            gdas.t06z.adpsfc_snow.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t06z.adpsfc_snow.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_aircar2ioda
@@ -1488,7 +1483,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_aircar.yaml"
-                            gdas.t12z.aircar.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.aircar.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_aircft_noamdar2ioda
@@ -1497,7 +1492,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_aircft_noAMDAR103.yaml"
-                            gdas.t12z.aircft_noAMDAR103.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.aircft_noAMDAR103.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_aircft_amdar2ioda
@@ -1506,7 +1501,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_aircft_AMDAR103.yaml"
-                            gdas.t12z.aircft_AMDAR103.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.aircft_AMDAR103.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_aircftprofiles2ioda
@@ -1515,7 +1510,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_aircft.yaml"
-                            gdas.t12z.acft_profiles.prepbufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.acft_profiles.prepbufr.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
 
@@ -1525,7 +1520,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_read_2_dim_blocks.yaml"
-                            bufr_read_2_dim_blocks.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_read_2_dim_blocks.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_read_wmo_radiosonde
@@ -1534,7 +1529,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_read_wmo_radiosonde.yaml"
-                            bufr_read_wmo_radiosonde.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_read_wmo_radiosonde.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_satwnd_old_format
@@ -1543,7 +1538,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_satwnd_old_format.yaml"
-                            NC005066.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            NC005066.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_satwnd_new_format
@@ -1552,7 +1547,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_satwnd_new_format.yaml"
-                            NC005031.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            NC005031.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_satwind_avhrr
@@ -1561,7 +1556,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_satwind_avhrr.yaml"
-                            gdas.t18z.satwnd_avhrr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t18z.satwnd_avhrr.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_mtiasi
@@ -1570,7 +1565,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_mtiasi.yaml"
-                            gdas.t12z.mtiasi_metop-c.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.mtiasi_metop-c.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_atms
@@ -1579,7 +1574,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_atms.yaml"
-                            gdas.t00z.atms_n20.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t00z.atms_n20.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_simple_groupby
@@ -1588,7 +1583,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_simple_groupby.yaml"
-                            bufr_simple_groupby.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_simple_groupby.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_empty_fields
@@ -1597,7 +1592,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_empty_fields.yaml"
-                            bufr_empty_fields.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_empty_fields.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_sfcshp
@@ -1606,7 +1601,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_sfcshp.yaml"
-                            bufr_sfcshp.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_sfcshp.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_adpupa
@@ -1615,7 +1610,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                     "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/adpupa_prepbufr.yaml"
-                    adpupa_prepbufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                    adpupa_prepbufr.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_prepbufr_adpupa
@@ -1624,7 +1619,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_adpupa.yaml"
-                            bufr_ncep_prepbufr_adpupa.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_ncep_prepbufr_adpupa.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_prepbufr_adpupa_api
@@ -1634,7 +1629,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${Python3_EXECUTABLE} testinput/bufr_ncep_prepbufr_adpupa.py"
-                            prepbufr_adpupa_api.nc ${IODA_CONV_COMP_TOL_ZERO} )
+                            prepbufr_adpupa_api.nc ${IODA_CONV_COMP_TOL} )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_adpupa2ioda
                     TYPE    SCRIPT
@@ -1642,7 +1637,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_adpupa.yaml"
-                            gdas.t12z.adpupa_bufr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t12z.adpupa_bufr.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_mesonet2ioda
@@ -1651,7 +1646,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_rtma_mesonet.yaml"
-                            rtma_ru.t00z.msonet.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            rtma_ru.t00z.msonet.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_rtma_adpsfc2ioda
@@ -1660,7 +1655,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_rtma_adpsfc.yaml"
-                            rtma_ru.t0000z.adpsfc_nc000101.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            rtma_ru.t0000z.adpsfc_nc000101.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
  ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_sevcsr
@@ -1669,7 +1664,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_sevcsr.yaml"
-                            gdas.t00z.sevcsr.tm00.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            gdas.t00z.sevcsr.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_specific_subsets_by_query
@@ -1678,7 +1673,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_specific_subsets_by_query.yaml"
-                            bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_specifying_subsets
@@ -1687,7 +1682,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_specifying_subsets.yaml"
-                            bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_specifying_subsets.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_lgycld
@@ -1696,7 +1691,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_lgycld_rrfs.yaml"
-                            rrfs.t06z.lgycld.bufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            rrfs.t06z.lgycld.bufr.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_ncep_prepbufr_adpsfc_cloud
@@ -1705,7 +1700,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_adpsfc_cloud_rrfs.yaml"
-                            rrfs.t06z.adpsfc.prepbufr.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            rrfs.t06z.adpsfc.prepbufr.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
 #  FIXME: Greg Thompson
@@ -1715,7 +1710,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/aircar_BUFR2ioda.yaml"
-#                            gdas.aircar.t00z.20210801.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            gdas.aircar.t00z.20210801.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_airep_wmo_bufr
@@ -1724,7 +1719,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/airep_wmoBUFR2ioda.yaml"
-#                            airep_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            airep_multi.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
   ecbuild_add_test( TARGET  test_iodaconv_bufr_wmo_amdar_multi
@@ -1733,7 +1728,7 @@ if(iodaconv_bufr_query_ENABLED)
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_wmo_amdar_multi.yaml"
-                            bufr_wmo_amdar_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+                            bufr_wmo_amdar_multi.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_gnssro_wmo_bufr
@@ -1742,7 +1737,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/gnssro_wmoBUFR2ioda.yaml"
-#                            gnssro_2020-306-2358C2E6.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            gnssro_2020-306-2358C2E6.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_generic_gnssro_bufr
@@ -1755,7 +1750,7 @@ if(iodaconv_bufr_query_ENABLED)
                             -d 2021080212
                             -i testinput/bfrPrf_C2E6.2021.214.12.00.G16_0001.0001_bufr
                             -o testrun/gnssro_cosmic2_2021080212.nc4"
-                            gnssro_cosmic2_2021080212.nc4 ${IODA_CONV_COMP_TOL_ZERO})
+                            gnssro_cosmic2_2021080212.nc4 ${IODA_CONV_COMP_TOL})
 
 #  FIXME: Greg Thompson
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_buoy_wmo_bufr
@@ -1764,7 +1759,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/buoy_wmoBUFR2ioda.yaml"
-#                            buoy_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            buoy_wmo_multi.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_rass_wmo_bufr
@@ -1773,7 +1768,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/rass_wmoBUFR2ioda.yaml"
-#                            rass_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            rass_wmo_multi.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_ship_wmo_bufr
@@ -1782,7 +1777,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/ship_wmoBUFR2ioda.yaml"
-#                            ship_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            ship_wmo_multi.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_synop_wmo_bufr
@@ -1791,7 +1786,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/synop_wmoBUFR2ioda.yaml"
-#                            synop_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO})
+#                            synop_wmo_multi.nc ${IODA_CONV_COMP_TOL})
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_EUMet_wmo_bufr
 #                    TYPE    SCRIPT
@@ -1799,7 +1794,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_EUMet_wmoBUFR2ioda.yaml"
-#                            satwind_EUMet.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            satwind_EUMet.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_Himawari_wmo_bufr
@@ -1808,7 +1803,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_Himawari_wmoBUFR2ioda.yaml"
-#                            satwind_Himawari.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            satwind_Himawari.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_satwind_Insat_wmo_bufr
@@ -1817,7 +1812,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/satwind_Insat_wmoBUFR2ioda.yaml"
-#                            satwind_Insat.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            satwind_Insat.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 #
 #  ecbuild_add_test( TARGET  test_iodaconv_bufr_vadwinds_wmo_bufr
@@ -1826,7 +1821,7 @@ if(iodaconv_bufr_query_ENABLED)
 #                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/vadwinds_wmoBUFR2ioda.yaml"
-#                            vadwinds_wmo_multi.nc ${IODA_CONV_COMP_TOL_ZERO}
+#                            vadwinds_wmo_multi.nc ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2ioda.x )
 endif()
 
@@ -1845,7 +1840,7 @@ if ( iodaconv_bufr_python_ENABLED )
                       ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                               netcdf
                               "${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/testinput/bufr_query_python_to_ioda_test.py"
-                      bufr_query_python_to_ioda_test.nc ${IODA_CONV_COMP_TOL_ZERO})
+                      bufr_query_python_to_ioda_test.nc ${IODA_CONV_COMP_TOL})
 
     ecbuild_add_test( TARGET  test_iodaconv_bufr_query_fieldname_validation
                       TYPE    SCRIPT
@@ -1869,7 +1864,7 @@ ecbuild_add_test( TARGET  test_iodaconv_atms_nc4
                           "${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/hdf5/atms_netcdf_hdf5_2ioda.py
                           -d 2021120600
                           -i testinput/SNDR_SNPP_ATMS_SAMPLE.nc4
-                          -o testrun/2021120600_atms_sdr.nc4" 2021120600_atms_sdr.nc4 ${IODA_CONV_COMP_TOL_ZERO} )
+                          -o testrun/2021120600_atms_sdr.nc4" 2021120600_atms_sdr.nc4 ${IODA_CONV_COMP_TOL} )
 
 ecbuild_add_test( TARGET  test_iodaconv_atms_BGRemap_nc4
                   TYPE    SCRIPT
@@ -1881,7 +1876,7 @@ ecbuild_add_test( TARGET  test_iodaconv_atms_BGRemap_nc4
                           -m BG
                           -d 2018041500
                           -i testinput/SNDR.J1.ATMS.20180415T0000.nc4
-                          -o testrun/2018041500_atms_BGRemap_sdr.nc4" 2018041500_atms_BGRemap_sdr.nc4 ${IODA_CONV_COMP_TOL_ZERO} )
+                          -o testrun/2018041500_atms_BGRemap_sdr.nc4" 2018041500_atms_BGRemap_sdr.nc4 ${IODA_CONV_COMP_TOL} )
 
 if( iodaconv_eccodes_ENABLED )
 
@@ -1900,7 +1895,7 @@ if( iodaconv_eccodes_ENABLED )
                            -o testrun/wmo_raob_double.nc4
                            -t share/raob_stations_small.json
                            --date 2021-02-01T12:00:00Z"
-                           wmo_raob_double.nc4 ${IODA_CONV_COMP_TOL_ZERO})
+                           wmo_raob_double.nc4 ${IODA_CONV_COMP_TOL})
 
 endif()
 
@@ -1918,7 +1913,7 @@ if( iodaconv_bufr_query_ENABLED )
                             "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/amdar_bufr2ioda.py
                             -i testinput/amdar_wmo_multi.bufr
                             -o testrun/amdar_wmo_multi2.nc"
-                            amdar_wmo_multi2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            amdar_wmo_multi2.nc ${IODA_CONV_COMP_TOL})
 
 #===============================================================================
 # Conventional data, surface Obs - SYNOP, Buoy and Ship BUFR (WMO) converters
@@ -1933,7 +1928,7 @@ if( iodaconv_bufr_query_ENABLED )
                             "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/buoy_bufr2ioda.py
                             -i testinput/buoy_wmo_multi.bufr
                             -o testrun/buoy_wmo_multi2.nc"
-                            buoy_wmo_multi2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            buoy_wmo_multi2.nc ${IODA_CONV_COMP_TOL})
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ship
                     TYPE    SCRIPT
@@ -1944,7 +1939,7 @@ if( iodaconv_bufr_query_ENABLED )
                             "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/ship_bufr2ioda.py
                             -i testinput/ship_wmo_multi.bufr
                             -o testrun/ship_wmo_multi2.nc"
-                            ship_wmo_multi2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            ship_wmo_multi2.nc ${IODA_CONV_COMP_TOL})
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_synop
                     TYPE    SCRIPT
@@ -1955,7 +1950,7 @@ if( iodaconv_bufr_query_ENABLED )
                             "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/synop_bufr2ioda.py
                             -i testinput/synop_wmo_multi.bufr
                             -o testrun/synop_wmo_multi2.nc"
-                            synop_wmo_multi2.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            synop_wmo_multi2.nc ${IODA_CONV_COMP_TOL})
 
 endif()
 
@@ -1982,7 +1977,7 @@ if( iodaconv_pbfortran_ENABLED )
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
                             -i testinput -o testrun gdas.t18z.1bmhs.tm00.bufr_d"
-                            mhs_metop-b_obs_2020101215.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            mhs_metop-b_obs_2020101215.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2nc_fortran.x)
 
 #  FIXME: Emily Liu
@@ -1993,7 +1988,7 @@ if( iodaconv_pbfortran_ENABLED )
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
 #                            -i testinput -o testrun gdas.t12z.esmhs.tm00.bufr_d"
-#                            mhs_n19_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+#                            mhs_n19_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2nc_fortran.x)
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_amsua_conv
@@ -2003,7 +1998,7 @@ if( iodaconv_pbfortran_ENABLED )
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
                             -i testinput -o testrun gdas.t12z.1bamua.tm00.bufr_d"
-                            amsua_metop-b_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            amsua_metop-b_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2nc_fortran.x)
 
 #  FIXME: Emily Liu
@@ -2014,7 +2009,7 @@ if( iodaconv_pbfortran_ENABLED )
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
 #                            -i testinput -o testrun gdas.t12z.esamua.tm00.bufr_d"
-#                            amsua_n18_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+#                            amsua_n18_obs_2020110112.nc4 ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2nc_fortran.x)
 
 #  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_iasi_conv
@@ -2024,7 +2019,7 @@ if( iodaconv_pbfortran_ENABLED )
 #                            netcdf
 #                            "${CMAKE_BINARY_DIR}/bin/bufr2nc_fortran.x
 #                            -i testinput -o testrun gdas.t12z.mtiasi.tm00.bufr_d"
-#                            iasi_metop-b_obs_2022021912.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+#                            iasi_metop-b_obs_2022021912.nc4 ${IODA_CONV_COMP_TOL}
 #                    DEPENDS bufr2nc_fortran.x)
 
 endif()
@@ -2042,7 +2037,7 @@ if( iodaconv_satbias_ENABLED )
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_amsua.yaml"
-                            satbias_amsua_n18.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            satbias_amsua_n18.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS satbias2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_satbias_cris
@@ -2051,7 +2046,7 @@ if( iodaconv_satbias_ENABLED )
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_cris.yaml"
-                            satbias_cris_npp.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            satbias_cris_npp.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS satbias2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_satbias_gmi
@@ -2060,7 +2055,7 @@ if( iodaconv_satbias_ENABLED )
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_gmi_gpm.yaml"
-                            satbias_gmi_gpm.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            satbias_gmi_gpm.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS satbias2ioda.x )
 
   ecbuild_add_test( TARGET  test_iodaconv_satbias_ssmis
@@ -2069,7 +2064,7 @@ if( iodaconv_satbias_ENABLED )
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/satbias2ioda.x testinput/satbias_converter_ssmis.yaml"
-                            satbias_ssmis_f16.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            satbias_ssmis_f16.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS satbias2ioda.x )
 endif()
 
@@ -2086,7 +2081,7 @@ if( iodaconv_obserror_ENABLED )
                     ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                             netcdf
                             "${CMAKE_BINARY_DIR}/bin/obserror2ioda.x testinput/Rcov_iasi_metop-b_sea.bin testrun/Rcov_iasi_metop-b_sea.nc4"
-                            Rcov_iasi_metop-b_sea.nc4 ${IODA_CONV_COMP_TOL_ZERO}
+                            Rcov_iasi_metop-b_sea.nc4 ${IODA_CONV_COMP_TOL}
                     DEPENDS obserror2ioda.x )
 endif()
 
@@ -2106,7 +2101,7 @@ if( iodaconv_pygrib_ENABLED )
                             -i testinput/imssnow_24km.grib2
                             -o testrun/imssnow_scf.nc
                             -m maskout"
-                            imssnow_scf.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            imssnow_scf.nc ${IODA_CONV_COMP_TOL})
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_afwa_snod
                     TYPE    SCRIPT
@@ -2118,7 +2113,7 @@ if( iodaconv_pygrib_ENABLED )
                             -i testinput/afwa_snod_24km.grib
                             -o testrun/afwa_snod.nc
                             -m maskout"
-                            afwa_snod.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            afwa_snod.nc ${IODA_CONV_COMP_TOL})
 endif()
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ghcn_snod
@@ -2133,7 +2128,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ghcn_snod
                           -f ${PROJECT_BINARY_DIR}/doc/fix/ghcn-stations.txt
                           -d 2020022818
                           -m maskout"
-                          ghcn_snod_20200228.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          ghcn_snod_20200228.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap_ssm
                     TYPE    SCRIPT
@@ -2145,7 +2140,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap_ssm
                             -i testinput/SMAP_L2_SM_P_NRT_24342_A_20190822T224858_N16023_002.h5
                             -o testrun/smap_ssm.nc
                             --maskMissing"
-                            smap_ssm.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            smap_ssm.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smos_ssm
                     TYPE    SCRIPT
@@ -2157,7 +2152,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smos_ssm
                             -i testinput/smos_l2nrt_ssm.nc
                             -o testrun/smos_ssm.nc
                             -m maskout"
-                            smos_ssm.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            smos_ssm.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ascat_ssm
                     TYPE    SCRIPT
@@ -2169,7 +2164,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_ascat_ssm
                             -i testinput/ascat_ssm.nc
                             -o testrun/ascat_ssm.nc
                             -m maskout"
-                            ascat_ssm.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            ascat_ssm.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_imsfv3_scf
                     TYPE    SCRIPT
@@ -2180,7 +2175,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_imsfv3_scf
                             "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/imsfv3_scf2ioda.py
                             -i testinput/imsscf_20191215_c48.nc
                             -o testrun/imsfv3_scf.nc"
-                            imsfv3_scf.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            imsfv3_scf.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap9km_ssm
                     TYPE    SCRIPT
@@ -2192,7 +2187,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_smap9km_ssm
                             -i testinput/SMAP_L2_SM_P_E_36365_D_20211122T013945_R18240_001.h5
                             -o testrun/smap9km_ssm.nc
                             --maskMissing"
-                            smap9km_ssm.nc ${IODA_CONV_COMP_TOL_ZERO})
+                            smap9km_ssm.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_land_owp_snow_obs_dup_thin
                   TYPE    SCRIPT
@@ -2204,7 +2199,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_land_owp_snow_obs_dup_thin
                           -i testinput/owp_snow_obs.csv
                           -o testrun/owp_snow_obs_dup_thin_err_fn.nc
                           --thin_swe 1 --thin_depth .5 --thin_random_seed 3  --err_fn dummy_err"
-                          owp_snow_obs_dup_thin_err_fn.nc ${IODA_CONV_COMP_TOL_ZERO})
+                          owp_snow_obs_dup_thin_err_fn.nc ${IODA_CONV_COMP_TOL})
 
 #######################################################
 # Auto-generated tests for ioda file validation


### PR DESCRIPTION
## Description

This PR changes the tolerance value for comparing floating point numbers to a consistent, non-zero value. This is coded in a single variable, IODA_CONV_COMP_TOL, and used everywhere the iodaconv_comp.sh script is used. Currently IODA_CONV_COMP_TOL is set to 1.0e-3 (relative tolerance of 0.001 percent).

## Issue(s) addressed

Partially addresses #1378

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None - no functional changes

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
