### PR TITLE
Add handling to avoid processing FFT remapping for missing satellite p…

### DIFF
--- a/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -71,8 +71,8 @@ namespace Ingester
         int nobs = (radObj->getDims())[0];
         int nchn = (radObj->getDims())[1];
 
-        oops::Log::info()  << "nobs =  " << nobs << std::endl;
-        oops::Log::info()  << "nchn =  " << nchn << std::endl;
+        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nobs =  " << nobs << std::endl;
+        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nchn =  " << nchn << std::endl;
 
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn

--- a/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -71,8 +71,8 @@ namespace Ingester
         int nobs = (radObj->getDims())[0];
         int nchn = (radObj->getDims())[1];
 
-        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nobs =  " << nobs << std::endl;
-        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nchn =  " << nchn << std::endl;
+        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nobs = " << nobs << std::endl;
+        oops::Log::info()  << "RemappedBrightnessTemperatureVariable: nchn = " << nchn << std::endl;
 
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn

--- a/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/src/bufr/BufrParser/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -71,6 +71,9 @@ namespace Ingester
         int nobs = (radObj->getDims())[0];
         int nchn = (radObj->getDims())[1];
 
+        oops::Log::info()  << "nobs =  " << nobs << std::endl;
+        oops::Log::info()  << "nchn =  " << nchn << std::endl;
+
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn
         std::vector<int> scanline(fovnObj->size(), DataObject<int>::missingValue());
@@ -104,9 +107,11 @@ namespace Ingester
         // Perform FFT image remapping
         // input only variables: nobs, nchn obstime, fovn, channel
         // input & output variables: btobs, scanline, error_status
-        int error_status;
-        ATMS_Spatial_Average_f(nobs, nchn, &obstime, &fovn, &channel, &btobs,
-                                           &scanline, &error_status);
+        if (nobs > 0) {
+            int error_status;
+            ATMS_Spatial_Average_f(nobs, nchn, &obstime, &fovn, &channel, &btobs,
+                                               &scanline, &error_status);
+        }
 
         // Export remapped observation (btobs)
         return std::make_shared<DataObject<float>>(btobs,


### PR DESCRIPTION
## Description

This is a bug fix
Add handling to avoid processing FFP remapping for missing satellite platforms from BUFR file
Users may list out all possible platforms from BUFR in the YAML (see YAML section below)
The FFT remapping part of the code should have handling to avoid processing data from missing satellite platforms in the BUFR file.  

Example of the Buggy situation:
Input ATMS BUFR contains data from one platform: n20 only, but users listed more.
The current BUFR converter already handle the missing satellites from the bufr file.  BUFR converter will print out warning " PRE-MAIN-WARNING   Skipped category npp n21"

But, the FFT remapping code does not handle this.  
The code change in this PR is to avoid processing FFTP remapping for missint satellite platforms from BUFR file.

```
        splits:
          satId:
            category:
              variable: satelliteIdentifier
              map:
                _224: npp
                _225: n20
                _226: n21

```

The same fix should be in IODA feature/bufr_backend

## Issue(s) addressed
Resolves #1443 

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
