### PR TITLE
Update AirNow converter

### DIFF
--- a/src/compo/airnow2ioda_nc.py
+++ b/src/compo/airnow2ioda_nc.py
@@ -8,7 +8,7 @@
 #
 # Read airnow text data file and convert to IODA netcdf
 
-import os, sys
+import os
 from datetime import datetime
 from pathlib import Path
 import netCDF4 as nc

--- a/src/compo/airnow2ioda_nc.py
+++ b/src/compo/airnow2ioda_nc.py
@@ -188,8 +188,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.epa_list:
-        locationKeyList.append(("airqualityClassification", "integer", ""))
-        meta_keys.append("airqualityClassification")
+        locationKeyList.append(("airQualityClassification", "integer", ""))
+        meta_keys.append("airQualityClassification")
 
     print('sitefile=', args.sitefile)
 
@@ -238,7 +238,7 @@ if __name__ == '__main__':
         data['height'] = np.append(data['height'], np.array(f3['elevation']) + 10.0)
 
         if args.epa_list:
-            data['airqualityClassification'] = np.append(data['airqualityClassification'],
+            data['airQualityClassification'] = np.append(data['airQualityClassification'],
                                                          np.array(f3['loc_type'], dtype=np.int32))
 
         GlobalAttrs['sourceFiles'] += str(infile.split('/')[-1]) + ", "

--- a/src/compo/airnow2ioda_nc.py
+++ b/src/compo/airnow2ioda_nc.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 
+#
+# (C) Copyright 2024 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
 # Read airnow text data file and convert to IODA netcdf
+
 import os, sys
 from datetime import datetime
 from pathlib import Path

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ list( APPEND test_input
   testinput/ascat_ssm.nc
   testinput/SM_REPR_MIR_OSUDP2_20100601T000131_20100601T001849_662_120_1.nc
   testinput/airnow_sites.dat
+  testinput/airnow_sites_epalist_20240716.csv
   testinput/airnow_2020081306.dat
   testinput/aeronet_aod.dat
   testinput/dt_global_twosat_phy_l4_20190101_vDT2021.nc
@@ -147,6 +148,7 @@ list( APPEND test_output
   testoutput/ascat_ssm.nc
   testoutput/smos_sss_l2.nc
   testoutput/airnow_2020081306.nc
+  testoutput/airnow_2020081306_epalist.nc
   testoutput/aeronet_aod.nc
   testoutput/ioda_dt_global_twosat_phy_l4_20190101_vDT2021.nc
   testoutput/ioda_global_vavh_l3_rt_s3a_20210930T18.nc
@@ -1340,7 +1342,19 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow
                           -i testinput/airnow_2020081306.dat
                           -s testinput/airnow_sites.dat
                           -o testrun/airnow_2020081306.nc"
-                          airnow_2020081306.nc ${IODA_CONV_COMP_TOL})
+
+ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow_epalist
+                  TYPE    SCRIPT
+                  ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                  COMMAND bash
+                  ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                          netcdf
+                          "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/airnow2ioda_nc.py
+                          -i testinput/airnow_2020081306.dat
+                          -s testinput/airnow_sites_epalist_20240716.csv
+			  --epa_list
+                          -o testrun/airnow_2020081306_epalist.nc"
+                          airnow_2020081306_epalist.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tropomi_co_total
                   TYPE    SCRIPT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1360,6 +1360,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow
                           -i testinput/airnow_2020081306.dat
                           -s testinput/airnow_sites.dat
                           -o testrun/airnow_2020081306.nc"
+                          airnow_2020081306.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_airnow_epalist
                   TYPE    SCRIPT

--- a/test/testoutput/airnow_2020081306.nc
+++ b/test/testoutput/airnow_2020081306.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fa3f387e6b6b84f0201bdd60a1da89049e55d1dfe1af84c7e1bb722d8ce7a8a
-size 75505
+oid sha256:062b3d473feb177cd0a9ea900e90d0cdcef7960409477d9ec4ade4b2efcff59d
+size 86321

--- a/test/testoutput/airnow_2020081306_epalist.nc
+++ b/test/testoutput/airnow_2020081306_epalist.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3a59a703c0d79f4a6ee5971fb0ee1cdd0fea2cc137efa30e5450293c287942c
+oid sha256:332a4a1d17d824d2ae775556517203eb5e3bfb11dbed4b37231c3f6eb8f02153
 size 81278

--- a/test/testoutput/airnow_2020081306_epalist.nc
+++ b/test/testoutput/airnow_2020081306_epalist.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3a59a703c0d79f4a6ee5971fb0ee1cdd0fea2cc137efa30e5450293c287942c
+size 81278


### PR DESCRIPTION
## Description
This PR updates the converter for AirNow observations with, 
1. Add land use to variable `airqualityClassification` (0=UNKNOWN, 1=RURAL, 2=SUBURBAN, 3=URBAN AND CENTER CITY) based on a full site list provided by EPA
2. Users can define whether the site list contains the land use information by giving `--epa_list` argument
3. multi-files capability 

## Issue(s) addressed

Resolves #1297 

## Dependencies
No dependencies

## Impact

Expected impact on downstream repositories:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
