### PR TITLE
Adding a quick & dirty fix for the deprecated obs2ioda converter

### DIFF
--- a/src/ncar-bufr2nc-fortran/define_mod.f90
+++ b/src/ncar-bufr2nc-fortran/define_mod.f90
@@ -1,7 +1,7 @@
-module define_mod
+module define_mod_deprecated
 
    use iodaconv_kinds, only: r_kind, i_kind, i_llong
-   use ufo_vars_mod, only: var_ps, var_prs, var_u, var_v, var_ts, var_tv, var_q, var_tb
+   use ufo_vars_mod_deprecated, only: var_ps, var_prs, var_u, var_v, var_ts, var_tv, var_q, var_tb
    use netcdf, only: nf90_float, nf90_int, nf90_char, nf90_int64
 
    implicit none
@@ -447,4 +447,4 @@ contains
       end if
    end subroutine set_ahi_obserr
 
-end module define_mod
+end module define_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/gnssro_mod.f90
+++ b/src/ncar-bufr2nc-fortran/gnssro_mod.f90
@@ -5,7 +5,7 @@
 !  Copyright UCAR 2022
 !  Author: Hailing Zhang
 
-module gnssro_bufr2ioda
+module gnssro_bufr2ioda_deprecated
    use netcdf
    use iso_fortran_env
    implicit none
@@ -664,4 +664,4 @@ contains
    END SUBROUTINE epochtimecalculator
 
 !end program
-end module gnssro_bufr2ioda
+end module gnssro_bufr2ioda_deprecated

--- a/src/ncar-bufr2nc-fortran/hsd.f90
+++ b/src/ncar-bufr2nc-fortran/hsd.f90
@@ -1,4 +1,4 @@
-module ahi_HSD_mod
+module ahi_HSD_mod_deprecated
 
 !Himawari Standard Data
 !HS_H08_20210119_1600_B09_FLDK_R20_S0510.DAT
@@ -15,12 +15,12 @@ module ahi_HSD_mod
 !https://www.jstage.jst.go.jp/article/jmsj/94/2/94_2016-009/_pdf/-char/en
 
    use iodaconv_kinds, only: i_byte, i_int, i_short, i_long, i_llong, i_kind, r_single, r_double, r_kind
-   use define_mod, only: missing_r, missing_i, nstring, ndatetime, &
-                         ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
-                         nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, set_brit_obserr, strlen
-   use ufo_vars_mod, only: ufo_vars_getindex
+   use define_mod_deprecated, only: missing_r, missing_i, nstring, ndatetime, &
+                                    ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
+                                    nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, set_brit_obserr, strlen
+   use ufo_vars_mod_deprecated, only: ufo_vars_getindex
    use netcdf, only: nf90_float, nf90_int, nf90_char, nf90_int64
-   use utils_mod, only: get_julian_time
+   use utils_mod_deprecated, only: get_julian_time
 
    implicit none
 
@@ -1045,4 +1045,4 @@ fnames(ij) = trim(inpdir)//'HS_'//ahi_satid//'_'//ccyymmdd//'_'//hhnn//'_'//band
 
     end subroutine read_error
 
-end module ahi_HSD_mod
+end module ahi_HSD_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/main.f90
+++ b/src/ncar-bufr2nc-fortran/main.f90
@@ -1,16 +1,16 @@
 program obs2ioda
 
-   use define_mod, only: write_nc_conv, write_nc_radiance, write_nc_radiance_geo, StrLen, xdata, &
+   use define_mod_deprecated, only: write_nc_conv, write_nc_radiance, write_nc_radiance_geo, StrLen, xdata, &
                          ninst
    use iodaconv_kinds, only: i_kind
-   use prepbufr_mod, only: read_prepbufr, sort_obs_conv, filter_obs_conv, do_tv_to_ts
-   use radiance_mod, only: read_amsua_amsub_mhs, read_airs_colocate_amsua, sort_obs_radiance, &
-                           read_iasi, read_cris, radiance_to_temperature
-   use ncio_mod, only: write_obs
-   use gnssro_bufr2ioda, only: read_write_gnssro
-   use ahi_hsd_mod, only: read_hsd, subsample, ahi_satid
-   use satwnd_mod, only: read_satwnd, filter_obs_satwnd, sort_obs_satwnd
-   use utils_mod, only: da_advance_time
+   use prepbufr_mod_deprecated, only: read_prepbufr, sort_obs_conv, filter_obs_conv, do_tv_to_ts
+   use radiance_mod_deprecated, only: read_amsua_amsub_mhs, read_airs_colocate_amsua, sort_obs_radiance, &
+                                      read_iasi, read_cris, radiance_to_temperature
+   use ncio_mod_deprecated, only: write_obs
+   use gnssro_bufr2ioda_deprecated, only: read_write_gnssro
+   use ahi_hsd_mod_deprecated, only: read_hsd, subsample, ahi_satid
+   use satwnd_mod_deprecated, only: read_satwnd, filter_obs_satwnd, sort_obs_satwnd
+   use utils_mod_deprecated, only: da_advance_time
 
    implicit none
 

--- a/src/ncar-bufr2nc-fortran/ncio_mod.f90
+++ b/src/ncar-bufr2nc-fortran/ncio_mod.f90
@@ -1,18 +1,18 @@
-module ncio_mod
+module ncio_mod_deprecated
 
    use netcdf
    use iodaconv_kinds, only: i_kind, r_single, r_kind
-   use define_mod, only: nobtype, nvar_info, n_ncdim, n_ncgrp, nstring, ndatetime, &
-                         obtype_list, name_ncdim, name_ncgrp, name_var_met, name_var_info, name_sen_info, &
-                         xdata, itrue, ifalse, vflag, ninst, inst_list, write_nc_conv, write_nc_radiance, &
-                         write_nc_radiance_geo, ninst_geo, geoinst_list, &
-                         var_tb, nsen_info, type_var_info, type_sen_info, dim_var_info, dim_sen_info, &
-                         unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr
-   use netcdf_mod, only: open_netcdf_for_write, close_netcdf, &
-                         def_netcdf_dims, def_netcdf_grp, def_netcdf_var, def_netcdf_end, &
-                         put_netcdf_var, get_netcdf_dims
-   use ufo_vars_mod, only: ufo_vars_getindex
-   use ahi_HSD_mod, only: ahi_satid
+   use define_mod_deprecated, only: nobtype, nvar_info, n_ncdim, n_ncgrp, nstring, ndatetime, &
+                                    obtype_list, name_ncdim, name_ncgrp, name_var_met, name_var_info, name_sen_info, &
+                                    xdata, itrue, ifalse, vflag, ninst, inst_list, write_nc_conv, write_nc_radiance, &
+                                    write_nc_radiance_geo, ninst_geo, geoinst_list, &
+                                    var_tb, nsen_info, type_var_info, type_sen_info, dim_var_info, dim_sen_info, &
+                                    unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr
+   use netcdf_mod_deprecated, only: open_netcdf_for_write, close_netcdf, &
+                                    def_netcdf_dims, def_netcdf_grp, def_netcdf_var, def_netcdf_end, &
+                                    put_netcdf_var, get_netcdf_dims
+   use ufo_vars_mod_deprecated, only: ufo_vars_getindex
+   use ahi_HSD_mod_deprecated, only: ahi_satid
 
    implicit none
 
@@ -350,4 +350,4 @@ contains
 
    end subroutine write_obs
 
-end module ncio_mod
+end module ncio_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/netcdf_mod.f90
+++ b/src/ncar-bufr2nc-fortran/netcdf_mod.f90
@@ -1,7 +1,7 @@
-module netcdf_mod
+module netcdf_mod_deprecated
    use,intrinsic :: iso_fortran_env
    use netcdf
-   use define_mod, only: missing_r, missing_i, nstring
+   use define_mod_deprecated, only: missing_r, missing_i, nstring
    implicit none
 
 ! public subroutines
@@ -375,4 +375,4 @@ contains
       return
    end subroutine put_netcdf_var_char
 
-end module netcdf_mod
+end module netcdf_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/prepbufr_mod.f90
+++ b/src/ncar-bufr2nc-fortran/prepbufr_mod.f90
@@ -1,14 +1,14 @@
-module prepbufr_mod
+module prepbufr_mod_deprecated
 
 ! adapated from WRFDA/var/da/da_obs_io/da_read_obs_bufr.inc
 
    use iodaconv_kinds, only: r_kind, i_kind, r_double, i_llong
-   use define_mod, only: nobtype, set_obtype_conv, obtype_list, xdata, &
-                         nvar_met, nvar_info, type_var_info, name_var_met, name_var_info, &
-                         t_kelvin, missing_r, missing_i, vflag, itrue, ifalse, nstring, ndatetime, not_use, &
-                         dtime_min, dtime_max
-   use ufo_vars_mod, only: ufo_vars_getindex, var_prs, var_u, var_v, var_ts, var_tv, var_q, var_ps
-   use utils_mod, only: get_julian_time, da_advance_time, da_get_time_slots
+   use define_mod_deprecated, only: nobtype, set_obtype_conv, obtype_list, xdata, &
+                                    nvar_met, nvar_info, type_var_info, name_var_met, name_var_info, &
+                                    t_kelvin, missing_r, missing_i, vflag, itrue, ifalse, nstring, ndatetime, not_use, &
+                                    dtime_min, dtime_max
+   use ufo_vars_mod_deprecated, only: ufo_vars_getindex, var_prs, var_u, var_v, var_ts, var_tv, var_q, var_ps
+   use utils_mod_deprecated, only: get_julian_time, da_advance_time, da_get_time_slots
    use netcdf, only: nf90_int, nf90_float, nf90_char, nf90_int64
 
    implicit none
@@ -1335,5 +1335,4 @@ contains
 
    end subroutine calc_qs
 
-end module prepbufr_mod
-
+end module prepbufr_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/radiance_mod.f90
+++ b/src/ncar-bufr2nc-fortran/radiance_mod.f90
@@ -1,13 +1,13 @@
-module radiance_mod
+module radiance_mod_deprecated
 
    use iodaconv_kinds, only: r_kind, i_kind, r_double, i_llong
-   use define_mod, only: missing_r, missing_i, nstring, ndatetime, &
-                         ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
-                         nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, &
-                         dtime_min, dtime_max, strlen
-   use ufo_vars_mod, only: ufo_vars_getindex
+   use define_mod_deprecated, only: missing_r, missing_i, nstring, ndatetime, &
+                                    ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
+                                    nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, &
+                                    dtime_min, dtime_max, strlen
+   use ufo_vars_mod_deprecated, only: ufo_vars_getindex
    use netcdf, only: nf90_float, nf90_int, nf90_char, nf90_int64
-   use utils_mod, only: get_julian_time, da_advance_time, da_get_time_slots
+   use utils_mod_deprecated, only: get_julian_time, da_advance_time, da_get_time_slots
 
    implicit none
    private
@@ -1407,4 +1407,4 @@ contains
 
    end subroutine read_spc
 
-end module radiance_mod
+end module radiance_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/satwnd_mod.f90
+++ b/src/ncar-bufr2nc-fortran/satwnd_mod.f90
@@ -1,12 +1,12 @@
-module satwnd_mod
+module satwnd_mod_deprecated
 
    use iodaconv_kinds, only: r_kind, i_kind, r_double
-   use define_mod, only: nobtype, set_obtype_conv, obtype_list, xdata, &
-                         nvar_met, nvar_info, type_var_info, name_var_met, name_var_info, &
-                         missing_r, missing_i, vflag, itrue, ifalse, nstring, ndatetime, &
-                         dtime_min, dtime_max
-   use ufo_vars_mod, only: ufo_vars_getindex, var_prs, var_u, var_v
-   use utils_mod, only: get_julian_time, da_advance_time, da_get_time_slots
+   use define_mod_deprecated, only: nobtype, set_obtype_conv, obtype_list, xdata, &
+                                    nvar_met, nvar_info, type_var_info, name_var_met, name_var_info, &
+                                    missing_r, missing_i, vflag, itrue, ifalse, nstring, ndatetime, &
+                                    dtime_min, dtime_max
+   use ufo_vars_mod_deprecated, only: ufo_vars_getindex, var_prs, var_u, var_v
+   use utils_mod_deprecated, only: get_julian_time, da_advance_time, da_get_time_slots
    use netcdf, only: nf90_int, nf90_float, nf90_char
 
    implicit none
@@ -593,5 +593,4 @@ contains
       end select
    end subroutine set_rptype_satwnd
 
-end module satwnd_mod
-
+end module satwnd_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/ufo_variables_mod.F90
+++ b/src/ncar-bufr2nc-fortran/ufo_variables_mod.F90
@@ -5,7 +5,7 @@
 !  which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 !
 
-module ufo_vars_mod
+module ufo_vars_mod_deprecated
 
    implicit none
    private
@@ -189,4 +189,4 @@ contains
 
 ! ------------------------------------------------------------------------------
 
-end module ufo_vars_mod
+end module ufo_vars_mod_deprecated

--- a/src/ncar-bufr2nc-fortran/utils_mod.f90
+++ b/src/ncar-bufr2nc-fortran/utils_mod.f90
@@ -1,4 +1,4 @@
-module utils_mod
+module utils_mod_deprecated
 
 ! adapated from WRFDA/var/da/da_tools/da_advance_time.inc
 
@@ -339,4 +339,4 @@ contains
 
    end subroutine da_get_time_slots
 
-end module utils_mod
+end module utils_mod_deprecated

--- a/src/ncar/obs2ioda/cmake/Obs2Ioda_CompilerFlags.cmake
+++ b/src/ncar/obs2ioda/cmake/Obs2Ioda_CompilerFlags.cmake
@@ -4,12 +4,6 @@ set(FORTRAN_COMPILER_GNU_FLAGS
     $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
 )
 
-# Set Fortran compiler flags specific to the GNU Compiler and Linux OS.
-# -mcmodel=medium: Allow for larger datasets in memory
-set(FORTRAN_COMPILER_GNU_LINUX_FLAGS
-        $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
-)
-
 # Set Debugging Fortran compiler flags specific to the GNU Compiler
 # -fbacktrace: Provide a backtrace when an error occurs
 # -ffpe-trap=invalid,zero,overflow: Trap floating point exceptions (invalid calculation, divide by zero, overflow)
@@ -17,12 +11,6 @@ set(FORTRAN_COMPILER_GNU_LINUX_FLAGS
 # -g: Produce debugging information
 set(FORTRAN_COMPILER_GNU_DEBUG_FLAGS
     $<$<COMPILE_LANGUAGE:Fortran>:-g -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=all>
-)
-
-# Set Fortran compiler flags for the Intel Compiler
-# -mcmodel=medium: Allow for larger datasets in memory
-set(FORTRAN_COMPILER_INTEL_FLAGS
-    $<$<COMPILE_LANGUAGE:Fortran>:-mcmodel=medium>
 )
 
 # Set Debugging Fortran compiler flags for the Intel Compiler


### PR DESCRIPTION
## Description
This PR adds a quick & dirty fix for the deprecated obs2ioda converter.

## Issue(s) addressed
Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1684

## Dependencies
None

## Impact
None

## Checklist
- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
