### PR TITLE
Replace deprecated sre_compile.compile function calls with re.compile function calls in cpplint script

### DIFF
--- a/tools/iodaconv_cpplint.py
+++ b/tools/iodaconv_cpplint.py
@@ -49,7 +49,6 @@ import itertools
 import math  # for log
 import os
 import re
-import sre_compile
 import string
 import sys
 import unicodedata
@@ -760,7 +759,7 @@ def Match(pattern, s):
   # performance reasons; factoring it out into a separate function turns out
   # to be noticeably expensive.
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re.compile(pattern)
   return _regexp_compile_cache[pattern].match(s)
 
 
@@ -778,14 +777,14 @@ def ReplaceAll(pattern, rep, s):
     string with replacements made (or original string if no replacements)
   """
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re.compile(pattern)
   return _regexp_compile_cache[pattern].sub(rep, s)
 
 
 def Search(pattern, s):
   """Searches the string for the pattern, caching the compiled regexp."""
   if pattern not in _regexp_compile_cache:
-    _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+    _regexp_compile_cache[pattern] = re.compile(pattern)
   return _regexp_compile_cache[pattern].search(s)
 
 


### PR DESCRIPTION
## Description

This PR removes dependency on the deprecated `sre_compile` module. `sre_compile.compile` can be replaced with `re.compile `which is the official public interface for compiling regular expressions.

## Issue(s) addressed

Partially addresses jcsda-internal/jedi-bundle/issues/117

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None - fixing the cpplint coding norms checker

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have run the unit tests before creating the PR
