### PR TITLE
Adding `satelliteAscendingFlag` & `dayOrNightQualifier` for SABER

### DIFF
--- a/src/conventional/saber2ioda.py
+++ b/src/conventional/saber2ioda.py
@@ -206,7 +206,7 @@ def get_data_from_file(obs_file_handle):
     time_raw = read_variable(obs_file_handle, 'time', dtype=numpy.int64, flatten=False)
     obs_data[('dateTime', META_DATA_NAME)] = get_epoch_time(date_raw, time_raw)
 
-    # Handle ascending flag (flipping from 0=asc to 1=asc)
+    # Handle satellite ascending flag (flipping from 0=asc to 1=asc)
     tpAD_raw = read_variable(obs_file_handle, 'tpAD', dtype=numpy.int32)
     valid_mask = numpy.isin(tpAD_raw, [0, 1])
     combined_mask = tpAD_raw.mask | ~valid_mask

--- a/src/conventional/saber2ioda.py
+++ b/src/conventional/saber2ioda.py
@@ -213,7 +213,7 @@ def get_data_from_file(obs_file_handle):
     tpAD_raw.mask = mask
     obs_data[("satelliteAscendingFlag", META_DATA_NAME)] = numpy.repeat(tpAD_raw, time_raw.shape[1])
 
-    # Handle day or night qualifier (from 0=day to 1=day)
+    # Handle day or night qualifier (flipping from 0=day to 1=day)
     tpDN_raw = read_variable(obs_file_handle, 'tpDN', dtype=numpy.int32)
     mask = tpDN_raw.mask | ~numpy.isin(tpDN_raw, [0, 1])
     tpDN_raw = numpy.ma.where(mask, tpDN_raw, 1 - tpDN_raw)

--- a/src/conventional/saber2ioda.py
+++ b/src/conventional/saber2ioda.py
@@ -202,9 +202,23 @@ def get_data_from_file(obs_file_handle):
     )
 
     # Handle time conversion
-    date_raw = read_variable(obs_file_handle, 'date', dtype=numpy.int64, flatten=False)
+    date_raw = read_variable(obs_file_handle, 'date', dtype=numpy.int64)
     time_raw = read_variable(obs_file_handle, 'time', dtype=numpy.int64, flatten=False)
     obs_data[('dateTime', META_DATA_NAME)] = get_epoch_time(date_raw, time_raw)
+
+    # Handle ascending flag (flipping from 0=asc to 1=asc)
+    tpAD_raw = read_variable(obs_file_handle, 'tpAD', dtype=numpy.int32)
+    mask = tpAD_raw.mask | ~numpy.isin(tpAD_raw, [0, 1])
+    tpAD_raw = numpy.ma.where(mask, tpAD_raw, 1 - tpAD_raw)
+    tpAD_raw.mask = mask
+    obs_data[("satelliteAscendingFlag", META_DATA_NAME)] = numpy.repeat(tpAD_raw, time_raw.shape[1])
+
+    # Handle day or night qualifier (from 0=day to 1=day)
+    tpDN_raw = read_variable(obs_file_handle, 'tpDN', dtype=numpy.int32)
+    mask = tpDN_raw.mask | ~numpy.isin(tpDN_raw, [0, 1])
+    tpDN_raw = numpy.ma.where(mask, tpDN_raw, 1 - tpDN_raw)
+    tpDN_raw.mask = mask
+    obs_data[("dayOrNightQualifier", META_DATA_NAME)] = numpy.repeat(tpDN_raw, time_raw.shape[1])
 
     # Add error and QC values
     nlocs = len(obs_data[('latitude', META_DATA_NAME)])

--- a/src/conventional/saber2ioda.py
+++ b/src/conventional/saber2ioda.py
@@ -208,16 +208,20 @@ def get_data_from_file(obs_file_handle):
 
     # Handle ascending flag (flipping from 0=asc to 1=asc)
     tpAD_raw = read_variable(obs_file_handle, 'tpAD', dtype=numpy.int32)
-    mask = tpAD_raw.mask | ~numpy.isin(tpAD_raw, [0, 1])
-    tpAD_raw = numpy.ma.where(mask, tpAD_raw, 1 - tpAD_raw)
-    tpAD_raw.mask = mask
+    valid_mask = numpy.isin(tpAD_raw, [0, 1])
+    combined_mask = tpAD_raw.mask | ~valid_mask
+    tpAD_raw = numpy.ma.masked_array(tpAD_raw, mask=combined_mask)
+    flip_idx = (tpAD_raw == 0) | (tpAD_raw == 1)
+    tpAD_raw[flip_idx] = 1 - tpAD_raw[flip_idx]
     obs_data[("satelliteAscendingFlag", META_DATA_NAME)] = numpy.repeat(tpAD_raw, time_raw.shape[1])
 
-    # Handle day or night qualifier (flipping from 0=day to 1=day)
+    # Handle day or night qualifier (flipping from 0=day to 1=day, keeping 2=twilight)
     tpDN_raw = read_variable(obs_file_handle, 'tpDN', dtype=numpy.int32)
-    mask = tpDN_raw.mask | ~numpy.isin(tpDN_raw, [0, 1])
-    tpDN_raw = numpy.ma.where(mask, tpDN_raw, 1 - tpDN_raw)
-    tpDN_raw.mask = mask
+    valid_mask = numpy.isin(tpDN_raw, [0, 1, 2])
+    combined_mask = tpDN_raw.mask | ~valid_mask
+    tpDN_raw = numpy.ma.masked_array(tpDN_raw, mask=combined_mask)
+    flip_idx = (tpDN_raw == 0) | (tpDN_raw == 1)
+    tpDN_raw[flip_idx] = 1 - tpDN_raw[flip_idx]
     obs_data[("dayOrNightQualifier", META_DATA_NAME)] = numpy.repeat(tpDN_raw, time_raw.shape[1])
 
     # Add error and QC values

--- a/test/testoutput/saber_timed.20160101T180000Z.nc4
+++ b/test/testoutput/saber_timed.20160101T180000Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b22b2142dfc526cc34d4c183e420a254c638706f3d7b0ed71dea25770647ca5f
+oid sha256:cb7be4493ca0a60dae2c1a5c3b884114bad2cc17c90256fc92c986f0f620a51c
 size 870659

--- a/test/testoutput/saber_timed.20160101T180000Z.nc4
+++ b/test/testoutput/saber_timed.20160101T180000Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ea9f6d34a0a634ebf32e2aa41d21ee110649fa84ce8ed1ec00d9d292cf7c8dd
-size 868410
+oid sha256:b22b2142dfc526cc34d4c183e420a254c638706f3d7b0ed71dea25770647ca5f
+size 870659


### PR DESCRIPTION
## Description
This PR adds `satelliteAscendingFlag` & `dayOrNightQualifier` for SABER.

## Issue(s) addressed
Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1679

## Dependencies
None

## Impact
None

## Checklist
- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR