### PR TITLE
Update gsi_ncdiag.py

### DIFF
--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -163,7 +163,7 @@ all_LocKeyList = {
     'SCCF_chan_wavelen': ('sensorCentralFrequency', 'double'),
     'QI_with_FC': ('percentConfidenceWithForecast', 'float'),
     'QI_without_FC': ('percentConfidenceWithoutForecast', 'float'),
-    'Data_Vertical_Velocity': ('windUpward', 'float'),
+    'Data_Vertical_Velocity': ('instantaneousAltitudeRate', 'float'),
     'LaunchTime': ('releaseTime', 'float'),
     'wind_computation_method': ('windComputationMethod', 'integer'),
     'satellite_zenith_angle': ('satelliteZenithAngle', 'float'),


### PR DESCRIPTION
Change windUpward to instantaneousAltitudeRate, which is the convention.

## Description

Change windUpward to instantaneousAltitudeRate, which is the convention.

## Issue(s) addressed

Mentioned in [https://github.com/JCSDA-internal/ufo/issues/3029](UFO#3029)

## Dependencies

None

## Impact

Output of GSI IODA file will change.


