### PR TITLE
update the AHI decoder in obs2ioda

### DIFF
--- a/src/ncar/obs2ioda/src/define_mod.f90
+++ b/src/ncar/obs2ioda/src/define_mod.f90
@@ -101,7 +101,7 @@ character(len=nstring), dimension(ninst) :: inst_list = &
 
 character(len=nstring), dimension(ninst_geo) :: geoinst_list = &
    (/                     &
-      'ahi_himawari8   '  &
+      'ahi_himawari    '  &
    /)
 ! variables for outputing netcdf files
 character(len=nstring), dimension(n_ncdim) :: name_ncdim = &

--- a/src/ncar/obs2ioda/src/hsd.f90
+++ b/src/ncar/obs2ioda/src/hsd.f90
@@ -14,7 +14,7 @@ module ahi_HSD_mod
 
 !https://www.jstage.jst.go.jp/article/jmsj/94/2/94_2016-009/_pdf/-char/en
 
-use kinds, only: i_byte, i_short, i_int, i_long, i_llong, i_kind, r_single, r_double, r_kind
+use kinds, only: i_byte, i_short, i_long, i_llong, i_kind, r_single, r_double, r_kind
 use define_mod, only: missing_r, missing_i, nstring, ndatetime, &
    ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
    nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, set_brit_obserr, strlen
@@ -66,8 +66,8 @@ type basic_info
   real(r_double)     :: obsStartTime   ! Modified Julian Date
   real(r_double)     :: obsEndTime     ! Modified Julian Date
   real(r_double)     :: fileCreateTime ! Modified Julian Date
-  integer(i_int)     :: totalHeaderLen
-  integer(i_int)     :: dataLen
+  integer(i_long)    :: totalHeaderLen
+  integer(i_long)    :: dataLen
   integer(i_byte)    :: qcflag1
   integer(i_byte)    :: qcflag2
   integer(i_byte)    :: qcflag3
@@ -91,8 +91,8 @@ type proj_info
   integer(i_byte)    :: headerNum      ! header block number = 3
   integer(i_short)   :: blockLen       ! block length = 127 bytes
   real(r_double)     :: subLon         ! 140.7 degree
-  integer(i_int)     :: cfac           ! column scaling factor
-  integer(i_int)     :: lfac           ! line scaling factor
+  integer(i_long)    :: cfac           ! column scaling factor
+  integer(i_long)    :: lfac           ! line scaling factor
   real(r_single)     :: coff           ! column offset
   real(r_single)     :: loff           ! line offset
   real(r_double)     :: satDis         ! distance from earth's center to virtual satellite = 42164 km
@@ -189,7 +189,7 @@ end type obsTime_info
 
 type error_info
   integer(i_byte)    :: headerNum      ! header block number = 10
-  integer(i_int)     :: blockLen       ! block length = 47
+  integer(i_long)    :: blockLen       ! block length = 47
   integer(i_short)   :: errorNum       ! number of error information data = 0
 !  integer(i_short), allocatable :: lineNo(:)    !(errorNum)
 !  integer(i_short), allocatable :: errPixNum(:) !(errorNum)

--- a/src/ncar/obs2ioda/src/hsd.f90
+++ b/src/ncar/obs2ioda/src/hsd.f90
@@ -14,7 +14,7 @@ module ahi_HSD_mod
 
 !https://www.jstage.jst.go.jp/article/jmsj/94/2/94_2016-009/_pdf/-char/en
 
-use kinds, only: i_byte, i_short, i_long, i_llong, i_kind, r_single, r_double, r_kind
+use kinds, only: i_byte, i_short, i_int, i_long, i_llong, i_kind, r_single, r_double, r_kind
 use define_mod, only: missing_r, missing_i, nstring, ndatetime, &
    ninst, inst_list, set_name_satellite, set_name_sensor, xdata, name_sen_info, &
    nvar_info, name_var_info, type_var_info, nsen_info, type_sen_info, set_brit_obserr, strlen
@@ -31,6 +31,7 @@ integer(i_llong) :: epochtime
 integer(i_kind)  :: iyear, imonth, iday, ihour, imin, isec
 
 integer(i_kind) :: subsample
+character(len=3)  :: ahi_satid
 
 integer(i_kind), parameter :: npixel = 5500
 integer(i_kind), parameter :: nline  = 5500
@@ -65,8 +66,8 @@ type basic_info
   real(r_double)     :: obsStartTime   ! Modified Julian Date
   real(r_double)     :: obsEndTime     ! Modified Julian Date
   real(r_double)     :: fileCreateTime ! Modified Julian Date
-  integer(i_long)    :: totalHeaderLen
-  integer(i_long)    :: dataLen
+  integer(i_int)     :: totalHeaderLen
+  integer(i_int)     :: dataLen
   integer(i_byte)    :: qcflag1
   integer(i_byte)    :: qcflag2
   integer(i_byte)    :: qcflag3
@@ -90,8 +91,8 @@ type proj_info
   integer(i_byte)    :: headerNum      ! header block number = 3
   integer(i_short)   :: blockLen       ! block length = 127 bytes
   real(r_double)     :: subLon         ! 140.7 degree
-  integer(i_long)    :: cfac           ! column scaling factor
-  integer(i_long)    :: lfac           ! line scaling factor
+  integer(i_int)     :: cfac           ! column scaling factor
+  integer(i_int)     :: lfac           ! line scaling factor
   real(r_single)     :: coff           ! column offset
   real(r_single)     :: loff           ! line offset
   real(r_double)     :: satDis         ! distance from earth's center to virtual satellite = 42164 km
@@ -188,7 +189,7 @@ end type obsTime_info
 
 type error_info
   integer(i_byte)    :: headerNum      ! header block number = 10
-  integer(i_long)    :: blockLen       ! block length = 47
+  integer(i_int)     :: blockLen       ! block length = 47
   integer(i_short)   :: errorNum       ! number of error information data = 0
 !  integer(i_short), allocatable :: lineNo(:)    !(errorNum)
 !  integer(i_short), allocatable :: errPixNum(:) !(errorNum)
@@ -238,9 +239,8 @@ character(len=16)   :: dummy16
 character(len=8)    :: ccyymmdd
 character(len=4)    :: ccyy, hhnn
 character(len=2)    :: mm, dd, hh, nn
-character(len=3)    :: satellite = 'H08'
 character(len=4)    :: region = 'FLDK'
-character(len=3)    :: resolution = 'R20'
+character(len=3)    :: resolution = 'R20'  ! hard-coded for IR channels; other resolutions R05 and R10 for VIS/NIR
 character(len=5)    :: segment ! S0110, S0210, etc
 character(len=3)    :: band    ! B07 - B16
 integer(i_short), allocatable :: idata(:)
@@ -251,7 +251,7 @@ integer(i_kind) :: ipixel, iline
 integer(i_kind) :: startLine, endLine
 integer(i_kind) :: radcount, i, ii, jj, ij, iv
 integer(i_kind) :: iband, isegm
-integer(i_kind) :: ierr
+integer(i_kind) :: ierr, ierrr
 integer(i_kind) :: nlocs, nvars, iloc
 integer(i_kind) :: ihh, imm, idd, jday, flength, rvalue, offset
 integer(i_kind) :: iunit = 21
@@ -300,13 +300,13 @@ do iband = 1, nband
       write(band, '(a,i2.2)') 'B', iband+6
       write(segment,'(a,i2.2,i2.2)') 'S', isegm, nsegm
       ij = isegm + (iband-1) * nsegm
-      fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
+      fnames(ij) = trim(inpdir)//'HS_'//ahi_satid//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
 !write(33,*) 'wget -np -nd -nc http://noaa-himawari8.s3.amazonaws.com/AHI-L1b-FLDK/' &
 !& //ccyy//'/'//mm//'/'//dd//'/'//hhnn//'/'//trim(fnames(ij))//'.bz2'
       inquire(file=trim(fnames(ij)), exist=fexist(ij))
       if ( fexist(ij) .eqv. .false. ) then
          write(segment,'(a,i2.2,i2.2)') 'S', isegm, nodivisionsegm
-         fnames(ij) = trim(inpdir)//'HS_'//satellite//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
+         fnames(ij) = trim(inpdir)//'HS_'//ahi_satid//'_'//ccyymmdd//'_'//hhnn//'_'//band//'_'//region//'_'//resolution//'_'//segment//'.DAT'
          inquire(file=trim(fnames(ij)), exist=fexist(ij))
       end if
 !print*,iband, isegm, trim(fnames(ij)), fexist(ij)
@@ -316,11 +316,15 @@ end do
 do iband = 1, nband
    do isegm = 1, nsegm
       ifile = isegm + (iband-1) * nsegm
-      if ( .not. fexist(ifile) ) cycle
+      if ( .not. fexist(ifile) ) then
+!        print*,'Cannot find file ',trim(fnames(ifile))
+         cycle
+      end if
       open(iunit, file=trim(fnames(ifile)), form='unformatted', action='read', access='stream', status='old', convert='little_endian')
       print*,'Reading from ', trim(fnames(ifile))
 
-      read(iunit) header%basic%headerNum, &
+      read(iunit, iostat=ierrr) &
+                  header%basic%headerNum, &
                   header%basic%blockLen, &
                   header%basic%numHeader, &
                   header%basic%byteOrder, &
@@ -341,14 +345,18 @@ do iband = 1, nband
                   header%basic%version, &
                   header%basic%fileName, &
                   header%basic%dummy40
-      read(iunit) header%data%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%data%headerNum, &
                   header%data%blockLen,&
                   header%data%bitPix, &
                   header%data%nPix, &
                   header%data%nLin, &
                   header%data%compression, &
                   header%data%dummy40
-      read(iunit) header%proj%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%proj%headerNum, &
                   header%proj%blockLen, &
                   header%proj%subLon, &
                   header%proj%cfac, &
@@ -365,7 +373,9 @@ do iband = 1, nband
                   header%proj%resampleKind, &
                   header%proj%resampleSize, &
                   header%proj%dummy40
-      read(iunit) header%navi%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%navi%headerNum, &
                   header%navi%blockLen, &
                   header%navi%navTime, &
                   header%navi%sspLon, &
@@ -380,7 +390,9 @@ do iband = 1, nband
                   header%navi%moonPos_y, &
                   header%navi%moonPos_z, &
                   header%navi%dummy40
-      read(iunit) header%calib%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%calib%headerNum, &
                   header%calib%blockLen, &
                   header%calib%bandNo, &
                   header%calib%waveLen, &
@@ -399,54 +411,84 @@ do iband = 1, nband
                   header%calib%planckConst, &
                   header%calib%bolzConst, &
                   header%calib%dummy40
-      read(iunit) header%interCalib%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%interCalib%headerNum, &
                   header%interCalib%blockLen, &
                   header%interCalib%dummy256
-      read(iunit) header%segm%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%segm%headerNum, &
                   header%segm%blockLen, &
                   header%segm%totalSegNum, &
                   header%segm%segSeqNo, &
                   header%segm%startLineNo, &
                   header%segm%dummy40
-      read(iunit) header%navicorr%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%navicorr%headerNum, &
                   header%navicorr%blockLen, &
                   header%navicorr%RoCenterColumn, &
                   header%navicorr%RoCenterLine, &
                   header%navicorr%RoCorrection, &
                   header%navicorr%correctNum
+      call read_error(ierrr)
       if ( header%navicorr%correctNum > 0 ) then
          numCorrect = header%navicorr%correctNum
          allocate(header%navicorr%lineNo(numCorrect))
          allocate(header%navicorr%columnShift(numCorrect))
          allocate(header%navicorr%lineShift(numCorrect))
+      else
+         write(*,'(3a,i6)') " Error reading file ",trim(fnames(ifile)), &
+                            " correctNum = ",header%navicorr%correctNum
+         call abort()
       end if
-      read(iunit) header%navicorr%lineNo(numCorrect), &
+      read(iunit, iostat=ierrr) &
+                  header%navicorr%lineNo(numCorrect), &
                   header%navicorr%columnShift(numCorrect), &
                   header%navicorr%lineShift(numCorrect), &
                   header%navicorr%dummy40
+      call read_error(ierrr)
       rewind(iunit)
-      read(iunit) header%obstime%headerNum, &
+      read(iunit, iostat=ierrr) &
+                  header%obstime%headerNum, &
                   header%obstime%blockLen, &
                   header%obstime%obsNum
+      call read_error(ierrr)
       if ( header%obsTime%obsNum > 0 ) then
          numObs = header%obsTime%obsNum
          allocate(header%obsTime%lineNo(numObs))
          allocate(header%obsTime%obsMJD(numObs))
+      else
+         write(*,'(3a,i6)') " Error reading file ",trim(fnames(ifile)), &
+                            " obsNum = ",header%obsTime%obsNum
+         call abort()
       end if
-      read(iunit) header%obstime%lineNo, &
+      read(iunit, iostat=ierrr) &
+                  header%obstime%lineNo, &
                   header%obstime%obsMJD, &
                   header%obstime%dummy40
-      read(iunit) header%error%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%error%headerNum, &
                   header%error%blockLen, &
                   header%error%errorNum, &
                   header%error%dummy40
-      read(iunit) header%dummy%headerNum, &
+      call read_error(ierrr)
+      read(iunit, iostat=ierrr) &
+                  header%dummy%headerNum, &
                   header%dummy%blockLen, &
                   header%dummy%dummy256
+      call read_error(ierrr)
       npix = header%data%nPix
       nlin = header%data%nLin
       ntotal = npix * nlin
-      allocate(idata(ntotal))
+      if (ntotal > 0) then
+         allocate(idata(ntotal))
+      else
+         write(*,'(a,i6)') " Error allocating idata, ntotal = ",ntotal
+         call abort()
+      end if
 
       inquire(file=trim(fnames(ifile)), size=flength)
       ! Offset relative to the beginning of the file
@@ -1006,6 +1048,19 @@ subroutine hisd_radiance_to_tbb (radiance, tbb)
  end if
  return
 end subroutine hisd_radiance_to_tbb
+
+subroutine read_error(ierr)
+
+ integer(i_kind) :: ierr
+
+ if (ierr /= 0) then
+    write(*,'(a,i6)') "Error in reading file, ierr = ",ierr
+    call abort()
+ endif
+
+ return
+
+end subroutine read_error
 
 !> @brief Compute the superobbed brightness temperature from a slice of BT values.
 !!

--- a/src/ncar/obs2ioda/src/main.f90
+++ b/src/ncar/obs2ioda/src/main.f90
@@ -305,6 +305,7 @@ iarg_outdir = -1
 iarg_datetime = -1
 iarg_subsample = -1
 iarg_superob_halfwidth = -1
+iarg_hs = -1
 iarg_ext = -1
 if ( narg > 0 ) then
    do iarg = 1, narg

--- a/src/ncar/obs2ioda/src/main.f90
+++ b/src/ncar/obs2ioda/src/main.f90
@@ -8,7 +8,7 @@ use radiance_mod, only: read_amsua_amsub_mhs, read_airs_colocate_amsua, sort_obs
    read_iasi, read_cris, radiance_to_temperature
 use ncio_mod, only: write_obs
 use gnssro_bufr2ioda, only: read_write_gnssro
-use ahi_hsd_mod, only: read_hsd, subsample
+use ahi_hsd_mod, only: read_hsd, subsample, ahi_satid
 use satwnd_mod, only: read_satwnd, filter_obs_satwnd, sort_obs_satwnd
 use utils_mod, only: da_advance_time
 
@@ -266,6 +266,10 @@ if ( do_ahi ) then
       write(*,*) 'Error: -t ccyymmddhhnn not specified for -ahi'
       stop
    end if
+   if (len_trim(ahi_satid) /=3) then
+      write (*, *) 'Error: Himawari AHI: with -ahi, specify satellite ID using -hs (H08 or H09)'
+      stop
+   end if
    call read_HSD(cdatetime, inpdir, do_superob, superob_halfwidth)
    filedate = cdatetime(1:10)
    call write_obs(filedate, write_nc_radiance_geo, outdir, 1, fileExt)
@@ -282,7 +286,7 @@ implicit none
 
 integer(i_kind)       :: iunit = 21
 integer(i_kind)       :: narg, iarg, iarg_inpdir, iarg_outdir, iarg_datetime, iarg_subsample
-integer(i_kind)       :: iarg_superob_halfwidth, iarg_ext
+integer(i_kind)       :: iarg_superob_halfwidth, iarg_ext, iarg_hs
 integer(i_kind)       :: itmp
 integer(i_kind)       :: iost, iret, idate
 character(len=StrLen) :: strtmp
@@ -294,6 +298,7 @@ fileExt = ''
 inpdir = '.'
 outdir = '.'
 cdatetime = ''
+ahi_satid = ''
 flist(:) = 'null'
 iarg_inpdir = -1
 iarg_outdir = -1
@@ -324,6 +329,8 @@ if ( narg > 0 ) then
          iarg_datetime = iarg + 1
       else if ( trim(strtmp) == '-s' ) then
          iarg_subsample = iarg + 1
+      else if ( trim(strtmp) == '-hs' ) then
+         iarg_hs = iarg + 1
       else if ( trim(strtmp) == '-superob' ) then
          do_superob = .true.
          iarg_superob_halfwidth = iarg + 1
@@ -349,6 +356,11 @@ if ( narg > 0 ) then
               read(strtmp,'(i2)') superob_halfwidth
             else
               iarg_superob_halfwidth = 1
+            end if
+         else if (iarg == iarg_hs) then
+            call get_command_argument(number=iarg, value=strtmp)
+            if (len_trim(strtmp) > 0) then
+              ahi_satid = strtmp(1:3)
             end if
          else
             ifile = ifile + 1

--- a/src/ncar/obs2ioda/src/ncio_mod.f90
+++ b/src/ncar/obs2ioda/src/ncio_mod.f90
@@ -9,6 +9,7 @@ use define_mod, only: nobtype, nvar_info, n_ncdim, n_ncgrp, nstring, ndatetime, 
    unit_var_met, iflag_conv, iflag_radiance, set_brit_obserr, set_ahi_obserr
 use netcdf, only: nf90_int, nf90_float, nf90_char, nf90_int64, nf90_string
 use ufo_vars_mod, only: ufo_vars_getindex
+use ahi_HSD_mod, only: ahi_satid
 use netcdf_cxx_mod, only: netcdfCreate, netcdfAddDim, netcdfPutAtt, netcdfAddVar, &
    netcdfSetFill, netcdfAddGroup, netcdfPutVar, netcdfClose
 
@@ -108,7 +109,11 @@ subroutine write_obs (filedate, write_opt, outdir, itim, fileExt)
       else if ( write_opt == write_nc_radiance ) then
          ncfname = trim(outdir)//trim(inst_list(ityp))//'_obs_'//trim(filedate)//'.'//fileExt
       else if ( write_opt == write_nc_radiance_geo ) then
-         ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_obs_'//trim(filedate)//'.'//fileExt
+         if (geoinst_list(ityp) == 'ahi_himawari') then
+            ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_'//trim(ahi_satid)//'_obs_'//trim(filedate)//'.'//fileExt
+         else
+            ncfname = trim(outdir)//trim(geoinst_list(ityp))//'_obs_'//trim(filedate)//'.'//fileExt
+         end if
       end if
       if ( write_opt == write_nc_radiance .or. write_opt == write_nc_radiance_geo ) then
          iv = ufo_vars_getindex(name_sen_info, 'sensor_channel')
@@ -116,6 +121,7 @@ subroutine write_obs (filedate, write_opt, outdir, itim, fileExt)
          ichan(:) = xdata(ityp,itim)%xseninfo_int(:,iv)
          allocate (obserr(xdata(ityp,itim)%nvars))
          if  ( write_opt == write_nc_radiance_geo ) then
+             ! AHI only supported geo sensor by decoder
              call set_ahi_obserr(geoinst_list(ityp), xdata(ityp,itim)%nvars, obserr)
          else
              call set_brit_obserr(inst_list(ityp), xdata(ityp,itim)%nvars, obserr)


### PR DESCRIPTION
## Description

There were some changes made to the **old** obs2ioda that needed porting to this new code they are from these PRs

https://github.com/JCSDA-internal/ioda-converters/pull/1649
https://github.com/JCSDA-internal/ioda-converters/pull/1698

this should allow for `obs2ioda` to decode either AHI from Himawari 8 or 9

jedi-ci-test-select=gcc

## Issue(s) addressed

Resolves #1713 

## Dependencies

some AHI files to decode in HSB (JMA Himawari Binary format) 

## Impact

working decoder straight to latest IODA specification

## Manual Testing Instructions (optional)


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
