### PR TITLE
Fixed fault with unintialized file unit variable.

### DIFF
--- a/src/obserror/obserror2ioda.f90
+++ b/src/obserror/obserror2ioda.f90
@@ -33,6 +33,10 @@ program obserror2ioda
    end if
 
 !> read GSI obs error covariances
+   !> the file descriptor, lu, needs to be set to an integer value, but the values
+   !> of 0, 5 and 6 need to be avoided since these are typically reserved for stderr, stdin
+   !> and stdout respectively.
+   lu = 10
    open (lu, file=trim(filename_in), convert='little_endian', form='unformatted')
    read (lu, IOSTAT=ioflag) nch_active, nctot, iprec
    print *, "Number of active channels: ", nch_active


### PR DESCRIPTION
## Description

This PR fixes intermittent failures of the ctest `test_iodaconv_obserror`. The issue was an integer variable being used for the file unit number which was uninitialized when used in a file open statement.

## Issue(s) addressed

None

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (code comments)
- [x] I have run the unit tests before creating the PR
