### PR TITLE
[Bug] fix thickness variable names for specified layers

### DIFF
--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -62,7 +62,7 @@ def satbias_upgrader(infile, outfile):
         'cloudLiquidWater': 'cloudWaterContent',
         'orbitalAngle': 'satelliteOrbitalAngle',
         'emissivity': 'emissivityJacobian',
-        'Legendre': 'legendre' 
+        'Legendre': 'legendre'
     }
     # variable names that should not change
     do_not_disturb = ['thickness']

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -55,7 +55,7 @@ def satbias_upgrader(infile, outfile):
             "numberObservationsUsed", "i4", ("Record", dimname))
         nobs_assim_out[0, :] = nobs_assim_in
 
-    # loop through predictors and create predictor variables
+    # variable names that should be replaced
     replace_dict = {
         'scanAngle': 'sensorScanAngle',
         'zenithAngle': 'sensorZenithAngle',
@@ -63,18 +63,22 @@ def satbias_upgrader(infile, outfile):
         'orbitalAngle': 'satelliteOrbitalAngle',
         'emissivity': 'emissivityJacobian',
         'Legendre': 'legendre',
-        'thickness850300hPa: 'thickness_850_300hPa',
-        'thickness20050hPa': 'thickness_200_50hPa'
     }
+    # variable names that should not change
+    do_not_disturb = ['thickness']
 
+    # loop through predictors and create predictor variables
     if 'bias_coefficients' in oldnc.variables.keys():
         bias_coeff = oldnc.variables['bias_coefficients'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            idorder = temp.index('order') if "order" in temp else None
-            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
-                ('_' + temp[idorder] + '_' + temp[idorder + 1]
-                 if idorder is not None else '')
+            if temp[0].lower() not in do_not_disturb:
+                idorder = temp.index('order') if "order" in temp else None
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
+                    ('_' + temp[idorder] + '_' + temp[idorder + 1]
+                     if idorder is not None else '')
+            else:
+                predOut = pred
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():
@@ -89,10 +93,13 @@ def satbias_upgrader(infile, outfile):
         bias_coeff_err = oldnc.variables['bias_coeff_errors'][:]
         for i, pred in enumerate(predictors):
             temp = pred.split('_')
-            idorder = temp.index('order') if "order" in temp else None
-            predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
-                ('_' + temp[idorder] + '_' + temp[idorder + 1]
-                 if idorder is not None else '')
+            if temp[0].lower() not in do_not_disturb:
+                idorder = temp.index('order') if "order" in temp else None
+                predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
+                    ('_' + temp[idorder] + '_' + temp[idorder + 1]
+                     if idorder is not None else '')
+            else:
+                predOut = pred
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -62,7 +62,9 @@ def satbias_upgrader(infile, outfile):
         'cloudLiquidWater': 'cloudWaterContent',
         'orbitalAngle': 'satelliteOrbitalAngle',
         'emissivity': 'emissivityJacobian',
-        'Legendre': 'legendre'
+        'Legendre': 'legendre',
+        'thickness850300hPa: 'thickness_850_300hPa',
+        'thickness20050hPa': 'thickness_200_50hPa'
     }
 
     if 'bias_coefficients' in oldnc.variables.keys():

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -101,7 +101,7 @@ def satbias_upgrader(infile, outfile):
                     ('_' + temp[idorder] + '_' + temp[idorder + 1]
                      if idorder is not None else '')
             else:
-                predOut = pred # Leave the predictor unchanged if it's in do_not_disturb
+                predOut = pred  # Leave the predictor unchanged if it's in do_not_disturb
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -62,7 +62,7 @@ def satbias_upgrader(infile, outfile):
         'cloudLiquidWater': 'cloudWaterContent',
         'orbitalAngle': 'satelliteOrbitalAngle',
         'emissivity': 'emissivityJacobian',
-        'Legendre': 'legendre',
+        'Legendre': 'legendre' 
     }
     # variable names that should not change
     do_not_disturb = ['thickness']

--- a/src/gsi_varbc/satbias_upgrader.py
+++ b/src/gsi_varbc/satbias_upgrader.py
@@ -74,11 +74,12 @@ def satbias_upgrader(infile, outfile):
             temp = pred.split('_')
             if temp[0].lower() not in do_not_disturb:
                 idorder = temp.index('order') if "order" in temp else None
+                # Create the new predictor variable with the desired format
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
                     ('_' + temp[idorder] + '_' + temp[idorder + 1]
                      if idorder is not None else '')
             else:
-                predOut = pred
+                predOut = pred  # Leave the predictor unchanged if it's in do_not_disturb
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():
@@ -95,11 +96,12 @@ def satbias_upgrader(infile, outfile):
             temp = pred.split('_')
             if temp[0].lower() not in do_not_disturb:
                 idorder = temp.index('order') if "order" in temp else None
+                # Create the new predictor variable with the desired format
                 predOut = temp[0] + ''.join(ele.title() for ele in temp[1:idorder]) + \
                     ('_' + temp[idorder] + '_' + temp[idorder + 1]
                      if idorder is not None else '')
             else:
-                predOut = pred
+                predOut = pred # Leave the predictor unchanged if it's in do_not_disturb
 
             # Replace strings using dictionary
             for key, value in replace_dict.items():


### PR DESCRIPTION
run-ci-on-draft=true

## Description

The satbias_upgrader.py program updates the names of variables to camel case unless they are specified in the dictionary or with "order" in the variable names. 

It was found in the [issue #148](https://github.com/JCSDA-internal/jcsda-discussions/issues/148) that: the thickness predictors to e.g. thickness850300Hpa in the relevant .nc4 files, but the ObsSpace.yaml leaves the old names e.g. thickness_850_300hPa untranslated. Given such a variable name is not a common physical variable name, we decided not to reinforce the naming convention. Therefore, I added this variable name to the dictionary as an exception. Same for the other variable listed as follows:

Variable: [ "thickness_850_300hPa" ]
Variable: [ "thickness_200_50hPa" ]

## Issue(s) addressed

Resolves [issue #148](https://github.com/JCSDA-internal/jcsda-discussions/issues/148)

## Dependencies

n/a

## Impact

Expected impact on BC files containing these two variables converted using this upgrader

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
