### PR TITLE
Correct MetaData for pressure in ADPUPA YAML

### DIFF
--- a/test/testinput/bufr_ncep_rtma_adpupa.yaml
+++ b/test/testinput/bufr_ncep_rtma_adpupa.yaml
@@ -41,10 +41,10 @@ observations:
             query: "*/CLON"
           stationElevation:
             query: "*/SELV"
-
-          # ObsValue
           pressure:
             query: "*/UARLV/PRLC"
+
+          # ObsValue
           airTemperature:
             query: "*/UARLV/UATMP/TMDB"
           dewPointTemperature:
@@ -121,13 +121,13 @@ observations:
           longName: "Elevation of Observing Location"
           units: "m"
 
-        # ObsValue
-        - name: "ObsValue/pressure"
+        - name: "MetaData/pressure"
           coordinates: "longitude latitude"
           source: variables/pressure
           longName: "Pressure"
           units: "Pa"
 
+        # ObsValue
         - name: "ObsValue/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperature

--- a/test/testinput/bufr_ncep_rtma_adpupa.yaml
+++ b/test/testinput/bufr_ncep_rtma_adpupa.yaml
@@ -43,6 +43,7 @@ observations:
             query: "*/SELV"
           pressure:
             query: "*/UARLV/PRLC"
+            type: float
 
           # ObsValue
           airTemperature:

--- a/test/testoutput/rtma.t00z.adpupa.tm00.nc
+++ b/test/testoutput/rtma.t00z.adpupa.tm00.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb15adfc838955e89c310ded0335b58e92568817bfdc69c7a91147d1cccdfe96
-size 432999
+oid sha256:642ec25bbeb89ffdbd701acb214eebfef6bd63c375c11d106620dd865d7af437
+size 433070


### PR DESCRIPTION
## Description

This PR corrects the MetaData group for the pressure variable in RTMA ADPUPA BUFR YAML. 

Ioda validation results: 
**Final results:**
  _errors:      0
  warnings:    0_

## Issue(s) addressed

Resolves #1457 

## Dependencies

None

## Impact

None

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
