### PR TITLE
Save mass content and effective radius of graupel particle

### DIFF
--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -229,7 +229,6 @@ gsi_add_vars_allsky = {
     'hxdbz': 'GsiHofX',
     'hxrw': 'GsiHofX',
     'standard_deviation_clear_bt': 'ClearSkyStdDev',
-    'Emissivity': 'GsiEmissivity',
 }
 
 gsi_add_qcvars_allsky = {

--- a/src/gsi_ncdiag/gsi_ncdiag.py
+++ b/src/gsi_ncdiag/gsi_ncdiag.py
@@ -229,6 +229,7 @@ gsi_add_vars_allsky = {
     'hxdbz': 'GsiHofX',
     'hxrw': 'GsiHofX',
     'standard_deviation_clear_bt': 'ClearSkyStdDev',
+    'Emissivity': 'GsiEmissivity',
 }
 
 gsi_add_qcvars_allsky = {
@@ -433,6 +434,9 @@ geovals_vars = {
     'effective_radius_of_cloud_particle_03': 'effective_radius_of_rain_particle',
     'atmosphere_mass_content_of_cloud_04': 'mass_content_of_snow_in_atmosphere_layer',
     'effective_radius_of_cloud_particle_04': 'effective_radius_of_snow_particle',
+    'atmosphere_mass_content_of_cloud_05': 'mass_content_of_graupel_in_atmosphere_layer',
+    'effective_radius_of_cloud_particle_05': 'effective_radius_of_graupel_particle',
+    'cloud_area_fraction_in_atmosphere': 'cloud_area_fraction_in_atmosphere_layer',
     'Water_Fraction': 'water_area_fraction',
     'Land_Fraction': 'land_area_fraction',
     'Ice_Fraction': 'ice_area_fraction',
@@ -566,6 +570,8 @@ units_values = {
     'effective_radius_of_rain_particle': '1e-6 m',
     'mass_content_of_snow_in_atmosphere_layer': 'kg m-2',
     'effective_radius_of_snow_particle': '1e-6 m',
+    'mass_content_of_graupel_in_atmosphere_layer': 'kg m-2',
+    'effective_radius_of_graupel_particle': '1e-6 m',
     'surface_temperature_where_sea': 'K',
     'surface_temperature_where_land': 'K',
     'surface_temperature_where_ice': 'K',


### PR DESCRIPTION
Save mass content and effective radius of graupel particle as well as cloud_area_fraction from GSI diagnostic outputs. Outputs are used to validate configurations of the all-sky assimilation with precipitable clouds in GFS.

## Dependencies
None
## Impact
None

## Checklist

- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
