### PR TITLE
fix typo in test reference

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -603,7 +603,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_gmao_argo
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/gmao_obs2ioda.py
                           -i testinput/gmao_argo.nc
                           -o testrun/gmao_argo.nc"
-                          godae_prof.nc ${IODA_CONV_COMP_TOL})
+                          gmao_argo.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_godae_prof
                   TYPE    SCRIPT

--- a/test/testoutput/gmao_argo.nc
+++ b/test/testoutput/gmao_argo.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f889b10890bf7f7f05e9280fd11fd18372d68ddd4c79813ec2ef523ab23dec81
-size 115479
+oid sha256:f655369d129a8197a7227a61c9b9a87b246f1bf15113549b4c9689b3dc354e4d
+size 116988


### PR DESCRIPTION
## Description

the new ctest pointed to the incorrect reference testoutput file

this ctest was introduced with the merge of https://github.com/JCSDA-internal/ioda-converters/pull/1528

this will correct the typo in the CMakeLists.txt and update the reference file itself in testoutput

## Issue(s) addressed

Resolves #1544 

## Impact

Ctest correctly passes

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
