### PR TITLE
[bugfix] Fix the timestamp for proper 4 digits (ignore seconds)

### DIFF
--- a/src/mrms/mrms_grib2ioda.py
+++ b/src/mrms/mrms_grib2ioda.py
@@ -216,8 +216,10 @@ def read_grib(input_file, obsvars, min_dbz):
             t = eccodes.codes_get(gid, "dataTime")
             if t > 2359:
                 logging.debug(f"DEBUG: dataTime is more than 4 digits, adjusting")
-                t = t/100
-            dt = datetime.strptime(str(d)+str(t), "%Y%m%d%H%M")
+                str_t = str(int(t/100))
+            else:
+                str_t = "{:04d}".format(t)
+            dt = datetime.strptime(str(d)+str_t, "%Y%m%d%H%M")
             logging.debug(f"DEBUG: date info: {d} {t}Z")
 
             ni = eccodes.codes_get(gid, "Ni")


### PR DESCRIPTION
## Description

The time stamp (hours/minutes) was incorrect since it could be single digit or two digits.  So force the integer retrieved for the time to be 4 digits before parsing for the datetime object.

## Issue(s) addressed

A separate one was not created.

## Dependencies

None

## Impact

There should be no impacts on downstream repositories

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
