### PR TITLE
fix for compiler flags

### DIFF
--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -8,25 +8,25 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -ffree-line-length-none -mcmodel=medium")
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -ffree-line-length-none")
 
 ####################################################################
 # RELEASE FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions -mcmodel=medium")
+set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions ")
 
 ####################################################################
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace -mcmodel=medium" )
+set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace " )
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions -mcmodel=medium" )
+set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions " )
 
 ####################################################################
 # LINK FLAGS

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -14,7 +14,7 @@ set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -ffree-line-length-none")
 # RELEASE FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions ")
+set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions")
 
 ####################################################################
 # DEBUG FLAGS

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -26,7 +26,7 @@ set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,ove
 # BIT REPRODUCIBLE FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions " )
+set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions" )
 
 ####################################################################
 # LINK FLAGS

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -20,7 +20,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions")
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace " )
+set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace" )
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS


### PR DESCRIPTION
## Description

The compiler flags for linux need to be fixed for linux due to recent change in code. 
https://github.com/JCSDA-internal/ioda-converters/pull/1399
We should no longer need mcmodel and thus can delete it.

## Issue(s) addressed

Resolves #1398 

## Dependencies

None


