### PR TITLE
Add the installation of Python scripts wsfm_2ioda.py and ssmis_upp_2ioda.py into build/bin

### DIFF
--- a/src/hdf5/CMakeLists.txt
+++ b/src/hdf5/CMakeLists.txt
@@ -8,7 +8,9 @@ list(APPEND scripts
   ozone_product_2ioda.py
   read_cloudsat.py
   read_dpr_gpm.py
+  ssmis_upp_2ioda.py
   tropics_2ioda.py
+  wsfm_2ioda.py
 )
 
 file( RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_BINARY_DIR}/bin ${PYIODACONV_BUILD_LIBDIR} )


### PR DESCRIPTION

## Description

Two Python scripts: [wsfm_2ioda.py ](https://github.com/JCSDA-internal/ioda-converters/blob/develop/src/hdf5/wsfm_2ioda.py)and [ssmis_upp_2ioda.py](https://github.com/JCSDA-internal/ioda-converters/blob/develop/src/hdf5/ssmis_upp_2ioda.py) were added to the ioda-converters/src/hdf5 in last May (respectively PR iodaconv #[1512](https://github.com/JCSDA-internal/ioda-converters/pull/1512)  and iodaconv #[1612](https://github.com/JCSDA-internal/ioda-converters/pull/1612)), but the [CmakeLists.txt](https://github.com/JCSDA-internal/ioda-converters/blob/develop/src/hdf5/CMakeLists.txt) file was not updated at the time, so that the scripts are not copied over the `build/bin` directory, as other decoders, during the build of the [iodaconv](https://github.com/JCSDA-internal/ioda-converters) repos.

This PR make sure that the two scripts are properly in installed.

## Issue(s) addressed

Resolves #[1703](https://github.com/JCSDA-internal/ioda-converters/issues/1703) 

## Dependencies

List the other PRs that this PR is dependent on:

None

## Impact

None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

1. Build jedi-bundle
2. List directory `build/bin` and check the presence/absence of scripts:  `wsfm_2ioda.py` and `ssmis_upp_2ioda.py`

## Checklist

- [x] I have performed a self-review of my own code

