### PR TITLE
Fix reader in bufr2nc_fortran.x converters for Himawari binary observation files available from NOAA AWS S3 explorer

### DIFF
--- a/src/ncar-bufr2nc-fortran/define_mod.f90
+++ b/src/ncar-bufr2nc-fortran/define_mod.f90
@@ -99,7 +99,7 @@ module define_mod
 
    character(len=nstring), dimension(ninst_geo) :: geoinst_list = &
                                                    (/ &
-                                                   'ahi_himawari8   ' &
+                                                   'ahi_himawari    ' &
                                                    /)
 ! variables for outputing netcdf files
    character(len=nstring), dimension(n_ncdim) :: name_ncdim = &

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -361,7 +361,6 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%data%nLin, &
                header%data%compression, &
                header%data%dummy40
-            write (*,*) header%data%headerNum, &
                header%data%blockLen, &
                header%data%bitPix, &
                header%data%nPix, &

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -361,12 +361,6 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%data%nLin, &
                header%data%compression, &
                header%data%dummy40
-               header%data%blockLen, &
-               header%data%bitPix, &
-               header%data%nPix, &
-               header%data%nLin, &
-               header%data%compression, &
-               header%data%dummy40
                call read_error(ierrr)
             read (iunit,iostat=ierrr) header%proj%headerNum, &
                header%proj%blockLen, &
@@ -446,8 +440,8 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                allocate (header%navicorr%columnShift(numCorrect))
                allocate (header%navicorr%lineShift(numCorrect))
             else
-               write(*,'(3A,I)') " Error reading file ",trim(fnames(ifile)),&
-                                 " correctNum = ",header%navicorr%correctNum
+               write(*,'(3A,I6)') " Error reading file ",trim(fnames(ifile)),&
+                                  " correctNum = ",header%navicorr%correctNum
                call abort()
             end if
             read (iunit,iostat=ierrr) header%navicorr%lineNo(numCorrect), &
@@ -465,8 +459,8 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                allocate (header%obsTime%lineNo(numObs))
                allocate (header%obsTime%obsMJD(numObs))
             else
-               write(*,'(3A,I)') " Error reading file ",trim(fnames(ifile)),&
-                                 " obsNum = ",header%obsTime%obsNum
+               write(*,'(3A,I6)') " Error reading file ",trim(fnames(ifile)),&
+                                  " obsNum = ",header%obsTime%obsNum
                call abort()
             end if
             read (iunit,iostat=ierrr) header%obstime%lineNo, &
@@ -488,7 +482,7 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
             if (ntotal > 0) then
                 allocate (idata(ntotal))
             else
-               write(*,'(A,I)') " Error allocating idata, ntotal = ",ntotal
+               write(*,'(A,I6)') " Error allocating idata, ntotal = ",ntotal
                call abort()
             end if
 

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -31,6 +31,7 @@ module ahi_HSD_mod
    integer(i_kind)  :: iyear, imonth, iday, ihour, imin, isec
 
    integer(i_kind) :: subsample
+   character(len=3) :: ahi_satid
 
    integer(i_kind), parameter :: npixel = 5500
    integer(i_kind), parameter :: nline = 5500
@@ -242,7 +243,7 @@ contains
       character(len=8)    :: ccyymmdd
       character(len=4)    :: ccyy, hhnn
       character(len=2)    :: mm, dd, hh, nn
-      character(len=3)    :: satellite = 'H08'
+!     character(len=3)    :: satellite = 'H08' now ahi_satid in module hsd
       character(len=4)    :: region = 'FLDK'
       character(len=3)    :: resolution = 'R20'
       character(len=5)    :: segment ! S0110, S0210, etc
@@ -312,13 +313,13 @@ contains
             write (band, '(a,i2.2)') 'B', iband + 6
             write (segment, '(a,i2.2,i2.2)') 'S', isegm, nsegm
             ij = isegm + (iband - 1)*nsegm
-fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
+fnames(ij) = trim(inpdir)//'HS_'//ahi_satid//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
 !write(33,*) 'wget -np -nd -nc http://noaa-himawari8.s3.amazonaws.com/AHI-L1b-FLDK/' &
 !& //ccyy//'/'//mm//'/'//dd//'/'//hhnn//'/'//trim(fnames(ij))//'.bz2'
             inquire (file=trim(fnames(ij)), exist=fexist(ij))
             if (fexist(ij) .eqv. .false.) then
                write (segment, '(a,i2.2,i2.2)') 'S', isegm, nodivisionsegm
-fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
+fnames(ij) = trim(inpdir)//'HS_'//ahi_satid//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
                inquire (file=trim(fnames(ij)), exist=fexist(ij))
             end if
 !print*,iband, isegm, trim(fnames(ij)), fexist(ij)

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -328,7 +328,10 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
       do iband = 1, nband
          do isegm = 1, nsegm
             ifile = isegm + (iband - 1)*nsegm
-            if (.not. fexist(ifile)) cycle
+            if (.not. fexist(ifile)) then
+                print*,'Cannot find file ',TRIM(fnames(ifile))
+                cycle
+            end if
    open (iunit, file=trim(fnames(ifile)), form='unformatted', action='read', access='stream', status='old', convert='little_endian')
             print *, 'Reading from ', trim(fnames(ifile))
 

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -14,7 +14,7 @@ module ahi_HSD_mod
 
 !https://www.jstage.jst.go.jp/article/jmsj/94/2/94_2016-009/_pdf/-char/en
 
-   use iodaconv_kinds, only: i_byte, i_short, i_long, i_llong, i_kind, r_single, r_double, r_kind
+   use iodaconv_kinds, only: i_byte, i_int, i_short, i_long, i_llong, i_kind, r_single, r_double, r_kind
    use define_mod, only: missing_r, missing_i, nstring, ndatetime, &
                          ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
                          nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, set_brit_obserr, strlen
@@ -58,8 +58,8 @@ module ahi_HSD_mod
       real(r_double)     :: obsStartTime   ! Modified Julian Date
       real(r_double)     :: obsEndTime     ! Modified Julian Date
       real(r_double)     :: fileCreateTime ! Modified Julian Date
-      integer(i_long)    :: totalHeaderLen
-      integer(i_long)    :: dataLen
+      integer(i_int)     :: totalHeaderLen
+      integer(i_int)     :: dataLen
       integer(i_byte)    :: qcflag1
       integer(i_byte)    :: qcflag2
       integer(i_byte)    :: qcflag3
@@ -83,8 +83,8 @@ module ahi_HSD_mod
       integer(i_byte)    :: headerNum      ! header block number = 3
       integer(i_short)   :: blockLen       ! block length = 127 bytes
       real(r_double)     :: subLon         ! 140.7 degree
-      integer(i_long)    :: cfac           ! column scaling factor
-      integer(i_long)    :: lfac           ! line scaling factor
+      integer(i_int)     :: cfac           ! column scaling factor
+      integer(i_int)     :: lfac           ! line scaling factor
       real(r_single)     :: coff           ! column offset
       real(r_single)     :: loff           ! line offset
       real(r_double)     :: satDis         ! distance from earth's center to virtual satellite = 42164 km
@@ -181,7 +181,7 @@ module ahi_HSD_mod
 
    type error_info
       integer(i_byte)    :: headerNum      ! header block number = 10
-      integer(i_long)    :: blockLen       ! block length = 47
+      integer(i_int)     :: blockLen       ! block length = 47
       integer(i_short)   :: errorNum       ! number of error information data = 0
 !  integer(i_short), allocatable :: lineNo(:)    !(errorNum)
 !  integer(i_short), allocatable :: errPixNum(:) !(errorNum)
@@ -255,7 +255,7 @@ contains
       integer(i_kind) :: startLine, endLine
       integer(i_kind) :: radcount, i, ii, jj, ij, iv
       integer(i_kind) :: iband, isegm
-      integer(i_kind) :: ierr
+      integer(i_kind) :: ierr, ierrr
       integer(i_kind) :: nlocs, nvars, iloc
       integer(i_kind) :: ihh, imm, idd, jday, flength, rvalue, offset
       integer(i_kind) :: iunit = 21
@@ -332,7 +332,7 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
    open (iunit, file=trim(fnames(ifile)), form='unformatted', action='read', access='stream', status='old', convert='little_endian')
             print *, 'Reading from ', trim(fnames(ifile))
 
-            read (iunit) header%basic%headerNum, &
+            read (iunit,iostat=ierrr) header%basic%headerNum, &
                header%basic%blockLen, &
                header%basic%numHeader, &
                header%basic%byteOrder, &
@@ -353,14 +353,23 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%basic%version, &
                header%basic%fileName, &
                header%basic%dummy40
-            read (iunit) header%data%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%data%headerNum, &
                header%data%blockLen, &
                header%data%bitPix, &
                header%data%nPix, &
                header%data%nLin, &
                header%data%compression, &
                header%data%dummy40
-            read (iunit) header%proj%headerNum, &
+            write (*,*) header%data%headerNum, &
+               header%data%blockLen, &
+               header%data%bitPix, &
+               header%data%nPix, &
+               header%data%nLin, &
+               header%data%compression, &
+               header%data%dummy40
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%proj%headerNum, &
                header%proj%blockLen, &
                header%proj%subLon, &
                header%proj%cfac, &
@@ -377,7 +386,8 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%proj%resampleKind, &
                header%proj%resampleSize, &
                header%proj%dummy40
-            read (iunit) header%navi%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%navi%headerNum, &
                header%navi%blockLen, &
                header%navi%navTime, &
                header%navi%sspLon, &
@@ -392,7 +402,8 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%navi%moonPos_y, &
                header%navi%moonPos_z, &
                header%navi%dummy40
-            read (iunit) header%calib%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%calib%headerNum, &
                header%calib%blockLen, &
                header%calib%bandNo, &
                header%calib%waveLen, &
@@ -411,61 +422,84 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
                header%calib%planckConst, &
                header%calib%bolzConst, &
                header%calib%dummy40
-            read (iunit) header%interCalib%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%interCalib%headerNum, &
                header%interCalib%blockLen, &
                header%interCalib%dummy256
-            read (iunit) header%segm%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%segm%headerNum, &
                header%segm%blockLen, &
                header%segm%totalSegNum, &
                header%segm%segSeqNo, &
                header%segm%startLineNo, &
                header%segm%dummy40
-            read (iunit) header%navicorr%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%navicorr%headerNum, &
                header%navicorr%blockLen, &
                header%navicorr%RoCenterColumn, &
                header%navicorr%RoCenterLine, &
                header%navicorr%RoCorrection, &
                header%navicorr%correctNum
+               call read_error(ierrr)
             if (header%navicorr%correctNum > 0) then
                numCorrect = header%navicorr%correctNum
                allocate (header%navicorr%lineNo(numCorrect))
                allocate (header%navicorr%columnShift(numCorrect))
                allocate (header%navicorr%lineShift(numCorrect))
+            else
+               write(*,'(3A,I)') " Error reading file ",trim(fnames(ifile)),&
+                                 " correctNum = ",header%navicorr%correctNum
+               call abort()
             end if
-            read (iunit) header%navicorr%lineNo(numCorrect), &
+            read (iunit,iostat=ierrr) header%navicorr%lineNo(numCorrect), &
                header%navicorr%columnShift(numCorrect), &
                header%navicorr%lineShift(numCorrect), &
                header%navicorr%dummy40
+               call read_error(ierrr)
             rewind (iunit)
-            read (iunit) header%obstime%headerNum, &
+            read (iunit,iostat=ierrr) header%obstime%headerNum, &
                header%obstime%blockLen, &
                header%obstime%obsNum
+               call read_error(ierrr)
             if (header%obsTime%obsNum > 0) then
                numObs = header%obsTime%obsNum
                allocate (header%obsTime%lineNo(numObs))
                allocate (header%obsTime%obsMJD(numObs))
+            else
+               write(*,'(3A,I)') " Error reading file ",trim(fnames(ifile)),&
+                                 " obsNum = ",header%obsTime%obsNum
+               call abort()
             end if
-            read (iunit) header%obstime%lineNo, &
+            read (iunit,iostat=ierrr) header%obstime%lineNo, &
                header%obstime%obsMJD, &
                header%obstime%dummy40
-            read (iunit) header%error%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%error%headerNum, &
                header%error%blockLen, &
                header%error%errorNum, &
                header%error%dummy40
-            read (iunit) header%dummy%headerNum, &
+               call read_error(ierrr)
+            read (iunit,iostat=ierrr) header%dummy%headerNum, &
                header%dummy%blockLen, &
                header%dummy%dummy256
+               call read_error(ierrr)
             npix = header%data%nPix
             nlin = header%data%nLin
             ntotal = npix*nlin
-            allocate (idata(ntotal))
+            if (ntotal > 0) then
+                allocate (idata(ntotal))
+            else
+               write(*,'(A,I)') " Error allocating idata, ntotal = ",ntotal
+               call abort()
+            end if
 
             inquire (file=trim(fnames(ifile)), size=flength)
             ! Offset relative to the beginning of the file
             offset = flength - (npix*nlin*2)
             ! Reposition the file to the offset value for reading
             call fseek(iunit, offset, 0, rvalue)
-            read (iunit) idata(:)
+            read (iunit,iostat=ierrr) idata(:)
+            call read_error(ierrr)
 
             startLine = header%segm%startLineNo
             endLine = startLine + header%data%nLin - 1
@@ -761,6 +795,7 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
          end if
 
          ! do thinning every subsample pixels
+         iloc = 0
          do jj = 1, nline, subsample
             do ii = 1, npixel, subsample
                if (.not. valid(ii, jj)) cycle
@@ -999,5 +1034,18 @@ fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band
       end if
       return
    end subroutine hisd_radiance_to_tbb
+
+   subroutine read_error(ierr)
+
+    integer(i_kind) :: ierr
+
+    if (ierr /= 0) then
+       write(*,'(A,I6)') "Error file reading, ierr = ",ierr
+       call abort()
+    endif
+
+    return
+
+    end subroutine read_error
 
 end module ahi_HSD_mod

--- a/src/ncar-bufr2nc-fortran/main.f90
+++ b/src/ncar-bufr2nc-fortran/main.f90
@@ -8,7 +8,7 @@ program obs2ioda
                            read_iasi, read_cris, radiance_to_temperature
    use ncio_mod, only: write_obs
    use gnssro_bufr2ioda, only: read_write_gnssro
-   use ahi_hsd_mod, only: read_hsd, subsample
+   use ahi_hsd_mod, only: read_hsd, subsample, ahi_satid
    use satwnd_mod, only: read_satwnd, filter_obs_satwnd, sort_obs_satwnd
    use utils_mod, only: da_advance_time
 
@@ -261,6 +261,10 @@ program obs2ioda
          write (*, *) 'Error: -t ccyymmddhhnn not specified for -ahi'
          stop
       end if
+      if (len_trim(ahi_satid) /=3) then
+         write (*, *) 'Error: Himawari satid: -hs H08/H09 must be specified with -ahi'
+         stop
+      end if
       call read_HSD(cdatetime, inpdir, do_superob, superob_halfwidth)
       filedate = cdatetime(1:10)
       call write_obs(filedate, write_nc_radiance_geo, outdir, 1)
@@ -276,7 +280,7 @@ contains
       implicit none
 
       integer(i_kind)       :: iunit = 21
-      integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth
+      integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample, iarg_superob_halfwidth, iarg_hs
       integer(i_kind)       :: itmp
       integer(i_kind)       :: iost, iret, idate
       character(len=StrLen) :: strtmp
@@ -287,6 +291,7 @@ contains
       inpdir = '.'
       outdir = '.'
       cdatetime = ''
+      ahi_satid = ''
       flist(:) = 'null'
       iarg_inpdir = -1
       iarg_outdir = -1
@@ -314,6 +319,8 @@ contains
                iarg_datetime = iarg + 1
             else if (trim(strtmp) == '-s') then
                iarg_subsample = iarg + 1
+            else if (trim(strtmp) == '-hs') then
+               iarg_hs = iarg + 1
             else if (trim(strtmp) == '-superob') then
                do_superob = .true.
                iarg_superob_halfwidth = iarg + 1
@@ -337,6 +344,11 @@ contains
                      read (strtmp, '(i2)') superob_halfwidth
                   else
                      iarg_superob_halfwidth = 1
+                  end if
+               else if (iarg == iarg_hs) then
+                  call get_command_argument(number=iarg, value=strtmp)
+                  if (len_trim(strtmp) > 0) then
+                      ahi_satid = strtmp(1:3)
                   end if
                else
                   ifile = ifile + 1

--- a/src/ncar-bufr2nc-fortran/ncio_mod.f90
+++ b/src/ncar-bufr2nc-fortran/ncio_mod.f90
@@ -12,6 +12,7 @@ module ncio_mod
                          def_netcdf_dims, def_netcdf_grp, def_netcdf_var, def_netcdf_end, &
                          put_netcdf_var, get_netcdf_dims
    use ufo_vars_mod, only: ufo_vars_getindex
+   use ahi_HSD_mod, only: ahi_satid
 
    implicit none
 
@@ -82,7 +83,11 @@ contains
          else if (write_opt == write_nc_radiance) then
             ncfname = trim(outdir)//trim(inst_list(ityp))//'_obs_'//trim(filedate)//'.nc4'
          else if (write_opt == write_nc_radiance_geo) then
-            ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_obs_'//trim(filedate)//'.nc4'
+            if (geoinst_list(ityp) == 'ahi_himawari') then
+                ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_'//trim(ahi_satid)//'_obs_'//trim(filedate)//'.nc4'
+            else
+                ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_obs_'//trim(filedate)//'.nc4'
+            end if
          end if
          if (write_opt == write_nc_radiance .or. write_opt == write_nc_radiance_geo) then
             iv = ufo_vars_getindex(name_sen_info, 'sensor_channel')
@@ -90,7 +95,7 @@ contains
             ichan(:) = xdata(ityp, itim)%xseninfo_int(:, iv)
             allocate (obserr(xdata(ityp, itim)%nvars))
             if (write_opt == write_nc_radiance_geo) then
-               if (geoinst_list(ityp) == 'ahi_himawari8') then
+               if (geoinst_list(ityp) == 'ahi_himawari') then
                   call set_ahi_obserr(geoinst_list(ityp), xdata(ityp, itim)%nvars, obserr)
                else
                   call set_brit_obserr(inst_list(ityp), xdata(ityp, itim)%nvars, obserr)


### PR DESCRIPTION
## Description bug fix

Full disk Himawari radiance observations are available in binary format from NOAA S3 explorer: https://noaa-himawari8.s3.amazonaws.com/index.html#AHI-L1b-FLDK/. See issue #[1624](https://github.com/JCSDA-internal/ioda-converters/issues/1624) for details. 

Also Himawari-9 are available changing the address to `9`, both `Himawari-8` and `Himawari-9` are the 3rd generation of Himawari sensors and contain the Advanced Himawari Imager (AHI)

The existing IODA converter [src/ncar-bufr2nc-fortran/hsd.f90](https://github.com/JCSDA-internal/ioda-converters/blob/b0ab0e4629728bf39cb3c7fb8415dd57bd5db399/src/ncar-bufr2nc-fortran/hsd.f90#L61) crashes when reading those binary file with the error:

`Fortran runtime error: Index '578886144' of dimension 1 of array 'header%navicorr%lineno' above upper bound of 0`

The problem comes from the use of `i_long` (8 bytes) to read integers from the binary files, while those integers were written as 4-byte integers.

This PR:

Bug fixes:
1. Replaces  `i_long` (8 bytes) into `i_int` (4 bytes) integers in file [src/ncar-bufr2nc-fortran/hsd.f90](https://github.com/JCSDA-internal/ioda-converters/blob/b0ab0e4629728bf39cb3c7fb8415dd57bd5db399/src/ncar-bufr2nc-fortran/hsd.f90#L61). 
2. Add additional error checks when reading or allocating arrays.
3. Initialize to 0 a counter (`i_loc`) in the subsampling loop. 

## Addition:
The current decoder is hard coded to take an input file from the Himawari 8 satellite only. Some code changes were made to allow for input files from both Himawari 8 and Himawari 9 satellites. 

This PR:

4) Pass the Himawari satellite ID (3 characters `H08` or `H09`) in the command line after the argument `-hs`


## Testing can be done with the following steps:

` aws s3 cp --no-sign-request s3://noaa-himawari8/AHI-L1b-FLDK/2022/02/16/0000/HS_H08_20220216_0000_B16_FLDK_R20_S1010.DAT.bz2 HS_H08_20220216_0000_B16_FLDK_R20_S1010.DAT.bz2`

`bunzip HS_H08_20220216_0000_B16_FLDK_R20_S1010.DAT.bz2`

`bufr2nc_fortran.x -i . -o . -ahi -t 202202160000 -s 16 -hs H08`


## Issue(s) addressed

Resolves #1624 

## Dependencies

There is no dependency but the ingest of Himawari images into R2D2 requires those two companion PRs:

-[] https://github.com/JCSDA-internal/skylab/pull/715
-[] https://github.com/JCSDA-internal/ewok/pull/1118

## Impact

The converter completes and generates an Himawari IODA file.

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
