### PR TITLE
Fixed acprofile test failure and some other things.

### DIFF
--- a/src/bufr/BufrParser/Query/Data.h
+++ b/src/bufr/BufrParser/Query/Data.h
@@ -9,6 +9,8 @@
 
 #include <string>
 #include <vector>
+#include <limits>
+#include <cmath>
 
 #include "Constants.h"
 
@@ -205,7 +207,8 @@ namespace bufr {
             }
             else
             {
-                return value.octets[idx] == MissingOctetValue;
+                return std::fabs(value.octets[idx] - MissingOctetValue)
+                       <= std::numeric_limits<double>::epsilon() * MissingOctetValue * 100;
             }
         }
 

--- a/src/bufr/BufrParser/Query/ResultSet.cpp
+++ b/src/bufr/BufrParser/Query/ResultSet.cpp
@@ -192,10 +192,16 @@ namespace bufr {
                     break;
                 }
 
-                const auto& maxCount = std::max(max(counts), 1);
+                const auto maxCount = std::max(max(counts), 1);
                 if (maxCount > metaData->rawDims[pathIdx])
                 {
                     metaData->rawDims[pathIdx] = maxCount;
+                }
+
+                if (target->exportDimIdxs.size() - 1 < static_cast<size_t>(exportIdxIdx))
+                {
+                    ++pathIdx;
+                    continue;
                 }
 
                 if (target->exportDimIdxs[exportIdxIdx] != pathIdx)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1536,14 +1536,14 @@ if(iodaconv_bufr_query_ENABLED)
                             gdas.t12z.aircft_AMDAR103.tm00.nc ${IODA_CONV_COMP_TOL}
                     DEPENDS bufr2ioda.x )
 
-#  ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_aircftprofiles2ioda
-#                    TYPE    SCRIPT
-#                    COMMAND bash
-#                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
-#                            netcdf
-#                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_aircft.yaml"
-#                            gdas.t12z.acft_profiles.prepbufr.nc ${IODA_CONV_COMP_TOL}
-#                    DEPENDS bufr2ioda.x )
+  ecbuild_add_test( TARGET  test_iodaconv_prepbufr_ncep_aircftprofiles2ioda
+                    TYPE    SCRIPT
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                            "${CMAKE_BINARY_DIR}/bin/bufr2ioda.x testinput/bufr_ncep_prepbufr_aircft.yaml"
+                            gdas.t12z.acft_profiles.prepbufr.nc ${IODA_CONV_COMP_TOL}
+                    DEPENDS bufr2ioda.x )
 
 
   ecbuild_add_test( TARGET  test_iodaconv_bufr_read_2_dim_blocks

--- a/test/testinput/bufr_ncep_prepbufr_aircft.yaml
+++ b/test/testinput/bufr_ncep_prepbufr_aircft.yaml
@@ -46,8 +46,8 @@ observations:
           #ObsValue
           pressure:
             query: "*/PRSLEVLA/P___INFO/P__EVENT/POB"
-#            transforms:
-#              - scale: 100
+            transforms:
+              - scale: 100
           airTemperature:
             query: "*/PRSLEVLA/T___INFO/T__EVENT/TOB"
             transforms:


### PR DESCRIPTION
## Description

Unit test test_iodaconv_prepbufr_ncep_aircftprofiles2ioda was failing due to a subtle problem with the way maxCount was being stored (as reference to a temporary rather than a copy). For some strange reason this actually worked most of the time... Surprised the compiler didn't warn about this (uuuuggg).

On the way to debugging this issue I noticed some other things that are potential problems so here is a list of fixes:

1) ResultSet::analyzeTarget:195  Type of `maxCount` changed to `const auto maxCount` from `const auto& maxCount`. Definitely wrong to have a reference to a temporary return value.
2) ResultSet::analyzeTarget:201-204  Valgrind flagged a potential issue where we were reading past the end of an array.
3) Data::isMissing:210-211  Improved comparison of float values. Wasn't causing an issue but maybe could...


