### PR TITLE
Add option to save LSW in gnssro bufr2ioda

### DIFF
--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -288,7 +288,7 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
         bang[bangid] = float_missing_value
         bang_err[bangid] = float_missing_value
 
-        lsw = bang_err/bang * 100   # CDACC saves LSW in radians as bang_err. Convert to percentage 
+        lsw = bang_err/bang * 100   # CDACC saves LSW in radians as bang_err. Convert to percentage
         lsw[bang == float_missing_value] = float_missing_value
         obs_data[('localSpectralWidth', "MetaData")] = assign_values(lsw)
     return obs_data

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -284,7 +284,7 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
             obs_data[k] = obs_data[k][good]
 
     if addLSW:
-        lsw = bang_err/bang * 100
+        lsw = bang_err/bang * 100   # CDACC saves LSW in radians as bang_err. Convert to percentage 
         obs_data[('localSpectralWidth', "MetaData")] = assign_values(lsw)
 
     return obs_data

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -284,9 +284,10 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
             obs_data[k] = obs_data[k][good]
 
     if addLSW:
+        bang[bang == 0] = float_missing_value
+        bang_err[bang == 0] = float_missing_value
         lsw = bang_err/bang * 100   # CDACC saves LSW in radians as bang_err. Convert to percentage 
         obs_data[('localSpectralWidth', "MetaData")] = assign_values(lsw)
-
     return obs_data
 
 

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -284,9 +284,12 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
             obs_data[k] = obs_data[k][good]
 
     if addLSW:
-        bang[bang == 0] = float_missing_value
-        bang_err[bang == 0] = float_missing_value
+        bangid = bang == 0
+        bang[bangid] = float_missing_value
+        bang_err[bangid] = float_missing_value
+
         lsw = bang_err/bang * 100   # CDACC saves LSW in radians as bang_err. Convert to percentage 
+        lsw[bang == float_missing_value] = float_missing_value
         obs_data[('localSpectralWidth', "MetaData")] = assign_values(lsw)
     return obs_data
 

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -431,7 +431,7 @@ if __name__ == "__main__":
         default=False, action='store_true', required=False)
 
     optional.add_argument(
-        '-l', '--localspectralwidth',
+        '-lsw', '--localspectralwidth',
         help='Calculate and output error metrics, LSW and STD4060',
         default=False, action='store_true', required=False)
 

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -112,8 +112,8 @@ def main(args):
     VarAttrs[('height', 'MetaData')]['_FillValue'] = float_missing_value
 
     if addLSW:
-        VarAttrs[('localSpectralWidth', 'ObsError')]['units'] = 'Percentage'
-        VarAttrs[('localSpectralWidth', 'ObsError')]['_FillValue'] = float_missing_value
+        VarAttrs[('localSpectralWidth', 'ObsValue')]['units'] = 'Percentage'
+        VarAttrs[('localSpectralWidth', 'ObsValue')]['_FillValue'] = float_missing_value
 
     # final write to IODA file
     writer.BuildIoda(obs_data, VarDims, VarAttrs, GlobalAttrs)
@@ -285,7 +285,7 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
 
     if addLSW:
         lsw = bang_err/bang * 100
-        obs_data[('localSpectralWidth', "ObsError")] = assign_values(lsw)
+        obs_data[('localSpectralWidth', "ObsValue")] = assign_values(lsw)
 
     return obs_data
 

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -283,7 +283,7 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
         for k in obs_data.keys():
             obs_data[k] = obs_data[k][good]
 
-    if addLSW:  
+    if addLSW:
         lsw = bang_err/bang * 100
 
         obs_data[('localSpectralWidth', "ObsError")] = assign_values(lsw)

--- a/src/gnssro/gnssro_bufr2ioda.py
+++ b/src/gnssro/gnssro_bufr2ioda.py
@@ -112,8 +112,8 @@ def main(args):
     VarAttrs[('height', 'MetaData')]['_FillValue'] = float_missing_value
 
     if addLSW:
-        VarAttrs[('localSpectralWidth', 'ObsValue')]['units'] = 'Percentage'
-        VarAttrs[('localSpectralWidth', 'ObsValue')]['_FillValue'] = float_missing_value
+        VarAttrs[('localSpectralWidth', 'MetaData')]['units'] = 'Percentage'
+        VarAttrs[('localSpectralWidth', 'MetaData')]['_FillValue'] = float_missing_value
 
     # final write to IODA file
     writer.BuildIoda(obs_data, VarDims, VarAttrs, GlobalAttrs)
@@ -285,7 +285,7 @@ def get_obs_data(bufr, profile_meta_data, add_qc, addLSW, record_number=None):
 
     if addLSW:
         lsw = bang_err/bang * 100
-        obs_data[('localSpectralWidth', "ObsValue")] = assign_values(lsw)
+        obs_data[('localSpectralWidth', "MetaData")] = assign_values(lsw)
 
     return obs_data
 


### PR DESCRIPTION
## Description

Adds the option to save LSW from CDAAC processed bufr files as its own variable when a flag is set.

## Issue(s) addressed

Resolves #1393 

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
