### PR TITLE
Removing CMake settings for `-mcmodel`

### DIFF
--- a/src/ncar/obs2ioda/cmake/Obs2Ioda_CompilerFlags.cmake
+++ b/src/ncar/obs2ioda/cmake/Obs2Ioda_CompilerFlags.cmake
@@ -4,12 +4,6 @@ set(FORTRAN_COMPILER_GNU_FLAGS
     $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
 )
 
-# Set Fortran compiler flags specific to the GNU Compiler and Linux OS.
-# -mcmodel=medium: Allow for larger datasets in memory
-set(FORTRAN_COMPILER_GNU_LINUX_FLAGS
-        $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
-)
-
 # Set Debugging Fortran compiler flags specific to the GNU Compiler
 # -fbacktrace: Provide a backtrace when an error occurs
 # -ffpe-trap=invalid,zero,overflow: Trap floating point exceptions (invalid calculation, divide by zero, overflow)
@@ -17,12 +11,6 @@ set(FORTRAN_COMPILER_GNU_LINUX_FLAGS
 # -g: Produce debugging information
 set(FORTRAN_COMPILER_GNU_DEBUG_FLAGS
     $<$<COMPILE_LANGUAGE:Fortran>:-g -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
-)
-
-# Set Fortran compiler flags for the Intel Compiler
-# -mcmodel=medium: Allow for larger datasets in memory
-set(FORTRAN_COMPILER_INTEL_FLAGS
-    $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
 )
 
 # Set Debugging Fortran compiler flags for the Intel Compiler


### PR DESCRIPTION
## Description

This PR removes CMake settings for `-mcmodel`.

## Issue(s) addressed
Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1682

## Dependencies
None

## Impact
None

## Checklist
- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
