### PR TITLE
Assigning error to DerivedObsValues. OSW

### DIFF
--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -189,10 +189,9 @@ def main(args):
 
     # Transfer from the 1-D data vectors and ensure output data (ioda_data) types using numpy.
     for iodavar in obsvars_ttl:
-        #iodavar = obsvars[0]
         ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
         ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
-        if iodavar=='windSpeed':
+        if iodavar == 'windSpeed':
             ioda_data[(iodavar, obsErrName)] = np.array(obs_data[iodavar+obsErrName], dtype=np.float32)
 
     # setup the IODA writer

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -52,7 +52,7 @@ MetaDataKeyList = [
 meta_keys = [m_item[0] for m_item in MetaDataKeyList]
 
 # The outgoing IODA variables (ObsValues), their units, and assigned constant ObsError.
-obsvars = ['windSpeed','windSpeed'+obsErrName, 'windSpeed'+obsQcName]
+obsvars = ['windSpeed', 'windSpeed'+obsErrName, 'windSpeed'+obsQcName]
 obsvars_units = 'm s-1'
 obsvars_dtype = 'float'
 
@@ -128,7 +128,7 @@ def main(args):
         file_cnt += 1
 
     # Add 0s for wind components to be able to assign obsError
-    obsvars_0s = ['windEastward','windNorthward']
+    obsvars_0s = ['windEastward', 'windNorthward']
     obs_data[obsvars_0s[0]] = 0.
     obs_data[obsvars_0s[1]] = 0.
     obs_data[obsvars_0s[0]+obsQcName] = 0.
@@ -141,7 +141,7 @@ def main(args):
     obs_data[iodavar].fillna(missing_vals[obsvars_dtype], inplace=True)
 
     # find where windSpeed is missing and set the components to missing as well
-    mask = obs_data['windSpeed']==missing_vals[obsvars_dtype]
+    mask = obs_data['windSpeed'] == missing_vals[obsvars_dtype]
     obs_data[obsvars_0s[0]].mask(mask.values, missing_vals[obsvars_dtype], inplace=True)
     obs_data[obsvars_0s[1]].mask(mask.values, missing_vals[obsvars_dtype], inplace=True)
 
@@ -165,19 +165,19 @@ def main(args):
     varDict = defaultdict(lambda: DefaultOrderedDict(dict))
     varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
 
-    obsvars_0s.insert(0,obsvars[0])
+    obsvars_0s.insert(0, obsvars[0])
     obsvars_ttl = obsvars_0s
     # Set coordinates and units of the ObsValues.
     for iodavar in obsvars_ttl:
-    # set the obs space attributes
-      varDict[iodavar]['valKey'] = iodavar, obsValName
-      varDict[iodavar]['errKey'] = iodavar, obsErrName
-      varDict[iodavar]['qcKey'] = iodavar, obsQcName
-      varAttrs[iodavar, obsValName]['coordinates'] = 'longitude latitude'
-      varAttrs[iodavar, obsErrName]['coordinates'] = 'longitude latitude'
-      varAttrs[iodavar, obsQcName]['coordinates'] = 'longitude latitude'
-      varAttrs[iodavar, obsValName]['units'] = obsvars_units
-      varAttrs[iodavar, obsErrName]['units'] = obsvars_units
+        # set the obs space attributes
+        varDict[iodavar]['valKey'] = iodavar, obsValName
+        varDict[iodavar]['errKey'] = iodavar, obsErrName
+        varDict[iodavar]['qcKey'] = iodavar, obsQcName
+        varAttrs[iodavar, obsValName]['coordinates'] = 'longitude latitude'
+        varAttrs[iodavar, obsErrName]['coordinates'] = 'longitude latitude'
+        varAttrs[iodavar, obsQcName]['coordinates'] = 'longitude latitude'
+        varAttrs[iodavar, obsValName]['units'] = obsvars_units
+        varAttrs[iodavar, obsErrName]['units'] = obsvars_units
 
     # Set units of the MetaData variables and all _FillValues.
     for key in meta_keys:
@@ -189,11 +189,11 @@ def main(args):
 
     # Transfer from the 1-D data vectors and ensure output data (ioda_data) types using numpy.
     for iodavar in obsvars_ttl:
-    #iodavar = obsvars[0]
-      ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
-      ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
-      if iodavar=='windSpeed':
-          ioda_data[(iodavar, obsErrName)] = np.array(obs_data[iodavar+obsErrName], dtype=np.float32)
+        #iodavar = obsvars[0]
+        ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
+        ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
+        if iodavar=='windSpeed':
+            ioda_data[(iodavar, obsErrName)] = np.array(obs_data[iodavar+obsErrName], dtype=np.float32)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output_file, MetaDataKeyList, DimDict)

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -205,6 +205,7 @@ def main(args):
     # report time
     toc = record_time(tic=tic)
 
+
 def get_data_source(afile):
     if 'title' in afile.attrs.keys() and 'CYGNSS' in afile.attrs['title'].decode('UTF-8'):
         return 'CYGNSS'

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -52,13 +52,15 @@ MetaDataKeyList = [
 meta_keys = [m_item[0] for m_item in MetaDataKeyList]
 
 # The outgoing IODA variables (ObsValues), their units, and assigned constant ObsError.
-obsvars = ['windSpeed', 'windSpeed'+obsErrName, 'windSpeed'+obsQcName]
+obsvars = ['windSpeed','windSpeed'+obsErrName, 'windSpeed'+obsQcName]
 obsvars_units = 'm s-1'
 obsvars_dtype = 'float'
 
 # Assign dimensions to the obs values
 VarDims = {
     'windSpeed': ['Location'],
+    'windEastward': ['Location'],
+    'windNorthward': ['Location'],
 }
 
 # Assign missing value details for the variables
@@ -125,11 +127,23 @@ def main(args):
         # count files
         file_cnt += 1
 
+    # Add 0s for wind components to be able to assign obsError
+    obsvars_0s = ['windEastward','windNorthward']
+    obs_data[obsvars_0s[0]] = 0.
+    obs_data[obsvars_0s[1]] = 0.
+    obs_data[obsvars_0s[0]+obsQcName] = 0.
+    obs_data[obsvars_0s[1]+obsQcName] = 0.
+
     # replace missing values
     for MetaDataKey in MetaDataKeyList:
         obs_data[MetaDataKey[0]].fillna(missing_vals[MetaDataKey[1]], inplace=True)
     iodavar = obsvars[0]
     obs_data[iodavar].fillna(missing_vals[obsvars_dtype], inplace=True)
+
+    # find where windSpeed is missing and set the components to missing as well
+    mask = obs_data['windSpeed']==missing_vals[obsvars_dtype]
+    obs_data[obsvars_0s[0]].mask(mask.values, missing_vals[obsvars_dtype], inplace=True)
+    obs_data[obsvars_0s[1]].mask(mask.values, missing_vals[obsvars_dtype], inplace=True)
 
     # sort by instrument and then time
     if args.sort:
@@ -151,17 +165,19 @@ def main(args):
     varDict = defaultdict(lambda: DefaultOrderedDict(dict))
     varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
 
+    obsvars_0s.insert(0,obsvars[0])
+    obsvars_ttl = obsvars_0s
     # Set coordinates and units of the ObsValues.
-    iodavar = obsvars[0]
+    for iodavar in obsvars_ttl:
     # set the obs space attributes
-    varDict[iodavar]['valKey'] = iodavar, obsValName
-    varDict[iodavar]['errKey'] = iodavar, obsErrName
-    varDict[iodavar]['qcKey'] = iodavar, obsQcName
-    varAttrs[iodavar, obsValName]['coordinates'] = 'longitude latitude'
-    varAttrs[iodavar, obsErrName]['coordinates'] = 'longitude latitude'
-    varAttrs[iodavar, obsQcName]['coordinates'] = 'longitude latitude'
-    varAttrs[iodavar, obsValName]['units'] = obsvars_units
-    varAttrs[iodavar, obsErrName]['units'] = obsvars_units
+      varDict[iodavar]['valKey'] = iodavar, obsValName
+      varDict[iodavar]['errKey'] = iodavar, obsErrName
+      varDict[iodavar]['qcKey'] = iodavar, obsQcName
+      varAttrs[iodavar, obsValName]['coordinates'] = 'longitude latitude'
+      varAttrs[iodavar, obsErrName]['coordinates'] = 'longitude latitude'
+      varAttrs[iodavar, obsQcName]['coordinates'] = 'longitude latitude'
+      varAttrs[iodavar, obsValName]['units'] = obsvars_units
+      varAttrs[iodavar, obsErrName]['units'] = obsvars_units
 
     # Set units of the MetaData variables and all _FillValues.
     for key in meta_keys:
@@ -172,10 +188,12 @@ def main(args):
         ioda_data[(key, metaDataName)] = np.array(obs_data[key], dtype=dtypes[dtypestr])
 
     # Transfer from the 1-D data vectors and ensure output data (ioda_data) types using numpy.
-    iodavar = obsvars[0]
-    ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
-    ioda_data[(iodavar, obsErrName)] = np.array(obs_data[iodavar+obsErrName], dtype=np.float32)
-    ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
+    for iodavar in obsvars_ttl:
+    #iodavar = obsvars[0]
+      ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
+      ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
+      if iodavar=='windSpeed':
+          ioda_data[(iodavar, obsErrName)] = np.array(obs_data[iodavar+obsErrName], dtype=np.float32)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output_file, MetaDataKeyList, DimDict)

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -131,8 +131,8 @@ def main(args):
     obsvars_0s = ['windEastward', 'windNorthward']
     obs_data[obsvars_0s[0]] = 0.
     obs_data[obsvars_0s[1]] = 0.
-    obs_data[obsvars_0s[0]+obsQcName] = 0.
-    obs_data[obsvars_0s[1]+obsQcName] = 0.
+    obs_data[obsvars_0s[0]+obsQcName] = 0
+    obs_data[obsvars_0s[1]+obsQcName] = 0
 
     # replace missing values
     for MetaDataKey in MetaDataKeyList:

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -166,9 +166,8 @@ def main(args):
     varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
 
     obsvars_0s.insert(0, obsvars[0])
-    obsvars_ttl = obsvars_0s
     # Set coordinates and units of the ObsValues.
-    for iodavar in obsvars_ttl:
+    for iodavar in obsvars_0s:
         # set the obs space attributes
         varDict[iodavar]['valKey'] = iodavar, obsValName
         varDict[iodavar]['errKey'] = iodavar, obsErrName
@@ -188,7 +187,7 @@ def main(args):
         ioda_data[(key, metaDataName)] = np.array(obs_data[key], dtype=dtypes[dtypestr])
 
     # Transfer from the 1-D data vectors and ensure output data (ioda_data) types using numpy.
-    for iodavar in obsvars_ttl:
+    for iodavar in obsvars_0s:
         ioda_data[(iodavar, obsValName)] = np.array(obs_data[iodavar], dtype=np.float32)
         ioda_data[(iodavar, obsQcName)] = np.array(obs_data[iodavar+obsQcName], dtype=np.int32)
         if iodavar == 'windSpeed':


### PR DESCRIPTION
## Description

Ocean surface winds, osw, are data only containing wind spd. the components are calculated using an ObsFunction, which store the components in DerivedObsValues group. We aren't able to assign ObsError to the DerivedObsValue group. This PR creates a workaround for that. 

ObsValue/windEastward and ObsValue/windNorthward are initiated in the converter as 0's, which makes them `observed variables` in addition to the `simulated variables` and allows for error assignment. Missing values are also assigned in colocations as missing wind speed values. 

skylab yamls need to be updated to match what worked in the ctest. 

to test it, I ran the `fv3-jedi` ctest: `fv3jedi_test_tier1_hyb-3dvar` with an obsSpace for CYGNSS and the needed variables. It is able to process the CYGNSS obs and creates an hofx of the wind components and has the expected ObsErrors we assign. 

**NOTE**:
The current handling of PreQC is to reject all windSpeed values that have 'bad' flags. The desired functionality is to assign the flags to both the speed and components, and let the user choose the flags to use. Currently we are not able to pass the PreQC flags to the wind components, so this needs to be addressed (perhaps another PR). 

**NOTE**:
**Any new CYGNSS and Spire obs need to use this converter and the updated skylab yamls instead of UFO branch with the FinalCheck.cc hack.** 

## Dependencies

skylab PR:  https://github.com/JCSDA-internal/skylab/pull/561

## Checklist

- [x] a converted obs file of CYGNSS runs with hofx 
- [x] the correct ObsError is assigned
- [x] the skylab yamls are updated
