### PR TITLE
update converter for uplifted public released data from COWVR

### DIFF
--- a/src/hdf5/CMakeLists.txt
+++ b/src/hdf5/CMakeLists.txt
@@ -2,6 +2,7 @@ list(APPEND scripts
   atms_netcdf_hdf5_2ioda.py
   amsr2_2ioda.py
   cloudsat_netcdf_to_ioda.py
+  cowvr_hdf5_2ioda.py
   gmi_2ioda.py
   osw_2ioda.py
   ozone_product_2ioda.py

--- a/src/hdf5/cowvr_hdf5_2ioda.py
+++ b/src/hdf5/cowvr_hdf5_2ioda.py
@@ -166,29 +166,29 @@ def get_tempest_data(f, obs_data, add_qc=True):
     WMO_sat_ID = get_WMO_satellite_ID(f['Metadata']['InstrumentShortName'][0].decode("utf-8"))
 
     # "Geolocation and flags"
-    sensor_altitude = np.array(f['Geolocation']['sat_alt'], dtype='float32')
-    # sat_alt_flag = np.array(f['Geolocation']['sc_att_flag'], dtype='int32')
-    sat_alt_flag = np.array(f['CalibratedSceneTemperatures']['obs_qual_flag'], dtype='int32')
-    obs_data[('latitude', metaDataName)] = np.array(f['Geolocation']['obs_lat'], dtype='float32')
-    obs_data[('longitude', metaDataName)] = np.array(f['Geolocation']['obs_lon'], dtype='float32')
+    sensor_altitude = np.array(f['GeolocationAndFlags']['sat_alt'], dtype='float32')
+    # sat_alt_flag = np.array(f['GeolocationAndFlags']['sc_att_flag'], dtype='int32')
+    sat_alt_flag = np.array(f['GeolocationAndFlags']['obs_qual_flag'], dtype='int32')
+    obs_data[('latitude', metaDataName)] = np.array(f['GeolocationAndFlags']['obs_lat'], dtype='float32')
+    obs_data[('longitude', metaDataName)] = np.array(f['GeolocationAndFlags']['obs_lon'], dtype='float32')
     obs_data[('sensorChannelNumber', metaDataName)] = np.array(np.arange(5)+1, dtype='int32')
-    obs_data[('sensorScanPosition', metaDataName)] = np.array(f['Geolocation']['scan_pos'], dtype='int32')
-    obs_data[('solarZenithAngle', metaDataName)] = np.array(f['Geolocation']['sat_solar_zen'], dtype='float32')
-    obs_data[('solarAzimuthAngle', metaDataName)] = np.array(f['Geolocation']['sat_solar_az'], dtype='float32')
-    obs_data[('sensorZenithAngle', metaDataName)] = np.array(f['Geolocation']['earth_inc_ang'], dtype='float32')
-    obs_data[('sensorAzimuthAngle', metaDataName)] = np.array(f['Geolocation']['earth_az_ang'], dtype='float32')
-    # instr_scan_angle = np.array(f['Geolocation']['instr_scan_ang'], dtype='float32')
+    obs_data[('sensorScanPosition', metaDataName)] = np.array(f['GeolocationAndFlags']['scan_pos'], dtype='int32')
+    obs_data[('solarZenithAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_zen'], dtype='float32')
+    obs_data[('solarAzimuthAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_az'], dtype='float32')
+    obs_data[('sensorZenithAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['earth_inc_ang'], dtype='float32')
+    obs_data[('sensorAzimuthAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['earth_az_ang'], dtype='float32')
+    # instr_scan_angle = np.array(f['GeolocationAndFlags']['instr_scan_ang'], dtype='float32')
     obs_data[('sensorViewAngle', metaDataName)] = compute_scan_angle(
-        np.array(f['Geolocation']['instr_scan_ang'], dtype='float32'),
+        np.array(f['GeolocationAndFlags']['instr_scan_ang'], dtype='float32'),
         sensor_altitude,
-        np.array(f['Geolocation']['earth_inc_ang'], dtype='float32'),
+        np.array(f['GeolocationAndFlags']['earth_inc_ang'], dtype='float32'),
         qc_flag=sat_alt_flag)
 
     nlocs = len(obs_data[('latitude', metaDataName)])
     obs_data[('satelliteIdentifier', metaDataName)] = np.full((nlocs), WMO_sat_ID, dtype='int32')
-    obs_data[('dateTime', metaDataName)] = np.array(get_epoch_time(f['Geolocation']['time_string']), dtype='int64')
-    qc_flag = f['CalibratedSceneTemperatures']['obs_qual_flag']
-    solar_array_flag = f['CalibratedSceneTemperatures']['solar_array_flag']
+    obs_data[('dateTime', metaDataName)] = np.array(get_epoch_time(f['GeolocationAndFlags']['time_string']), dtype='int64')
+    qc_flag = f['GeolocationAndFlags']['obs_qual_flag']
+    solar_array_flag = f['GeolocationAndFlags']['solar_array_flag']
 
     nchans = len(obs_data[('sensorChannelNumber', metaDataName)])
     obs_data[('brightnessTemperature', obsValName)] = np.array(
@@ -243,12 +243,8 @@ def get_cowvr_data(f, obs_data, add_qc=True):
     obs_data[('longitude', metaDataName)] = np.array(f['GeolocationAndFlags']['obs_lon'], dtype='float32')
     obs_data[('sensorChannelNumber', metaDataName)] = np.array(np.arange(12)+1, dtype='int32')
     obs_data[('sensorScanPosition', metaDataName)] = np.array(np.round(f['GeolocationAndFlags']['instr_scan_ang']), dtype='int32')
-    if level == 1:
-        obs_data[('solarZenithAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_zen'], dtype='float32')
-        obs_data[('solarAzimuthAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_az'], dtype='float32')
-    else:
-        obs_data.pop(('solarZenithAngle', metaDataName))
-        obs_data.pop(('solarAzimuthAngle', metaDataName))
+    obs_data[('solarZenithAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_zen'], dtype='float32')
+    obs_data[('solarAzimuthAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['sat_solar_az'], dtype='float32')
     obs_data[('sensorZenithAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['earth_inc_ang'], dtype='float32')
     obs_data[('sensorAzimuthAngle', metaDataName)] = np.array(f['GeolocationAndFlags']['earth_az_ang'], dtype='float32')
     obs_data[('sensorViewAngle', metaDataName)] = compute_scan_angle(
@@ -260,20 +256,11 @@ def get_cowvr_data(f, obs_data, add_qc=True):
     nlocs = len(obs_data[('latitude', metaDataName)])
     obs_data[('satelliteIdentifier', metaDataName)] = np.full((nlocs), WMO_sat_ID, dtype='int32')
     obs_data[('dateTime', metaDataName)] = np.array(get_epoch_time(f['GeolocationAndFlags']['time_string']), dtype='int64')
-    if level == 1:
-        qc_flag = f['CalibratedSceneTemperatures']['obs_qual_flag']  # do not use -- calval team advice
-        solar_array_flag = f['CalibratedSceneTemperatures']['solar_array_flag']
-        support_arm_flag = f['CalibratedSceneTemperatures']['support_arm_flag']
-        rain_flag = None
-        rfi_flag = None
-        ufo_flag = None
-    elif level == 2:
-        qc_flag = f['GeolocationAndFlags']['obs_qual_flag']  # do not use -- calval team advice
-        solar_array_flag = f['GeolocationAndFlags']['solar_array_flag']
-        support_arm_flag = f['GeolocationAndFlags']['support_arm_flag']
-        rain_flag = f['GeolocationAndFlags']['rain_flag']
-        rfi_flag = f['GeolocationAndFlags']['rfi_flag']
-        ufo_flag = f['GeolocationAndFlags']['ufo_obstruct_flag']
+    qc_flag = f['GeolocationAndFlags']['obs_qual_flag']  # initial advice was DO NOT USE -- ask calval team for updated advice
+    solar_array_flag = f['GeolocationAndFlags']['solar_array_flag']
+    support_arm_flag = f['GeolocationAndFlags']['support_arm_flag']
+    rfi_flag = f['GeolocationAndFlags']['rfi_flag']
+    ufo_flag = f['GeolocationAndFlags']['ufo_obstruction_flag']
 
     nchans = len(obs_data[('sensorChannelNumber', metaDataName)])
     obs_data[('brightnessTemperature', obsValName)] = np.array(
@@ -284,12 +271,12 @@ def get_cowvr_data(f, obs_data, add_qc=True):
     obs_data[('brightnessTemperature', qcName)] = np.full((nlocs, nchans), 0, dtype='int32')
 
     if add_qc:
-        obs_data = cowvr_gross_quality_control(obs_data, solar_array_flag, support_arm_flag, rain_flag, rfi_flag, ufo_flag)
+        obs_data = cowvr_gross_quality_control(obs_data, solar_array_flag, support_arm_flag, rfi_flag, ufo_flag)
 
     return obs_data
 
 
-def cowvr_gross_quality_control(obs_data, solar_array_flag, support_arm_flag, rain_flag, rfi_flag, ufo_flag):
+def cowvr_gross_quality_control(obs_data, solar_array_flag, support_arm_flag, rfi_flag, ufo_flag):
 
     tb_key = 'brightnessTemperature'
     good = \
@@ -301,7 +288,7 @@ def cowvr_gross_quality_control(obs_data, solar_array_flag, support_arm_flag, ra
         (solar_array_flag[:] == 0) & (support_arm_flag[:] == 0)
 
     if rfi_flag:
-        good = good & (rain_flag[:] == 0) & (rfi_flag[:] == 0) & (ufo_flag[:] == 0)
+        good = good & (rfi_flag[:] == 0) & (ufo_flag[:] == 0)
 
     for k in obs_data:
         if metaDataName in k[1] and 'sensorChannelNumber' not in k[0]:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2193,6 +2193,18 @@ endif()
                             -o testrun/obs.20201001T000000Z_PT1M_tec_groundbased.nc4"
                             obs.20201001T000000Z_PT1M_tec_groundbased.nc4 ${IODA_CONV_COMP_TOL})
 
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_cowvr_iss
+                    TYPE    SCRIPT
+                    ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                            "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/cowvr_hdf5_2ioda.py 
+                            -i testinput/COWVR_TSDR.020421.20240430T215845.20240430T230345.V1001.sample.h5 
+                            -o testrun/obs.20240430T220600Z_PT2M_cowvr_iss.nc4
+                            -d 2024050100"
+                            obs.20240430T220600Z_PT2M_cowvr_iss.nc4 ${IODA_CONV_COMP_TOL})
+
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_osw_cygnss
                     TYPE    SCRIPT
                     ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,6 +104,7 @@ list( APPEND test_input
   testinput/pandora_site_classification.csv
   testinput/balloonsonde_sample_20241001T00Z_PT15M.json
   testinput/tec_groundBased_TENET_20201001T00Z.tec
+  testinput/COWVR_TSDR.020421.20240430T215845.20240430T230345.V1001.sample.h5
 )
 
 list( APPEND test_output
@@ -200,6 +201,7 @@ list( APPEND test_output
   testoutput/Pandora57s1_BoulderCO_L2_rnvs3p1-8.nc
   testoutput/obs.20241001T000000Z_PT15M_balloonsonde.nc4
   testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
+  testoutput/obs.20240430T220600Z_PT2M_cowvr_iss.nc4
 )
 
 if( iodaconv_gnssro_ENABLED )

--- a/test/testinput/COWVR_TSDR.020421.20240430T215845.20240430T230345.V1001.sample.h5
+++ b/test/testinput/COWVR_TSDR.020421.20240430T215845.20240430T230345.V1001.sample.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec01d08ad99cbb8de35cd9e83bce3fe16679eac7bdb18402db320279ba1297da
+size 206648

--- a/test/testoutput/obs.20240430T220600Z_PT2M_cowvr_iss.nc4
+++ b/test/testoutput/obs.20240430T220600Z_PT2M_cowvr_iss.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76d559eab3f8d7016296789fb6d8920287fd723b093951a143086d5fad12f501
+size 56620


### PR DESCRIPTION


## Description

The COWVR and TEMPEST data are now publicly available through NASA.  This newly uplifted data has changes to the format from the originally release calibration and validation data

## Issue(s) addressed

Resolves #1601 

## Dependencies

NASA earthdata account and the `COWVR_STPH8_L1_TSDR_V10.0` version files

## Impact

Expected impact on downstream repositories:

this enables https://github.com/JCSDA-internal/ewok/pull/1095
and https://github.com/JCSDA-internal/skylab/pull/658

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
