### PR TITLE
port change into new obs2ioda to handle missing t29

### DIFF
--- a/src/ncar/obs2ioda/src/prepbufr_mod.f90
+++ b/src/ncar/obs2ioda/src/prepbufr_mod.f90
@@ -221,7 +221,10 @@ subroutine read_prepbufr(filename, filedate)
       call ufbint(iunit,obs,8,255,nlevels,obstr)
 
       r8sid = hdr(1)
-      t29 = nint(hdr(7))
+      t29 = missing_i
+      if (hdr(7) < r8bfms) then
+         t29 = nint(hdr(7))
+      end if
       kx  = nint(hdr(5))
 
       if ( use_errtable ) then


### PR DESCRIPTION
## Description

The missing value is not handled in the converter this will correctly detect and set value to missing if missing in BUFR

this is the same change as what was done to **old** version of this converter:
https://github.com/JCSDA-internal/ioda-converters/pull/1706

jedi-ci-test-select=gcc


## Issue(s) addressed

Resolves #1706 

## Impact

converter correctly setting missing value

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
