### PR TITLE
fix cygnss quality flag

### DIFF
--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -387,7 +387,7 @@ def quality_control(obs_data, qc_strict=False):
 
 
 def get_normalized_bit(value, bit_index):
-    return (int(value) >> bit_index) & 1 == 0
+    return (int(value) >> bit_index) & 1 == 1
 
 
 if __name__ == "__main__":

--- a/src/hdf5/osw_2ioda.py
+++ b/src/hdf5/osw_2ioda.py
@@ -387,7 +387,7 @@ def quality_control(obs_data, qc_strict=False):
 
 
 def get_normalized_bit(value, bit_index):
-    return (value >> bit_index) & 1
+    return (int(value) >> bit_index) & 1 == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This corrects the get_normalized_bit function in the CyGNSS ingest

## Issue(s) addressed

Resolves #1599 

## Impact

Correct interpretation of quality bits

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
