### PR TITLE
Windborne data is reverse labelled

### DIFF
--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -153,10 +153,19 @@ def main(args):
         latitude = [file['observations'][ii]['latitude'] for ii in range(len(file['observations']))]
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
-        pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
-        # NOTE: THESE 2 ARE TEMPORARILY REVERSED UNTIL DATA LABELING CONFIRMED
-        windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-        windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))] 
+        # Check when the file was created to handle wind components accordingly
+        dat_created = datetime.strptime(file['CreateDateTime'],"%Y-%m-%dT%H:%M:%S.%f")
+        # UPDATE THIS DATE WHEN Windborne CHANGES THEIR OBS RECORDS
+        # CreateDateTime description is not reported on their website. It appears to be either the 
+        # uploaded or downloaded date
+        dat_updated = datetime.strptime('2024-12-31T00:00:00',"%Y-%m-%dT%H:%M:%S")
+        if dat_created<dat_updated:
+          windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+          windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        else:
+          windEastward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+          windNorthward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
         #
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime

--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -154,19 +154,13 @@ def main(args):
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
         pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
-        # Check when the file was created to handle wind components accordingly
-        dat_created = datetime.strptime(file['CreateDateTime'], "%Y-%m-%dT%H:%M:%S.%f")
-        # UPDATE THIS DATE WHEN Windborne CHANGES THEIR OBS RECORDS
-        # CreateDateTime description is not reported on their website. It appears to be either the
-        # uploaded or downloaded date
-        dat_updated = datetime.strptime('2024-12-31T00:00:00', "%Y-%m-%dT%H:%M:%S")
-        if dat_created < dat_updated:
-            windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        # Check the speed variables available and handle accordingly (data changed in March 2024) 
+        if 'speed_u' in file['observations'][0].keys():
+            windEastward = [file['observations'][ii]['speed_u'] for ii in range(len(file['observations']))]
+            windNorthward = [file['observations'][ii]['speed_v'] for ii in range(len(file['observations']))]
         else:
-            windEastward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
-            windNorthward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-        #
+            windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))] 
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime
 

--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -154,13 +154,13 @@ def main(args):
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
         pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
-        # Check the speed variables available and handle accordingly (data changed in March 2024) 
+        # Check the speed variables available and handle accordingly (data changed in March 2024)
         if 'speed_u' in file['observations'][0].keys():
             windEastward = [file['observations'][ii]['speed_u'] for ii in range(len(file['observations']))]
             windNorthward = [file['observations'][ii]['speed_v'] for ii in range(len(file['observations']))]
         else:
             windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))] 
+            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime
 

--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -154,10 +154,10 @@ def main(args):
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
         pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
-        #### NOTE: THESE 2 ARE TEMPORARILY REVERSED UNTIL DATA LABELING CONFIRMED
+        # NOTE: THESE 2 ARE TEMPORARILY REVERSED UNTIL DATA LABELING CONFIRMED
         windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
         windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
-        ####
+        #
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime
 

--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -153,19 +153,19 @@ def main(args):
         latitude = [file['observations'][ii]['latitude'] for ii in range(len(file['observations']))]
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
-        pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))] 
+        pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
         # Check when the file was created to handle wind components accordingly
-        dat_created = datetime.strptime(file['CreateDateTime'],"%Y-%m-%dT%H:%M:%S.%f")
+        dat_created = datetime.strptime(file['CreateDateTime'], "%Y-%m-%dT%H:%M:%S.%f")
         # UPDATE THIS DATE WHEN Windborne CHANGES THEIR OBS RECORDS
-        # CreateDateTime description is not reported on their website. It appears to be either the 
+        # CreateDateTime description is not reported on their website. It appears to be either the
         # uploaded or downloaded date
-        dat_updated = datetime.strptime('2024-12-31T00:00:00',"%Y-%m-%dT%H:%M:%S")
-        if dat_created<dat_updated:
-          windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-          windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        dat_updated = datetime.strptime('2024-12-31T00:00:00', "%Y-%m-%dT%H:%M:%S")
+        if dat_created < dat_updated:
+            windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
         else:
-          windEastward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
-          windNorthward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+            windEastward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+            windNorthward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
         #
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime

--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -154,8 +154,10 @@ def main(args):
         longitude = [file['observations'][ii]['longitude'] for ii in range(len(file['observations']))]
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
         pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
-        windEastward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
-        windNorthward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+        #### NOTE: THESE 2 ARE TEMPORARILY REVERSED UNTIL DATA LABELING CONFIRMED
+        windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
+        windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        ####
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime
 


### PR DESCRIPTION
## Description

o-b looks a lot better in skylab if the u and v wind components are reversed first. to test whether this is true before applying hofx, we need to adjust the converter, re-convert the data, and re-run JEDI for the 2023 sept period. 

After talking to Windborne, their labeling was backwards and `speed_x` is now changed to `speed_v` and `speed_y` to `speed_u`. the converter is updated to handle both cases (speed_u or speed_y). 

The variable names from their previous data were compared to their updated obs website, and they match, aside from the addition of speed_u and _v. (march 21st 2024). There is expected to be a specific humidity variable to come in the future. 

**Their converter script:** https://github.com/windborne/to-prepbufr/blob/main/wb_to_prepbufr.py
^in which, they convert RH to Q and give error estimates:
```
# Right now, we simply hardcode these values to reasonable averages
        # However, in the future we may calculate these ourselves
        wind_x_error = 1.18
        wind_y_error = 1.18
        relative_humidity_error = 8.23
        temperature_error = 0.83
```

## Issue(s) addressed

Resolves #1489 