### PR TITLE
Fix the value of CO2 in terms of mol/mol instead of ppmv

### DIFF
--- a/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
+++ b/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6292657d1c84b92bfd1c0dd3915de8c35c64239f3c60e7f137ccb91dc1e98bae
-size 9752226
+oid sha256:2dfb9eb6e3173a47d17db521beb761df55f3c00f4622b5f19bd859b7ecf23447
+size 459387

--- a/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
+++ b/test/testinput/gsidiag_amsua_aqua_radiance_test.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:088f5157fa1923445393f6d2e09df6b55130a9e9afbb1617f31db02c9d0063f8
-size 505127
+oid sha256:6292657d1c84b92bfd1c0dd3915de8c35c64239f3c60e7f137ccb91dc1e98bae
+size 9752226


### PR DESCRIPTION
## Description

The Geovals file had ppmv value for variable atmosphere_absorber_02 [mole_fraction_of_carbon_dioxide_in_air], changing that to mol/mol value by dividing the values with 1e6

## Issue(s) addressed

Resolves #(https://github.com/JCSDA-internal/ufo/issues/3734)

## Dependencies

List the other PRs that this PR is dependent on:
build-group=https://github.com/JCSDA-internal/ufo/pull/3797

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
