### PR TITLE
Update the satellite bias coefficient(BC) upgrader following naming conventions

### DIFF
--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -54,7 +54,8 @@ def satbias_upgrader(infile, outfile):
     'scanAngle': 'sensorScanAngle',
     'zenithAngle': 'sensorZenithAngle',
     'cloudLiquidWater': 'cloudWaterContent',
-    'orbialAngle': 'satelliteOrbitalAngle'
+    'orbialAngle': 'satelliteOrbitalAngle',
+    'emissivity': 'emissivityJacobian'
     }
 
     if 'bias_coefficients' in oldnc.variables.keys():

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -60,7 +60,7 @@ def satbias_upgrader(infile, outfile):
         'scanAngle': 'sensorScanAngle',
         'zenithAngle': 'sensorZenithAngle',
         'cloudLiquidWater': 'cloudWaterContent',
-        'orbialAngle': 'satelliteOrbitalAngle',
+        'orbitalAngle': 'satelliteOrbitalAngle',
         'emissivity': 'emissivityJacobian'
     }
 

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -5,7 +5,6 @@ import argparse
 import netCDF4 as nc
 import numpy as np
 
-
 def satbias_upgrader(infile, outfile):
     # convert satbias files from old to new format
 
@@ -51,43 +50,43 @@ def satbias_upgrader(infile, outfile):
         nobs_assim_out[0, :] = nobs_assim_in
 
     # loop through predictors and create predictor variables
+    replace_dict = {
+    'scanAngle': 'sensorScanAngle',
+    'zenithAngle': 'sensorZenithAngle',
+    'cloudLiquidWater': 'cloudWaterContent',
+    'orbialAngle': 'satelliteOrbitalAngle'
+    }
+
     if 'bias_coefficients' in oldnc.variables.keys():
         bias_coeff = oldnc.variables['bias_coefficients'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            if "order" in temp:
-                idorder = temp.index('order')
-                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
-            else:
-                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            if 'scanAngle' in predOut:
-                predOut = predOut.replace("scanAngle", "sensorScanAngle")
-            if 'zenithAngle' in predOut:
-                predOut = predOut.replace("zenithAngle", "sensorZenithAngle")
-            if 'cloudLiquidWater' in predOut:
-                predOut = predOut.replace("cloudLiquidWater", "cloudWaterContent")
-            if 'orbialAngle' in predOut:
-                predOut = predOut.replace("orbialAngle", "satelliteOrbitalAngle")
+            idorder = temp.index('order') if "order" in temp else None
+            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
+                  ('_' + temp[idorder] + '_' + temp[idorder + 1] if idorder is not None else '')
+
+            # Replace strings using dictionary
+            for key, value in replace_dict.items():
+                if key in predOut:
+                    predOut = predOut.replace(key, value)
+
             var1_out = newnc.createVariable(f"BiasCoefficients/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var1_out[0, :] = bias_coeff[i, :]
+
     if 'bias_coeff_errors' in oldnc.variables.keys():
         bias_coeff_err = oldnc.variables['bias_coeff_errors'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            if "order" in temp:
-                idorder = temp.index('order')
-                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
-            else:
-                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            if 'scanAngle' in predOut:
-                predOut = predOut.replace("scanAngle", "sensorScanAngle")
-            if 'zenithAngle' in predOut:
-                predOut = predOut.replace("zenithAngle", "sensorZenithAngle")
-            if 'cloudLiquidWater' in predOut:
-                predOut = predOut.replace("cloudLiquidWater", "cloudWaterContent")
-            if 'orbialAngle' in predOut:
-                predOut = predOut.replace("orbialAngle", "satelliteOrbitalAngle")
+            idorder = temp.index('order') if "order" in temp else None
+            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
+                  ('_' + temp[idorder] + '_' + temp[idorder + 1] if idorder is not None else '')
+
+            # Replace strings using dictionary
+            for key, value in replace_dict.items():
+                if key in predOut:
+                    predOut = predOut.replace(key, value)
+
             var2_out = newnc.createVariable(f"BiasCoefficientErrors/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var2_out[0, :] = bias_coeff_err[i, :]

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -40,7 +40,7 @@ def satbias_upgrader(infile, outfile):
         vars_out = newnc.createVariable("Variable", str, ("Variable",))
         vars_out[:] = vars_in
         dimname = 'Variable'
-    #Hui: TODO once using string Record is fixed in OOPS and UFO, change Record to str.
+    #Hui: TODO change Record to str so that it can be used to store extra information, like identifier
     #Hui: nrecs_out = newnc.createVariable("Record", str, ("Record"))
     #Hui: nrecs_out[0] = ' '
     nrecs_out = newnc.createVariable("Record", "i4", ("Record"))

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -31,7 +31,7 @@ def satbias_upgrader(infile, outfile):
     if 'channels' in oldnc.variables.keys():
         nvars = newnc.createDimension("Channel", len(oldnc.dimensions['nchannels']))
         channels_in = oldnc.variables['channels'][:]
-        channels_out = newnc.createVariable("Channel", "i4", ("Channel",))
+        channels_out = newnc.createVariable("sensorChannelNumber", "i4", ("Channel",))
         channels_out[:] = channels_in
         dimname = 'Channel'
     if 'variables' in oldnc.variables.keys():
@@ -53,8 +53,8 @@ def satbias_upgrader(infile, outfile):
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
             predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            if predOut == 'emissivity':
-                predOut = 'emissivityK'
+            #Hui if predOut == 'emissivity':
+            #Hui     predOut = 'emissivityK'
             var1_out = newnc.createVariable(f"BiasCoefficients/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var1_out[0, :] = bias_coeff[i, :]
@@ -63,8 +63,8 @@ def satbias_upgrader(infile, outfile):
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
             predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            if predOut == 'emissivity':
-                predOut = 'emissivityK'
+            #Hui if predOut == 'emissivity':
+            #Hui     predOut = 'emissivityK'
             var2_out = newnc.createVariable(f"BiasCoefficientErrors/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var2_out[0, :] = bias_coeff_err[i, :]

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -40,9 +40,9 @@ def satbias_upgrader(infile, outfile):
         vars_out = newnc.createVariable("Variable", str, ("Variable",))
         vars_out[:] = vars_in
         dimname = 'Variable'
-    #Hui: TODO change Record to str so that it can be used to store extra information, like identifier
-    #Hui: nrecs_out = newnc.createVariable("Record", str, ("Record"))
-    #Hui: nrecs_out[0] = ' '
+    # Hui: TODO change Record to str so that it can be used to store extra information, like identifier
+    # nrecs_out = newnc.createVariable("Record", str, ("Record"))
+    # nrecs_out[0] = ' '
     nrecs_out = newnc.createVariable("Record", "i4", ("Record"))
     nrecs_out[0] = 0
     if 'number_obs_assimilated' in oldnc.variables.keys():
@@ -56,7 +56,7 @@ def satbias_upgrader(infile, outfile):
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
             if "order" in temp:
-                idorder=temp.index('order')
+                idorder = temp.index('order')
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
             else:
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
@@ -76,7 +76,7 @@ def satbias_upgrader(infile, outfile):
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
             if "order" in temp:
-                idorder=temp.index('order')
+                idorder = temp.index('order')
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
             else:
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -5,6 +5,7 @@ import argparse
 import netCDF4 as nc
 import numpy as np
 
+
 def satbias_upgrader(infile, outfile):
     # convert satbias files from old to new format
 
@@ -28,34 +29,39 @@ def satbias_upgrader(infile, outfile):
     variables = False
     # create top level variables
     if 'channels' in oldnc.variables.keys():
-        nvars = newnc.createDimension("Channel", len(oldnc.dimensions['nchannels']))
+        nvars = newnc.createDimension(
+            "Channel", len(oldnc.dimensions['nchannels']))
         channels_in = oldnc.variables['channels'][:]
-        channels_out = newnc.createVariable("sensorChannelNumber", "i4", ("Channel",))
+        channels_out = newnc.createVariable(
+            "sensorChannelNumber", "i4", ("Channel",))
         channels_out[:] = channels_in
         dimname = 'Channel'
     if 'variables' in oldnc.variables.keys():
-        nvars = newnc.createDimension("Variable", len(oldnc.dimensions['nvariables']))
+        nvars = newnc.createDimension(
+            "Variable", len(oldnc.dimensions['nvariables']))
         vars_in = oldnc.variables['variables'][:]
         vars_out = newnc.createVariable("Variable", str, ("Variable",))
         vars_out[:] = vars_in
         dimname = 'Variable'
-    # Hui: TODO change Record to str so that it can be used to store extra information, like identifier
+    # Hui: TODO change Record to str so that it can be used to store
+    # extra information, like identifier
     # nrecs_out = newnc.createVariable("Record", str, ("Record"))
     # nrecs_out[0] = ' '
     nrecs_out = newnc.createVariable("Record", "i4", ("Record"))
     nrecs_out[0] = 0
     if 'number_obs_assimilated' in oldnc.variables.keys():
         nobs_assim_in = oldnc.variables['number_obs_assimilated'][:]
-        nobs_assim_out = newnc.createVariable("numberObservationsUsed", "i4", ("Record", dimname))
+        nobs_assim_out = newnc.createVariable(
+            "numberObservationsUsed", "i4", ("Record", dimname))
         nobs_assim_out[0, :] = nobs_assim_in
 
     # loop through predictors and create predictor variables
     replace_dict = {
-    'scanAngle': 'sensorScanAngle',
-    'zenithAngle': 'sensorZenithAngle',
-    'cloudLiquidWater': 'cloudWaterContent',
-    'orbialAngle': 'satelliteOrbitalAngle',
-    'emissivity': 'emissivityJacobian'
+        'scanAngle': 'sensorScanAngle',
+        'zenithAngle': 'sensorZenithAngle',
+        'cloudLiquidWater': 'cloudWaterContent',
+        'orbialAngle': 'satelliteOrbitalAngle',
+        'emissivity': 'emissivityJacobian'
     }
 
     if 'bias_coefficients' in oldnc.variables.keys():
@@ -64,7 +70,8 @@ def satbias_upgrader(infile, outfile):
             temp = pred.split('_')
             idorder = temp.index('order') if "order" in temp else None
             predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
-                  ('_' + temp[idorder] + '_' + temp[idorder + 1] if idorder is not None else '')
+                ('_' + temp[idorder] + '_' + temp[idorder + 1]
+                 if idorder is not None else '')
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():
@@ -81,7 +88,8 @@ def satbias_upgrader(infile, outfile):
             temp = pred.split('_')
             idorder = temp.index('order') if "order" in temp else None
             predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
-                  ('_' + temp[idorder] + '_' + temp[idorder + 1] if idorder is not None else '')
+                ('_' + temp[idorder] + '_' + temp[idorder + 1]
+                 if idorder is not None else '')
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -40,8 +40,11 @@ def satbias_upgrader(infile, outfile):
         vars_out = newnc.createVariable("Variable", str, ("Variable",))
         vars_out[:] = vars_in
         dimname = 'Variable'
-    nrecs_out = newnc.createVariable("Record", str, ("Record"))
-    nrecs_out[0] = ' '
+    #Hui: TODO once using string Record is fixed in OOPS and UFO, change Record to str.
+    #Hui: nrecs_out = newnc.createVariable("Record", str, ("Record"))
+    #Hui: nrecs_out[0] = ' '
+    nrecs_out = newnc.createVariable("Record", "i4", ("Record"))
+    nrecs_out[0] = 0
     if 'number_obs_assimilated' in oldnc.variables.keys():
         nobs_assim_in = oldnc.variables['number_obs_assimilated'][:]
         nobs_assim_out = newnc.createVariable("numberObservationsUsed", "i4", ("Record", dimname))
@@ -52,9 +55,16 @@ def satbias_upgrader(infile, outfile):
         bias_coeff = oldnc.variables['bias_coefficients'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            #Hui if predOut == 'emissivity':
-            #Hui     predOut = 'emissivityK'
+            if "order" in temp:
+                idorder=temp.index('order')
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
+            else:
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
+            #Hui: naming convention to be confirmed 
+            #Hui: if predOut == 'emissivity':
+            #Hui:     predOut = 'emissivityK'
+            if 'scanAngle' in predOut:
+                predOut = predOut.replace("scanAngle", "sensorScanAngle")
             var1_out = newnc.createVariable(f"BiasCoefficients/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var1_out[0, :] = bias_coeff[i, :]
@@ -62,9 +72,16 @@ def satbias_upgrader(infile, outfile):
         bias_coeff_err = oldnc.variables['bias_coeff_errors'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            #Hui if predOut == 'emissivity':
-            #Hui     predOut = 'emissivityK'
+            if "order" in temp:
+                idorder=temp.index('order')
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
+            else:
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
+            #Hui: naming convention to be confirmed 
+            #Hui: if predOut == 'emissivity':
+            #Hui:     predOut = 'emissivityK'
+            if 'scanAngle' in predOut:
+                predOut = predOut.replace("scanAngle", "sensorScanAngle")
             var2_out = newnc.createVariable(f"BiasCoefficientErrors/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var2_out[0, :] = bias_coeff_err[i, :]

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -60,11 +60,14 @@ def satbias_upgrader(infile, outfile):
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
             else:
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            #Hui: naming convention to be confirmed 
-            #Hui: if predOut == 'emissivity':
-            #Hui:     predOut = 'emissivityK'
             if 'scanAngle' in predOut:
                 predOut = predOut.replace("scanAngle", "sensorScanAngle")
+            if 'zenithAngle' in predOut:
+                predOut = predOut.replace("zenithAngle", "sensorZenithAngle")
+            if 'cloudLiquidWater' in predOut:
+                predOut = predOut.replace("cloudLiquidWater", "cloudWaterContent")
+            if 'orbialAngle' in predOut:
+                predOut = predOut.replace("orbialAngle", "satelliteOrbitalAngle")
             var1_out = newnc.createVariable(f"BiasCoefficients/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var1_out[0, :] = bias_coeff[i, :]
@@ -77,11 +80,14 @@ def satbias_upgrader(infile, outfile):
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder])+'_'+temp[idorder]+'_'+temp[idorder+1]
             else:
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:])
-            #Hui: naming convention to be confirmed 
-            #Hui: if predOut == 'emissivity':
-            #Hui:     predOut = 'emissivityK'
             if 'scanAngle' in predOut:
                 predOut = predOut.replace("scanAngle", "sensorScanAngle")
+            if 'zenithAngle' in predOut:
+                predOut = predOut.replace("zenithAngle", "sensorZenithAngle")
+            if 'cloudLiquidWater' in predOut:
+                predOut = predOut.replace("cloudLiquidWater", "cloudWaterContent")
+            if 'orbialAngle' in predOut:
+                predOut = predOut.replace("orbialAngle", "satelliteOrbitalAngle")
             var2_out = newnc.createVariable(f"BiasCoefficientErrors/{predOut}", "f4", ("Record", dimname),
                                             fill_value=-3.36879526e+38)
             var2_out[0, :] = bias_coeff_err[i, :]


### PR DESCRIPTION
jedi-ci-build-cache=skip


## Description
During the earlier VarBC code sprint, we decided to update the BC files with new format as well as following the IODA naming conventions. This upgrader was initially developed by Cory updates the BC files for the dimension part as well as some variable name changes. This PR is intended to complete this work, following the discussions with our kinds teams (EMC, MetOffice). 

Please note, this upgrader only works for the BC file in the format being used currently in develop (ufo-data)! The data files in VarBC-sprint (which has partial changes already) shouldnt use the upgrader in this PR. 

The new format will have two-dimension (Channel and Record) arrays for coefficients and errors per predictor. For satellite radiance BC, the dimension Record is not being used at this point and therefore is fixed to be 1. This Record dimension will be adopted in the new future for aircraft BC (or BC for other observation types.). For now, this PR focuses on satellite radiance (or any channel dependent observations). 

Naming convention: 
(1) uses CamelCase, instead of underscore in the variable names, unless some exceptions, e.g. scan_angle_order_1-> sensorScanAngle_order_1
(2) uses existing variable names from observation naming convention: e.g., channels->sensorChannelNumber, cloud_liquid_water->cloudWaterContent

Use of this upgrader: 
python3 satbias_upgrader.py -i input.nc4 -o output.nc4

## Impact

The commit this upgrader wouldn't have any impacts. However, use of this upgrader to BC files in develop would have impacts on coding and tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
