### PR TITLE
Adding try statement to tropomi converter

### DIFF
--- a/src/compo/tropomi_no2_co_nc2ioda.py
+++ b/src/compo/tropomi_no2_co_nc2ioda.py
@@ -68,6 +68,7 @@ class tropomi(object):
             except OSError as e:
                 if 'NetCDF: Unknown file format' in str(e):
                     print(f'WARNING: This is not a NetCDF file: {f}')
+                    continue
                 else:
                     raise e
 

--- a/src/compo/tropomi_no2_co_nc2ioda.py
+++ b/src/compo/tropomi_no2_co_nc2ioda.py
@@ -61,7 +61,15 @@ class tropomi(object):
         # loop through input filenames
         first = True
         for f in self.filenames:
-            ncd = nc.Dataset(f, 'r')
+
+            # Open file
+            try:
+                ncd = nc.Dataset(f, 'r')
+            except OSError as e:
+                if 'NetCDF: Unknown file format' in str(e):
+                    print(f'WARNING: This is not a NetCDF file: {f}')
+                else:
+                    raise e
 
             # get global attributes
             AttrData['date_time_string'] = ncd.getncattr('time_reference')[0:19]+'Z'


### PR DESCRIPTION
## Description

A bug was found when running the observation ingest suite, where the converter would error out if one file out of the group was unable to be opened. This PR adds a try statement to check each file during processing based on suggestions from Fabio. It will not use the file if it cannot open it, but the other files in the batch will be used to convert the observations to iodaformat. 

Previous error message and failing EWOK suite:
```
ncdump: obs.tropomi_s5p_no2.20241105T120000Z.3.nc: NetCDF: Unknown file format
```

New message and continuation of processing:
```
WARNING: This is not a NetCDF file: /Users/agriffin/JEDI_workflow/workdir/ce5b90/20241105T120000Z/obs_tropomi_s5p_no2/obs.tropomi_s5p_no2.20241105T120000Z.3.nc
```

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ewok/issues/1076

## Dependencies

None

## Impact

Observation ingest CI

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
