### PR TITLE
Changing the IODA conventions for RH inside the balloon sonde converter

### DIFF
--- a/src/conventional/balloon_sonde_json2ioda.py
+++ b/src/conventional/balloon_sonde_json2ioda.py
@@ -47,7 +47,7 @@ obsvars = ['airTemperature',
            'windEastward',
            'windNorthward']
 obsvars_units = ['K', '1', 'm s-1', 'm s-1']
-obserrlist = [1.2, 20.0, 1.7, 1.7]
+obserrlist = [1.2, 0.2, 1.7, 1.7]
 obsvars_dtype = ['float',
                  'float',
                  'float',
@@ -179,6 +179,9 @@ def main(args):
 
         # convert temperature from Celsius to Kelvin
         airTemperature = [temp_i+273.15 if temp_i is not None else temp_i for temp_i in airTemperature]
+
+        # change units of relative humidity from percent to ratio
+        relativeHumidity = [rh_i/100 if rh_i is not None else rh_i for rh_i in relativeHumidity]
 
         # Make a list of lists to feed into dataframe
         data_lists = list(zip(height, relativeHumidity, latitude, longitude, stationIdentification, pressure,


### PR DESCRIPTION
## Description
This PR changes the IODA conventions for RH inside the balloon sonde converter.

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1523

## Dependencies
None.

## Impact
None.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
