### PR TITLE
add compatibility for two labeling of speeds

### DIFF
--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -124,12 +124,20 @@ def main(args):
         file = json.load(open(file_name))
 
         if file_cnt == 0:
+            observation_keys = file['observations'][0].keys()
+            if 'speed_u' in observation_keys:
+                speed_eastward = 'speed_u'
+                speed_northward = 'speed_v'
+                observation_keys = [x for x in observation_keys if x not in ['speed_x', 'speed_y']]
+            else:
+                speed_eastward = 'speed_y'
+                speed_northward = 'speed_x'
             # Create data frame to store each file's Meta Dataa
             df_metaData_files = pd.DataFrame(columns=file.keys())
             df_metaData_files.drop(['observations'], axis=1, inplace=True)
 
             # Create data frame to store all observation data
-            obs_data = pd.DataFrame(columns=file['observations'][0].keys())
+            obs_data = pd.DataFrame(columns=observation_keys)
             obs_data['releaseTime'] = None
             obs_data['stationElevation'] = None
 
@@ -137,8 +145,8 @@ def main(args):
             obs_data.drop(['id', 'mission_id'], axis=1, inplace=True)
 
             # Rename variables to IODA variables
-            obs_data.rename(columns={'speed_x': 'windEastward',
-                                     'speed_y': 'windNorthward',
+            obs_data.rename(columns={speed_eastward: 'windEastward',
+                                     speed_northward: 'windNorthward',
                                      'altitude': 'height',
                                      'mission_name': 'stationIdentification',
                                      'humidity': 'relativeHumidity',
@@ -155,12 +163,8 @@ def main(args):
         stationIdentification = [file['observations'][ii]['mission_name'] for ii in range(len(file['observations']))]
         pressure = [file['observations'][ii]['pressure'] for ii in range(len(file['observations']))]
         # Check the speed variables available and handle accordingly (data changed in March 2024)
-        if 'speed_u' in file['observations'][0].keys():
-            windEastward = [file['observations'][ii]['speed_u'] for ii in range(len(file['observations']))]
-            windNorthward = [file['observations'][ii]['speed_v'] for ii in range(len(file['observations']))]
-        else:
-            windEastward = [file['observations'][ii]['speed_y'] for ii in range(len(file['observations']))]
-            windNorthward = [file['observations'][ii]['speed_x'] for ii in range(len(file['observations']))]
+        windEastward = [file['observations'][ii][speed_eastward] for ii in range(len(file['observations']))]
+        windNorthward = [file['observations'][ii][speed_northward] for ii in range(len(file['observations']))]
         airTemperature = [file['observations'][ii]['temperature'] for ii in range(len(file['observations']))]
         dateTime = [file['observations'][ii]['timestamp'] for ii in range(len(file['observations']))]  # datetime
 


### PR DESCRIPTION

## Description

there have been changes to the wind speed files being ingested from Windborne, this includes changing from wind speed in the `x` and `y` to `u` and `v`.  

The winds were switched in the API from mis-labeled `speed_x` and `speed_y` to `speed_u` and `speed_v`.  The data was backprocssed.

However on 20240322T161500Z the files began showing *both* `speed_u` and `speed_v` as well as the `speed_x` and `speed_y` 

changes have been made to accommodate these modifications

## Issue(s) addressed

Resolves #1500 


## Impact

correctly decoded balloonsondes, must confirm if the `speed_x` and `speed_y` are now corrected to be the longitudinal and latitudinal winds

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
