### PR TITLE
Compiler flags change for less warnings and easier debugging

### DIFF
--- a/cmake/compiler_flags_Clang_CXX.cmake
+++ b/cmake/compiler_flags_Clang_CXX.cmake
@@ -19,7 +19,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS}")
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
@@ -31,7 +31,7 @@ set(CMAKE_CXX_FLAGS_BIT "${CMAKE_CXX_FLAGS} -O2 -ffp-model=strict")
 # LINK FLAGS
 ####################################################################
 
-set(CMAKE_CXX_LINK_FLAGS "")
+set(CMAKE_CXX_LINK_FLAGS "-Wl,-no_compact_unwind")
 
 ####################################################################
 

--- a/cmake/compiler_flags_Clang_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_Clang_GNU_Fortran.cmake
@@ -20,7 +20,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions")
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace" )
+set( CMAKE_Fortran_FLAGS_DEBUG   "-g -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace" )
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS
@@ -32,7 +32,7 @@ set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions" )
 # LINK FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_LINK_FLAGS    "" )
+set( CMAKE_Fortran_LINK_FLAGS  "-Wl,-no_compact_unwind")
 
 ####################################################################
 

--- a/cmake/compiler_flags_GNU_CXX.cmake
+++ b/cmake/compiler_flags_GNU_CXX.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g -Wall -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -g -Wall -Wno-deprecated-declarations")
 
 ####################################################################
 # RELEASE FLAGS
@@ -19,7 +19,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_FXX_FLAGS} -O3")
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_FXX_FLAGS} -O0")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_FXX_FLAGS} -ggdb")
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -20,7 +20,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops -finline-functions")
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace" )
+set( CMAKE_Fortran_FLAGS_DEBUG   "-ggdb -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace" )
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS


### PR DESCRIPTION
## Description

This PR changes the compiler flags for compiling ioda-converters
1). eliminates libunwind from the gnu fortran compiler when compiing with clang c++ to cut down on compiler warnings that may confuse the user.

ld: warning: could not create compact unwind for ___qg_error_covariance_mod_MOD_qg_error_covariance_setup: stack subq instruction is too different from dwarf stack size
ld: warning: could not create compact unwind for ___qg_fields_mod_MOD_qg_fields_read_file: stack subq instruction is too different from dwarf stack size
ld: warning: could not create compact unwind for ___qg_fields_mod_MOD_qg_fields_write_file: stack subq instruction is too different from dwarf stack size
ld: warning: could not create compact unwind for ___qg_obsdb_mod_MOD_qg_obsdb_setup: stack subq instruction is too different from dwarf stack size


2) add in flags for gdb for the debug build type for non macos systems so that when debugging one doesn't need to do this manually.

This will be added to other repos piecemeal
## Issue(s) addressed

Resolves #1473 

## Dependencies

None

## Impact

None

## Checklist

- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ x] I have run the unit tests before creating the PR
