### PR TITLE
ensure the string being passed to strptime is 2 digit when necessary

### DIFF
--- a/src/hdf5/ssmis_upp_2ioda.py
+++ b/src/hdf5/ssmis_upp_2ioda.py
@@ -221,14 +221,13 @@ def populate_obsValue(line, local_data, WMO_sat_ID=int_missing_value, ssmis_uas=
     nlocs = len(local_data[('latitude', metaDataName)])
     local_data[('satelliteIdentifier', metaDataName)].append(WMO_sat_ID)
     # will use a single time for now... need to find out seconds between scans?
-    datetime_obj = datetime.strptime(
-        f"{int(year):04d}"
-        f"{int(month):02d}"
-        f"{int(day):02d}"
-        f"{int(hour):02d}"
-        f"{int(minute):02d}"
-        f"{int(second):02d}",
-        "%Y%m%d%H%M%S"
+    datetime_obj = datetime(
+        year=int(year),
+        month=int(month),
+        day=int(day),
+        hour=int(hour),
+        minute=int(minute),
+        second=int(second)
     )
     local_data[('dateTime', metaDataName)].append(get_epoch_time(datetime_obj))
     qc_flag = int(irej)

--- a/src/hdf5/ssmis_upp_2ioda.py
+++ b/src/hdf5/ssmis_upp_2ioda.py
@@ -221,7 +221,15 @@ def populate_obsValue(line, local_data, WMO_sat_ID=int_missing_value, ssmis_uas=
     nlocs = len(local_data[('latitude', metaDataName)])
     local_data[('satelliteIdentifier', metaDataName)].append(WMO_sat_ID)
     # will use a single time for now... need to find out seconds between scans?
-    datetime_obj = datetime.strptime(year + month + day + hour + minute + second, "%Y%m%d%H%M%S")
+    datetime_obj = datetime.strptime(
+        f"{int(year):04d}"
+        f"{int(month):02d}"
+        f"{int(day):02d}"
+        f"{int(hour):02d}"
+        f"{int(minute):02d}"
+        f"{int(second):02d}",
+        "%Y%m%d%H%M%S"
+    )
     local_data[('dateTime', metaDataName)].append(get_epoch_time(datetime_obj))
     qc_flag = int(irej)
 


### PR DESCRIPTION
## Description

ensure the string being passed to strptime has 2 digit month day min etc


## Issue(s) addressed

Resolves #1661 

## Dependencies

python bindings to IODA

## Impact

ability to produce IODA file from SSMIS UPP

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
