### PR TITLE
fix the crash of bufr2ioda.x when it is copied outside the build directory

### DIFF
--- a/src/bufr/CMakeLists.txt
+++ b/src/bufr/CMakeLists.txt
@@ -125,6 +125,8 @@ if ( iodaconv_bufr_query_ENABLED )
 
   add_library( ${PROJECT_NAME}::ingester ALIAS ingester)
 
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${CMAKE_BINARY_DIR}/lib64")
   ecbuild_add_executable( TARGET  bufr2ioda.x
                           SOURCES bufr2ioda.cpp
                           LIBS    ingester )


### PR DESCRIPTION
## Description

This PR fixes the crash of bufr2ioda.x when it is copied outside the build directory

## Issue(s) addressed

Resolves #1547 

## Dependencies

none

## Impact

none

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR

