### PR TITLE
quietly find NOAA bufr_query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ endif()
 
 if( eckit_FOUND AND oops_FOUND AND ioda_FOUND AND bufr_FOUND )
     set(iodaconv_bufr_query_ENABLED True)
+    find_package( bufr_query QUIET )
     message(STATUS "Found: eckit")
     message(STATUS "Found: oops")
     message(STATUS "Found: ioda")


### PR DESCRIPTION
## Description

to help enable mepo support for NASA GMAO this adds a quiet find of the NOAA bufr_query package

this is a duplicate and replacement PR for:
https://github.com/JCSDA-internal/ioda-converters/pull/1660


## Issue(s) addressed

Resolves #1728 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
