### PR TITLE
Add IMS stationIdentification to output

### DIFF
--- a/src/land/imsfv3_scf2ioda.py
+++ b/src/land/imsfv3_scf2ioda.py
@@ -84,14 +84,17 @@ class imsFV3(object):
         ncd = nc.Dataset(self.filename)
         lons = ncd.variables['lon'][:].ravel()
         lats = ncd.variables['lat'][:].ravel()
+        stid = ncd.variables['stid'][:].ravel()
         oros = ncd.variables['oro'][:].ravel()
         sncv = ncd.variables['IMSscf'][:].ravel()
         sncv[sncv == -999.] = float_missing_value
         sndv = ncd.variables['IMSsnd'][:].ravel()
         sndv[sndv == -999.] = float_missing_value
+        strstid = np.empty_like(lons, dtype=object)
 
         lons = lons.astype('float32')
         lats = lats.astype('float32')
+        stid = stid.astype('int64')
         oros = oros.astype('float32')
         sncv = sncv.astype('float32')
         sndv = sndv.astype('float32')
@@ -104,6 +107,9 @@ class imsFV3(object):
 
         times = get_observation_time(self.filename, sncv, ncd)
 
+        for i in range(len(lons)):
+            strstid[i] = str(stid[i])
+
         ncd.close()
 
         # add metadata variables
@@ -112,6 +118,7 @@ class imsFV3(object):
         self.varAttrs[('dateTime', metaDataName)]['_FillValue'] = long_missing_value
         self.outdata[('latitude', metaDataName)] = lats
         self.outdata[('longitude', metaDataName)] = lons
+        self.outdata[('stationIdentification', metaDataName)] = strstid
         self.outdata[('stationElevation', metaDataName)] = oros
         self.varAttrs[('stationElevation', metaDataName)]['units'] = 'm'
 

--- a/src/land/imsfv3_scf2ioda.py
+++ b/src/land/imsfv3_scf2ioda.py
@@ -100,7 +100,7 @@ class imsFV3(object):
         qdflg = 0*sndv.astype('int32')
         errsc = 0.0*sncv
         errsd = 0.0*sndv
-        errsd[:] = 40.
+        errsd[:] = 80.
 
         times = get_observation_time(self.filename, sncv, ncd)
 

--- a/test/testinput/ascii_input_IMSscf.20230501.oro_C48.nc
+++ b/test/testinput/ascii_input_IMSscf.20230501.oro_C48.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14a6de18ae11e9c965d8158c071dcd0715f76904c395b38696f6978da8e3f590
-size 120681
+oid sha256:460bc5e98d2f41bee907fbe81f149b31ba7e9210a578deba0cf35ddc85786efb
+size 132463

--- a/test/testinput/nc_input_IMSscf.20230501.oro_C48.nc
+++ b/test/testinput/nc_input_IMSscf.20230501.oro_C48.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e158ec9dccf195cd60e8fa9b01555ed0f0a53a5507e667b10aee36484c8848b0
-size 120783
+oid sha256:d1e665ac789c9b770108c046476dfa76bb2839dc7291b70755d9c0f1adeb1902
+size 132565

--- a/test/testoutput/imsfv3_scf.nc
+++ b/test/testoutput/imsfv3_scf.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93aa715c557f9308c767ecae2208f6c63d579bfe87a3834820042566cb6046a6
-size 66041
+oid sha256:4e78f36a96811e67a4909b3691eec46afb524fa1bf3fb782b100ee5a0822d293
+size 207133

--- a/test/testoutput/imsfv3grid_scf.nc
+++ b/test/testoutput/imsfv3grid_scf.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:087cc14684641450e26886fdd26f26bcc6a73d831c2433a435fc880f2d926255
-size 66041
+oid sha256:4146d780b62df4c53c5b239e55c1a0eb1fdc9bb3e9ea1a8989db9e5a884dc390
+size 207133


### PR DESCRIPTION
## Description

we need to output IMS station IDs (i.e., stationIdentification as a nine-digit string) to the ioda formatted output to be used for follow-up QC.


This is a duplicate of:  https://github.com/JCSDA-internal/ioda-converters/pull/1654

However, PR1654 is a fork and not from JCSDA-internal this is a duplicate allowing merge into internal

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1642
