### PR TITLE
update handing of fractional seconds

### DIFF
--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -204,7 +204,7 @@ def get_reference_time(afile, osw_source):
         dat_ref = afile['time'].attrs['units'][-19:].decode('UTF-8')
         dat_ref = datetime.strptime(dat_ref, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
     elif osw_source in ('Spire'):
-        # the precision of the seconds appears troublesome when too many digits 
+        # the precision of the seconds appears troublesome when too many digits
         # take the floor of the seconds by stripping of fractional seconds
         dat_ref = afile['sample_time'].attrs['units'].decode('UTF-8').split()[-1]
         dat_ref = dat_ref.split('.')[0]

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -204,8 +204,11 @@ def get_reference_time(afile, osw_source):
         dat_ref = afile['time'].attrs['units'][-19:].decode('UTF-8')
         dat_ref = datetime.strptime(dat_ref, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
     elif osw_source in ('Spire'):
-        dat_ref = afile['sample_time'].attrs['units'][-29:-3].decode('UTF-8')
-        dat_ref = datetime.strptime(dat_ref, '%Y-%m-%dT%H:%M:%S.%f').replace(tzinfo=timezone.utc).timestamp()
+        # the precision of the seconds appears troublesome when too many digits 
+        # take the floor of the seconds by stripping of fractional seconds
+        dat_ref = afile['sample_time'].attrs['units'].decode('UTF-8').split()[-1]
+        dat_ref = dat_ref.split('.')[0]
+        dat_ref = datetime.strptime(dat_ref, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
     return dat_ref
 
 

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -198,10 +198,11 @@ def get_data_source(afile):
 
 def get_reference_time(afile, osw_source):
     if osw_source in ('CYGNSS'):
-        dat_ref = afile['sample_time'].attrs['units'][-19:].decode('UTF-8')
+        dat_ref = afile['sample_time'].attrs['units'].decode('UTF-8').split('since ')[-1]
         dat_ref = datetime.strptime(dat_ref, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
     elif osw_source in ('Muon'):
-        dat_ref = afile['time'].attrs['units'][-19:].decode('UTF-8')
+        # note same as CYGNSS except item key is simply time
+        dat_ref = afile['time'].attrs['units'].decode('UTF-8').split('since ')[-1]
         dat_ref = datetime.strptime(dat_ref, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
     elif osw_source in ('Spire'):
         # the precision of the seconds appears troublesome when too many digits


### PR DESCRIPTION
## Description

jedi-ci-build-cache=skip


update handing of fractional seconds in ocean surface wind converter,

there are different lengths of the fractional seconds which with the string extraction method didn't work correctly, this fixes that

also functionally do a floor of the seconds to handle cases where too many digits are provided in the fractional seconds and this also cased issues with datetime ptime function


## Issue(s) addressed

Resolves #1487 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
