### PR TITLE
timeoffset update for compiling issue

### DIFF
--- a/src/bufr/BufrParser/Exports/Variables/TimeoffsetVariable.cpp
+++ b/src/bufr/BufrParser/Exports/Variables/TimeoffsetVariable.cpp
@@ -58,10 +58,8 @@ namespace Ingester
 
         // Convert the reference time (ISO8601 string) to time struct
         std::tm ref_time = {};
-        std::istringstream ss(conf_.getString(ConfKeys::Referencetime));
-
-        ss >> std::get_time(&ref_time, "%Y-%m-%dT%H:%M:%S");
-        if (ss.fail())
+	std::string time_str = conf_.getString(ConfKeys::Referencetime);
+        if (strptime(time_str.c_str(), "%Y-%m-%dT%H:%M:%S", &ref_time) == NULL)
         {
             std::ostringstream errStr;
             errStr << "Reference time MUST be formatted like 2021-11-29T22:43:51Z";


### PR DESCRIPTION
## Description

This PR fixed a segmentation fault when using std::istringstream to read a date. 

## Issue(s) addressed

Resolves #<1622>
