### PR TITLE
Merging shuffle and deflate code from NCAR

### DIFF
--- a/src/ncar/obs2ioda/src/cxx/CMakeLists.txt
+++ b/src/ncar/obs2ioda/src/cxx/CMakeLists.txt
@@ -22,3 +22,9 @@ set(obs2ioda_cxx_INCLUDE_DIRS
 add_library(obs2ioda_cxx SHARED ${obs2ioda_cxx_SOURCES})
 target_compile_definitions(obs2ioda_cxx PUBLIC OBS2IODA_ROOT_DIR="${CMAKE_SOURCE_DIR}")
 obs2ioda_cxx_library(obs2ioda_cxx "${obs2ioda_cxx_INCLUDE_DIRS}" "${obs2ioda_cxx_LIBRARIES}")
+
+ecbuild_add_test( TARGET  ${PROJECT_NAME}_obs2ioda_coding_norms
+                    TYPE    SCRIPT
+                    COMMAND ${CMAKE_BINARY_DIR}/bin/${PROJECT_NAME}_cpplint.py
+                    ARGS    --quiet --recursive ${CMAKE_CURRENT_SOURCE_DIR}
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin )

--- a/src/ncar/obs2ioda/src/cxx/ioda_obs_schema.cc
+++ b/src/ncar/obs2ioda/src/cxx/ioda_obs_schema.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "ioda_obs_schema.h"
 
 void
@@ -86,7 +93,7 @@ void IodaObsVariable::load(const std::shared_ptr<IYamlNode> &node,
                            const eckit::LocalConfiguration &config) {
     static constexpr std::array<const char *, 2> keys = {"Variable",
                                                          "Dimension"};
-    for (const auto &key: keys) {
+    for (const auto &key : keys) {
         if (node->hasKey(config, key) && node->isKeySequence(config, key)) {
             this->setNames(node, config, key);
             break;

--- a/src/ncar/obs2ioda/src/cxx/ioda_obs_schema.h
+++ b/src/ncar/obs2ioda/src/cxx/ioda_obs_schema.h
@@ -1,5 +1,12 @@
-#ifndef IODASCHEMA_H
-#define IODASCHEMA_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_IODA_OBS_SCHEMA_H_
+#define NCAR_OBS2IODA_SRC_CXX_IODA_OBS_SCHEMA_H_
 
 #include <memory>
 #include <string>
@@ -20,7 +27,7 @@
  * YAML library (e.g., yaml-cpp). It enables dependency injection and mocking.
  */
 class IYamlNode {
-public:
+ public:
     /**
      * @brief Check whether a category (eg: "Variables") exists in the node.
      * @param category The category to check.
@@ -85,7 +92,7 @@ public:
  * generic access to YAML keys, sequences, and nested nodes.
  */
 class YamlEckitNode : public IYamlNode {
-public:
+ public:
     /**
      * @brief Constructor from a yaml file path.
      * @param yamlPath The path of file to get the node.
@@ -141,7 +148,7 @@ public:
     std::vector<eckit::LocalConfiguration>
     getSequence(const std::string &key) const override;
 
-private:
+ private:
     eckit::YAMLConfiguration node_;  ///< The wrapped eckit YAML node.
 };
 
@@ -152,7 +159,7 @@ private:
  * optionally a list of deprecated aliases.
  */
 class IodaObsSchemaComponent {
-protected:
+ protected:
     std::string validName;              ///< Canonical name (first name in list).
     std::vector<std::string> names;     ///< All known names (canonical + aliases).
     std::string componentType;          ///< Type: "Variable", "Attribute", etc.
@@ -179,7 +186,7 @@ protected:
     explicit IodaObsSchemaComponent(std::string componentType,
                                     std::string name = "");
 
-public:
+ public:
     /**
      * @brief Returns the canonical name of the component.
      * @return Canonical name string.
@@ -210,7 +217,7 @@ public:
  * @brief Represents an attribute entry in the schema.
  */
 class IodaObsAttribute final : public IodaObsSchemaComponent {
-public:
+ public:
     /**
      * @brief Constructor for an attribute component.
      * @param name Optional attribute name.
@@ -222,7 +229,7 @@ public:
  * @brief Represents a group entry in the schema.
  */
 class IodaObsGroup final : public IodaObsSchemaComponent {
-public:
+ public:
     /**
      * @brief Constructor for a group component.
      * @param name Optional group name.
@@ -234,7 +241,7 @@ public:
  * @brief Represents a dimension entry in the schema.
  */
 class IodaObsDimension final : public IodaObsSchemaComponent {
-public:
+ public:
     /**
      * @brief Constructor for a dimension component.
      * @param name Optional dimension name.
@@ -248,7 +255,7 @@ public:
  * Variables may appear under both "Variables" and "Dimensions".
  */
 class IodaObsVariable final : public IodaObsSchemaComponent {
-public:
+ public:
     /**
      * @brief Constructor for a variable component.
      * @param name Optional variable name.
@@ -270,10 +277,14 @@ public:
  * Parses schema components and resolves deprecated names to canonical ones.
  */
 class IodaObsSchema {
-    std::unordered_map<std::string, std::shared_ptr<IodaObsVariable>> variables;   ///< Variable name to variable object.
-    std::unordered_map<std::string, std::shared_ptr<IodaObsDimension>> dimensions; ///< Dimension name to dimension object.
-    std::unordered_map<std::string, std::shared_ptr<IodaObsGroup>> groups;         ///< Group name to group object.
-    std::unordered_map<std::string, std::shared_ptr<IodaObsAttribute>> attributes; ///< Attribute name to attribute object.
+    /// < Variable name to variable object.
+    std::unordered_map<std::string, std::shared_ptr<IodaObsVariable>> variables;
+    /// < Dimension name to dimension object.
+    std::unordered_map<std::string, std::shared_ptr<IodaObsDimension>> dimensions;
+    /// < Group name to group object.
+    std::unordered_map<std::string, std::shared_ptr<IodaObsGroup>> groups;
+    /// < Attribute name to attribute object.
+    std::unordered_map<std::string, std::shared_ptr<IodaObsAttribute>> attributes;
 
     /**
      * @brief Generic component loader from YAML into the component map.
@@ -290,11 +301,11 @@ class IodaObsSchema {
                        const std::string &key,
                        std::unordered_map<std::string, std::shared_ptr<T>> &componentMap) {
         if (schema->hasCategory(category) && schema->isCategorySequence(category)) {
-            for (const auto &item: schema->getSequence(category)) {
+            for (const auto &item : schema->getSequence(category)) {
                 if (schema->hasKey(item, key)) {
                     auto component = std::make_shared<T>();
                     component->load(schema, item);
-                    for (const auto &n: component->getNames()) {
+                    for (const auto &n : component->getNames()) {
                         componentMap.emplace(n, component);
                     }
                 }
@@ -322,7 +333,7 @@ class IodaObsSchema {
         return component;
     }
 
-public:
+ public:
     /**
      * @brief Construct and populate schema from YAML node.
      * @param schema Shared pointer to parsed YAML root node.
@@ -362,4 +373,4 @@ public:
     getVariable(const std::string &name);
 };
 
-#endif  // IODASCHEMA_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_IODA_OBS_SCHEMA_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_attribute.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_attribute.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_attribute.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
@@ -15,28 +22,21 @@ namespace Obs2Ioda {
             if (varName == nullptr) {
                 std::string msg = "Variable name cannot be null";
                 throw netCDF::exceptions::NcBadName(
-                    msg.c_str(), __FILE__, __LINE__
-                );
+                    msg.c_str(), __FILE__, __LINE__);
             }
             if (!std::string(varName).empty()) {
                 auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
                 auto var = group->getVar(iodaVarName);
                 if constexpr(std::is_same_v<const char *, T> && netcdfString) {
-                    var.putAtt(
-                        attName, std::string(
-                            reinterpret_cast<const char *>(values)
-                        )
-                    );
+                    var.putAtt(attName, std::string(
+                            reinterpret_cast<const char *>(values)));
                 } else {
                     var.putAtt(attName, netcdfDataType, len, values);
                 }
             } else {
                 if constexpr(std::is_same_v<const char *, T> && netcdfString) {
-                    group->putAtt(
-                        attName, std::string(
-                            reinterpret_cast<const char *>(values)
-                        )
-                    );
+                    group->putAtt(attName, std::string(
+                            reinterpret_cast<const char *>(values)));
                 } else {
                     group->putAtt(attName, netcdfDataType, len, values);
                 }
@@ -54,8 +54,7 @@ namespace Obs2Ioda {
     ) {
         return netcdfPutAtt(
             netcdfID, attName, attValue, varName, groupName,
-            netCDF::NcType(netCDF::ncInt), attLen
-        );
+            netCDF::NcType(netCDF::ncInt), attLen);
     }
 
     int netcdfPutAttRealArray(
@@ -64,8 +63,7 @@ namespace Obs2Ioda {
     ) {
         return netcdfPutAtt(
             netcdfID, attName, attValue, varName, groupName,
-            netCDF::NcType(netCDF::ncFloat), attLen
-        );
+            netCDF::NcType(netCDF::ncFloat), attLen);
     }
 
     int netcdfPutAttInt(
@@ -74,8 +72,7 @@ namespace Obs2Ioda {
     ) {
         return netcdfPutAtt(
             netcdfID, attName, attValue, varName, groupName,
-            netCDF::NcType(netCDF::ncInt), 1
-        );
+            netCDF::NcType(netCDF::ncInt), 1);
     }
 
     int netcdfPutAttString(
@@ -84,7 +81,6 @@ namespace Obs2Ioda {
     ) {
         return netcdfPutAtt<const char *, true>(
             netcdfID, attName, attValue, varName, groupName,
-            netCDF::NcType(netCDF::ncString), strlen(attValue)
-        );
+            netCDF::NcType(netCDF::ncString), strlen(attValue));
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_attribute.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_attribute.h
@@ -1,5 +1,12 @@
-#ifndef NETCDF_ATTRIBUTE_H
-#define NETCDF_ATTRIBUTE_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_ATTRIBUTE_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_ATTRIBUTE_H_
 
 namespace Obs2Ioda {
     extern "C" {
@@ -21,8 +28,7 @@ namespace Obs2Ioda {
      */
     int netcdfPutAttInt(
         int netcdfID, const char *attName, const int *attValue,
-        const char *varName, const char *groupName
-    );
+        const char *varName, const char *groupName);
 
     /**
      * @brief Writes an integer array attribute to a variable, group, or as a global attribute in a NetCDF file.
@@ -44,19 +50,16 @@ namespace Obs2Ioda {
      */
     int netcdfPutAttIntArray(
         int netcdfID, const char *attName, const int *attValue,
-        int attLen, const char *varName, const char *groupName
-    );
+        int attLen, const char *varName, const char *groupName);
 
     int netcdfPutAttRealArray(
         int netcdfID, const char *attName, const float *attValue,
-        int attLen, const char *varName, const char *groupName
-    );
+        int attLen, const char *varName, const char *groupName);
 
     int netcdfPutAttString(
         int netcdfID, const char *attName, const char *attValue,
-        const char *varName, const char *groupName
-    );
+        const char *varName, const char *groupName);
     }
-}
+}  // namespace Obs2Ioda
 
-#endif //NETCDF_ATTRIBUTE_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_ATTRIBUTE_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_dimension.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_dimension.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_utils.h"
 #include "netcdf_dimension.h"
 #include "netcdf_file.h"
@@ -19,11 +26,7 @@ namespace Obs2Ioda {
             *dimID = dim.getId();
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
-            return netcdfErrorMessage(
-                e,
-                __LINE__,
-                __FILE__
-            );
+            return netcdfErrorMessage(e, __LINE__, __FILE__);
         }
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_dimension.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_dimension.h
@@ -1,5 +1,12 @@
-#ifndef NETCDF_DIMENSION_H
-#define NETCDF_DIMENSION_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_DIMENSION_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_DIMENSION_H_
 
 
 namespace Obs2Ioda {
@@ -34,9 +41,8 @@ namespace Obs2Ioda {
         const char *groupName,
         const char *dimName,
         int len,
-        int *dimID
-    );
+        int *dimID);
     }
-}
+}  // namespace Obs2Ioda
 
-#endif //NETCDF_DIMENSION_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_DIMENSION_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_error.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_error.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include <sstream>
 #include "netcdf_error.h"
 
@@ -10,7 +17,7 @@ namespace Obs2Ioda {
     ) {
         std::stringstream message;
         message << "NetCDF Error: Code: " << e.errorCode();
-        if (not fileName.empty()) {
+        if (!fileName.empty()) {
             message << " File: " << fileName;
             if (lineNumber > 0) {
                 message << " Line: " << lineNumber;
@@ -20,4 +27,4 @@ namespace Obs2Ioda {
         std::cerr << message.str();
         return e.errorCode() == 0 ? -1 : e.errorCode();
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_error.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_error.h
@@ -1,10 +1,18 @@
-#ifndef OBS2IODA_NETCDF_ERROR_H
-#define OBS2IODA_NETCDF_ERROR_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_ERROR_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_ERROR_H_
 
 
 #include <netcdf>
 #include <variant>
 #include <ncChar.h>
+#include <cstdint>
 
 namespace Obs2Ioda {
 
@@ -58,7 +66,7 @@ namespace Obs2Ioda {
             throw netCDF::exceptions::NcBadType(msg.c_str(), __FILE__,
                                                 __LINE__);
         };
-        using SupportedTypes = std::variant<int, float, double, long long, const char *>;
+        using SupportedTypes = std::variant<int, float, double, int64_t, const char *>;
 
         if constexpr (!is_in_variant<T, SupportedTypes>::value) {
             throwBadTypeError(errorMessage);
@@ -74,7 +82,7 @@ namespace Obs2Ioda {
             if (netcdfDataType != NC_DOUBLE)
                 throwBadTypeError(errorMessage);
 
-        } else if constexpr (std::is_same_v<T, long long>) {
+        } else if constexpr (std::is_same_v<T, int64_t>) {
             if (netcdfDataType != NC_INT64)
                 throwBadTypeError(errorMessage);
 
@@ -125,9 +133,8 @@ namespace Obs2Ioda {
     int netcdfErrorMessage(
             const netCDF::exceptions::NcException &e,
             int lineNumber = -1,
-            const std::string &fileName = ""
-    );
+            const std::string &fileName = "");
 
-}
+}  // namespace Obs2Ioda
 
-#endif //OBS2IODA_NETCDF_ERROR_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_ERROR_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_file.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_file.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_file.h"
 #include "netcdf_error.h"
 #include <memory>
@@ -23,8 +30,7 @@ namespace Obs2Ioda {
             throw netCDF::exceptions::NcCantCreate(
                     "NetCDF ID already exists in the NetCDF file map",
                     __FILE__,
-                    __LINE__
-            );
+                    __LINE__);
         }
         this->fileMap[netcdfID] = file;
     }
@@ -38,8 +44,7 @@ namespace Obs2Ioda {
             throw netCDF::exceptions::NcBadId(
                     "NetCDF ID not found in the NetCDF file map",
                     __FILE__,
-                    __LINE__
-            );
+                    __LINE__);
         }
         this->fileMap.erase(netcdfFileIterator);
     }
@@ -51,8 +56,7 @@ namespace Obs2Ioda {
             throw netCDF::exceptions::NcBadId(
                     "NetCDF ID not found in the NetCDF file map",
                     __FILE__,
-                    __LINE__
-            );
+                    __LINE__);
         }
         return netcdfFileIterator->second;
     }
@@ -65,21 +69,18 @@ namespace Obs2Ioda {
         try {
             const auto file = std::make_shared<netCDF::NcFile>(
                     path,
-                    static_cast<netCDF::NcFile::FileMode>(fileMode)
-            );
+                    static_cast<netCDF::NcFile::FileMode>(fileMode));
             *netcdfID = file->getId();
             FileMap::getInstance().addFile(
                     *netcdfID,
-                    file
-            );
+                    file);
 
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
             return netcdfErrorMessage(
                     e,
                     __LINE__,
-                    __FILE__
-            );
+                    __FILE__);
         }
     }
 
@@ -92,8 +93,7 @@ namespace Obs2Ioda {
             return netcdfErrorMessage(
                     e,
                     __LINE__,
-                    __FILE__
-            );
+                    __FILE__);
         }
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_file.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_file.h
@@ -1,5 +1,12 @@
-#ifndef OBS2IODA_NETCDF_FILE_H
-#define OBS2IODA_NETCDF_FILE_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_FILE_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_FILE_H_
 
 #include <netcdf>
 #include <unordered_map>
@@ -14,7 +21,7 @@ namespace Obs2Ioda {
      * @brief Singleton class for managing a mapping of NetCDF file IDs to file objects.
      */
     class FileMap {
-    public:
+     public:
         /**
          * @brief Retrieves the singleton instance of the NetcdfFileMap.
          *
@@ -50,8 +57,7 @@ namespace Obs2Ioda {
          */
         void addFile(
             int netcdfID,
-            const std::shared_ptr<netCDF::NcFile> &file
-        );
+            const std::shared_ptr<netCDF::NcFile> &file);
 
         /**
          * @brief Removes a NetCDF file from the map.
@@ -63,30 +69,29 @@ namespace Obs2Ioda {
          * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
          */
         void removeFile(
-            int netcdfID
-        );
+            int netcdfID);
 
         /**
          * @brief Retrieves a NetCDF file from the map.
          *
-         * Retrieves the `std::shared_ptr` to the `netCDF::NcFile` object associated with the given
-         * NetCDF file ID.
+         * Retrieves the `std::shared_ptr` to the `netCDF::NcFile` object
+         *  associated with the given NetCDF file ID.
          *
          * @param netcdfID The unique NetCDF file ID to retrieve.
          * @return A shared pointer to the NetCDF file.
          * @throws netCDF::exceptions::NcBadId if the `netcdfID` does not exist in the map.
          */
         std::shared_ptr<netCDF::NcFile> getFile(
-            int netcdfID
-        );
+            int netcdfID);
 
-    private:
+     private:
         /**
          * @brief Private constructor to prevent direct instantiation.
          */
         FileMap() = default;
 
-        /// Map associating NetCDF file IDs with their corresponding shared pointers to NetCDF files.
+        /// Map associating NetCDF file IDs with their
+        /// corresponding shared pointers to NetCDF files.
         std::unordered_map<int, std::shared_ptr<netCDF::NcFile> >
         fileMap;
     };
@@ -109,12 +114,12 @@ namespace Obs2Ioda {
      * @return 0 on success, or a non-zero error code on failure.
      */
     int netcdfCreate(
+        /// < The path to the NetCDF file to be created.
         const char *path,
-        ///< The path to the NetCDF file to be created.
+        /// < The ID of the created NetCDF file.
         int *netcdfID,
-        ///< The ID of the created NetCDF file.
-        int fileMode ///< File mode for creating the NetCDF file.
-    );
+        /// < File mode for creating the NetCDF file.
+        int fileMode);
 
     /**
      * @brief Closes the NetCDF file associated with the given ID.
@@ -126,9 +131,9 @@ namespace Obs2Ioda {
      * @return 0 on success, or a non-zero error code on failure.
      */
     int netcdfClose(
-        int netcdfID
-    ); ///< The ID of the NetCDF file to be closed.
+        /// < The ID of the NetCDF file to be closed.
+        int netcdfID);
     }
-} // namespace Obs2Ioda
+}  // namespace Obs2Ioda
 
-#endif // OBS2IODA_NETCDF_FILE_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_FILE_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_group.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_group.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_group.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
@@ -19,8 +26,7 @@ namespace Obs2Ioda {
             return netcdfErrorMessage(
                 e,
                 __LINE__,
-                __FILE__
-            );
+                __FILE__);
         }
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_group.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_group.h
@@ -1,5 +1,12 @@
-#ifndef NETCDF_GROUP_H
-#define NETCDF_GROUP_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_GROUP_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_GROUP_H_
 
 namespace Obs2Ioda {
 
@@ -32,11 +39,8 @@ namespace Obs2Ioda {
         int netcdfAddGroup(
                 int netcdfID,
                 const char *parentGroupName,
-                const char *groupName
-        );
-
+                const char *groupName);
     }
+}  // namespace Obs2Ioda
 
-}
-
-#endif //NETCDF_GROUP_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_GROUP_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_utils.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_utils.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_utils.h"
 
 std::shared_ptr<netCDF::NcGroup> Obs2Ioda::setNetcdfGroup(

--- a/src/ncar/obs2ioda/src/cxx/netcdf_utils.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_utils.h
@@ -1,5 +1,12 @@
-#ifndef OBS2IODA_NETCDF_UTILS_H
-#define OBS2IODA_NETCDF_UTILS_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_UTILS_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_UTILS_H_
 #include <ncGroup.h>
 #include <ncFile.h>
 #include <memory>
@@ -9,8 +16,7 @@ namespace Obs2Ioda {
     std::shared_ptr<netCDF::NcGroup>
     setNetcdfGroup(
             const std::shared_ptr<netCDF::NcFile> &file,
-            const char *groupName
-    );
+            const char *groupName);
 }
 
-#endif //OBS2IODA_NETCDF_UTILS_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_UTILS_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_variable.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_variable.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "netcdf_variable.h"
 #include "netcdf_file.h"
 #include "netcdf_error.h"
@@ -36,8 +43,8 @@ namespace Obs2Ioda {
             std::vector<netCDF::NcDim> dims;
             dims.reserve(numDims);
             for (int i = 0; i < numDims; i++) {
-                dims.push_back(file->getDim(iodaSchema.getDimension(
-                        dimNames[i])->getValidName()));;
+                dims.push_back(file->getDim(
+                    iodaSchema.getDimension(dimNames[i])->getValidName()));;
             }
             auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
             auto var = group->addVar(iodaVarName,
@@ -50,7 +57,7 @@ namespace Obs2Ioda {
                 std::vector<size_t> chunks;
                 chunks.reserve(dims.size());
 
-                for (const auto &d: dims) {
+                for (const auto &d : dims) {
                     size_t n = d.getSize();
 
                     // avoid huge chunks (important for performance)
@@ -89,8 +96,7 @@ namespace Obs2Ioda {
                     "Invalid data type for NetCDF variable '" +
                     std::string(varName) +
                     "': expected " + std::string(typeid(T).name()) +
-                    ", got NetCDF type ID " + var.getType().getName()
-            );
+                    ", got NetCDF type ID " + var.getType().getName());
             if constexpr (std::is_same<T, const char *>::value && netcdfChar) {
                 if (var.getDims().size() != 2) {
                     std::string msg =
@@ -126,7 +132,7 @@ namespace Obs2Ioda {
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const long long *values
+            const int64_t *values
     ) {
         return netcdfPutVar(netcdfID, groupName, varName, values);
     }
@@ -186,8 +192,7 @@ namespace Obs2Ioda {
                     "Invalid data type for NetCDF variable '" +
                     std::string(varName) +
                     "': expected " + std::string(typeid(T).name()) +
-                    ", got NetCDF type ID " + var.getType().getName()
-            );
+                    ", got NetCDF type ID " + var.getType().getName());
             var.setFill(fillMode != 0,  // true if fillMode is non-zero
                         fillValue);
             return 0;
@@ -221,7 +226,7 @@ namespace Obs2Ioda {
             const char *groupName,
             const char *varName,
             int fillMode,
-            long long fillValue
+            int64_t fillValue
     ) {
         return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
@@ -235,4 +240,4 @@ namespace Obs2Ioda {
     ) {
         return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
-}
+}  // namespace Obs2Ioda

--- a/src/ncar/obs2ioda/src/cxx/netcdf_variable.cc
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_variable.cc
@@ -10,15 +10,13 @@ namespace Obs2Ioda {
     std::vector<char>
     flattenCharArray(const char *const *values, size_t numStrings,
                      size_t stringLen) {
-        std::vector<char> flattened(numStrings * stringLen,
-                                    ' ');  // default to space padding
+        std::vector<char> flattened(numStrings * stringLen, ' ');  // default to space padding
 
         for (size_t i = 0; i < numStrings; ++i) {
-            size_t len = std::min(std::strlen(values[i]), stringLen -
-                                                          1);  // leave room for null terminator
+            size_t len = std::min(std::strlen(values[i]), stringLen - 1);
+            // leave room for null terminator
             std::memcpy(&flattened[i * stringLen], values[i], len);
-            flattened[i * stringLen +
-                      len] = '\0';  // explicitly null-terminate
+            flattened[i * stringLen + len] = '\0';  // explicitly null-terminate
         }
         return flattened;
     }
@@ -29,34 +27,47 @@ namespace Obs2Ioda {
             const char *varName,
             nc_type netcdfDataType,
             int numDims,
-            const char **dimNames
+            const char **dimNames,
+            const ZlibSettings *zlibSettings
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
-            const auto group = setNetcdfGroup(
-                    file,
-                    groupName
-            );
+            const auto group = setNetcdfGroup(file, groupName);
             std::vector<netCDF::NcDim> dims;
             dims.reserve(numDims);
             for (int i = 0; i < numDims; i++) {
                 dims.push_back(file->getDim(iodaSchema.getDimension(
                         dimNames[i])->getValidName()));;
             }
-            auto iodaVarName = iodaSchema.getVariable(
-                    varName)->getValidName();
-            auto var = group->addVar(
-                    iodaVarName,
-                    netCDF::NcType(netcdfDataType),
-                    dims
-            );
+            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
+            auto var = group->addVar(iodaVarName,
+                                     netCDF::NcType(netcdfDataType),
+                                     dims);
+            // Skip types not supported by deflate
+            bool compressible = netcdfDataType != NC_STRING && netcdfDataType != NC_CHAR;
+
+            if (compressible && !dims.empty() && zlibSettings->enabled) {
+                std::vector<size_t> chunks;
+                chunks.reserve(dims.size());
+
+                for (const auto &d: dims) {
+                    size_t n = d.getSize();
+
+                    // avoid huge chunks (important for performance)
+                    if (n > 256) n = 256;
+                    if (n == 0) n = 1;
+                    chunks.push_back(n);
+                }
+
+                // Required before compression
+                var.setChunking(netCDF::NcVar::nc_CHUNKED, chunks);
+                // shuffle filter + deflate level 4
+                var.setCompression(zlibSettings->shuffle, zlibSettings->deflate,
+                                   zlibSettings->deflateLevel);
+            }
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
-            return netcdfErrorMessage(
-                    e,
-                    __LINE__,
-                    __FILE__
-            );
+            return netcdfErrorMessage(e, __LINE__, __FILE__);
         }
     }
 
@@ -69,12 +80,8 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
-            const auto group = setNetcdfGroup(
-                    file,
-                    groupName
-            );
-            auto iodaVarName = iodaSchema.getVariable(
-                    varName)->getValidName();
+            const auto group = setNetcdfGroup(file, groupName);
+            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
             const auto var = group->getVar(iodaVarName);
             // Validate the data type of the variable
             validateNetcdfDataType<T>(
@@ -84,33 +91,25 @@ namespace Obs2Ioda {
                     "': expected " + std::string(typeid(T).name()) +
                     ", got NetCDF type ID " + var.getType().getName()
             );
-            if constexpr (std::is_same<T, const char *>::value &&
-                          netcdfChar) {
+            if constexpr (std::is_same<T, const char *>::value && netcdfChar) {
                 if (var.getDims().size() != 2) {
                     std::string msg =
                             "Expected a 2D char variable for NetCDF variable '" +
                             std::string(varName) + "', but got " +
                             std::to_string(var.getDims().size()) +
                             " dimensions.";
-                    throw netCDF::exceptions::NcBadDim(msg.c_str(), __FILE__,
-                                                       __LINE__);
+                    throw netCDF::exceptions::NcBadDim(msg.c_str(), __FILE__, __LINE__);
                 }
                 auto numStrings = var.getDims()[0].getSize();
                 auto stringLen = var.getDims()[1].getSize();
-                auto flattenedCharValues = flattenCharArray(values,
-                                                            numStrings,
-                                                            stringLen);
+                auto flattenedCharValues = flattenCharArray(values, numStrings, stringLen);
                 var.putVar(flattenedCharValues.data());
                 return 0;
             }
             var.putVar(values);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
-            return netcdfErrorMessage(
-                    e,
-                    __LINE__,
-                    __FILE__
-            );
+            return netcdfErrorMessage(e, __LINE__, __FILE__);
         }
     }
 
@@ -120,12 +119,7 @@ namespace Obs2Ioda {
             const char *varName,
             const int *values
     ) {
-        return netcdfPutVar(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar(netcdfID, groupName, varName, values);
     }
 
     int netcdfPutVarInt64(
@@ -134,12 +128,7 @@ namespace Obs2Ioda {
             const char *varName,
             const long long *values
     ) {
-        return netcdfPutVar(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar(netcdfID, groupName, varName, values);
     }
 
     int netcdfPutVarReal(
@@ -148,12 +137,7 @@ namespace Obs2Ioda {
             const char *varName,
             const float *values
     ) {
-        return netcdfPutVar(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar(netcdfID, groupName, varName, values);
     }
 
     int netcdfPutVarDouble(
@@ -162,12 +146,7 @@ namespace Obs2Ioda {
             const char *varName,
             const double *values
     ) {
-        return netcdfPutVar(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar(netcdfID, groupName, varName, values);
     }
 
     int netcdfPutVarChar(
@@ -176,12 +155,7 @@ namespace Obs2Ioda {
             const char *varName,
             const char **values
     ) {
-        return netcdfPutVar<const char *, true>(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar<const char *, true>(netcdfID, groupName, varName, values);
     }
 
     int netcdfPutVarString(
@@ -190,12 +164,7 @@ namespace Obs2Ioda {
             const char *varName,
             const char **values
     ) {
-        return netcdfPutVar(
-                netcdfID,
-                groupName,
-                varName,
-                values
-        );
+        return netcdfPutVar(netcdfID, groupName, varName, values);
     }
 
     template<typename T>
@@ -208,12 +177,8 @@ namespace Obs2Ioda {
     ) {
         try {
             auto file = FileMap::getInstance().getFile(netcdfID);
-            const auto group = setNetcdfGroup(
-                    file,
-                    groupName
-            );
-            auto iodaVarName = iodaSchema.getVariable(
-                    varName)->getValidName();
+            const auto group = setNetcdfGroup(file, groupName);
+            auto iodaVarName = iodaSchema.getVariable(varName)->getValidName();
             auto var = group->getVar(iodaVarName);
             // Validate the data type of the variable
             validateNetcdfDataType<T>(
@@ -223,17 +188,11 @@ namespace Obs2Ioda {
                     "': expected " + std::string(typeid(T).name()) +
                     ", got NetCDF type ID " + var.getType().getName()
             );
-            var.setFill(
-                    fillMode != 0,  // true if fillMode is non-zero
-                    fillValue
-            );
+            var.setFill(fillMode != 0,  // true if fillMode is non-zero
+                        fillValue);
             return 0;
         } catch (netCDF::exceptions::NcException &e) {
-            return netcdfErrorMessage(
-                    e,
-                    __LINE__,
-                    __FILE__
-            );
+            return netcdfErrorMessage(e, __LINE__, __FILE__);
         }
     }
 
@@ -244,13 +203,7 @@ namespace Obs2Ioda {
             int fillMode,
             int fillValue
     ) {
-        return netcdfSetFill(
-                netcdfID,
-                groupName,
-                varName,
-                fillMode,
-                fillValue
-        );
+        return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
 
     int netcdfSetFillReal(
@@ -260,13 +213,7 @@ namespace Obs2Ioda {
             int fillMode,
             float fillValue
     ) {
-        return netcdfSetFill(
-                netcdfID,
-                groupName,
-                varName,
-                fillMode,
-                fillValue
-        );
+        return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
 
     int netcdfSetFillInt64(
@@ -276,13 +223,7 @@ namespace Obs2Ioda {
             int fillMode,
             long long fillValue
     ) {
-        return netcdfSetFill(
-                netcdfID,
-                groupName,
-                varName,
-                fillMode,
-                fillValue
-        );
+        return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
 
     int netcdfSetFillString(
@@ -292,13 +233,6 @@ namespace Obs2Ioda {
             int fillMode,
             const char *fillValue
     ) {
-        return netcdfSetFill(
-                netcdfID,
-                groupName,
-                varName,
-                fillMode,
-                fillValue
-
-        );
+        return netcdfSetFill(netcdfID, groupName, varName, fillMode, fillValue);
     }
 }

--- a/src/ncar/obs2ioda/src/cxx/netcdf_variable.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_variable.h
@@ -1,5 +1,12 @@
-#ifndef NETCDF_VARIABLE_H
-#define NETCDF_VARIABLE_H
+/*
+ * (C) Copyright 2026 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef NCAR_OBS2IODA_SRC_CXX_NETCDF_VARIABLE_H_
+#define NCAR_OBS2IODA_SRC_CXX_NETCDF_VARIABLE_H_
 
 #include <netcdf>
 
@@ -58,8 +65,7 @@ namespace Obs2Ioda {
             nc_type netcdfDataType,
             int numDims,
             const char **dimNames,
-            const ZlibSettings *zlibSettings
-    );
+            const ZlibSettings *zlibSettings);
 
     /**
     * @brief Writes data to a variable in a NetCDF file.
@@ -76,43 +82,37 @@ namespace Obs2Ioda {
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const int *values
-    );
+            const int *values);
 
     int netcdfPutVarInt64(
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const long long *values
-    );
+            const int64_t *values);
 
     int netcdfPutVarReal(
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const float *values
-    );
+            const float *values);
 
     int netcdfPutVarDouble(
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const double *values
-    );
+            const double *values);
 
     int netcdfPutVarString(
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const char **values
-    );
+            const char **values);
 
     int netcdfPutVarChar(
             int netcdfID,
             const char *groupName,
             const char *varName,
-            const char **values
-    );
+            const char **values);
 
     /**
     * @brief Sets the fill mode and fill value for a variable in a NetCDF file.
@@ -133,33 +133,29 @@ namespace Obs2Ioda {
             const char *groupName,
             const char *varName,
             int fillMode,
-            int fillValue
-    );
+            int fillValue);
 
     int netcdfSetFillReal(
             int netcdfID,
             const char *groupName,
             const char *varName,
             int fillMode,
-            float fillValue
-    );
+            float fillValue);
 
     int netcdfSetFillInt64(
             int netcdfID,
             const char *groupName,
             const char *varName,
             int fillMode,
-            long long fillValue
-    );
+            int64_t fillValue);
 
     int netcdfSetFillString(
             int netcdfID,
             const char *groupName,
             const char *varName,
             int fillMode,
-            const char *fillValue
-    );
+            const char *fillValue);
     }
-}
+}  // namespace Obs2Ioda
 
-#endif //NETCDF_VARIABLE_H
+#endif  // NCAR_OBS2IODA_SRC_CXX_NETCDF_VARIABLE_H_

--- a/src/ncar/obs2ioda/src/cxx/netcdf_variable.h
+++ b/src/ncar/obs2ioda/src/cxx/netcdf_variable.h
@@ -3,6 +3,13 @@
 
 #include <netcdf>
 
+    struct ZlibSettings {
+        int enabled = 0;
+        int shuffle = 1;
+        int deflate = 1;
+        int deflateLevel = 4;
+    };
+
 namespace Obs2Ioda {
 
     /**
@@ -38,6 +45,8 @@ namespace Obs2Ioda {
      * @param netcdfDataType The NetCDF data type of the variable (e.g., NC_INT, NC_FLOAT).
      * @param numDims The number of dimensions associated with the variable.
      * @param dimNames An array of dimension names specifying the shape of the variable.
+     * @param zlibSettings Compression settings to be applied to the variable.
+     *                     If compression is not desired, all fields should be set to 0.
      * @return int A status code indicating the outcome of the operation:
      *         - 0: Success.
      *         - Non-zero: Failure, with an error message logged.
@@ -48,7 +57,8 @@ namespace Obs2Ioda {
             const char *varName,
             nc_type netcdfDataType,
             int numDims,
-            const char **dimNames
+            const char **dimNames,
+            const ZlibSettings *zlibSettings
     );
 
     /**

--- a/src/ncar/obs2ioda/src/netcdf_cxx_i_mod.f90
+++ b/src/ncar/obs2ioda/src/netcdf_cxx_i_mod.f90
@@ -133,6 +133,8 @@ module netcdf_cxx_i_mod
         !       The number of dimensions associated with the variable.
         !     - dimNames (type(c_ptr), intent(in), value):
         !       A C pointer to an array of null-terminated strings representing the dimension names.
+        !     - zlibSettings (type(c_ptr), intent(in), value):
+        !       A C pointer to struct of compression settings
         !
         !   Returns:
         !     - integer(c_int): Status code indicating the result of the operation:
@@ -143,7 +145,7 @@ module netcdf_cxx_i_mod
         !     - This function assumes that `netcdfID` corresponds to a valid NetCDF file.
         !     - All strings must be null-terminated and passed as C pointers.
         function c_netcdfAddVar(&
-                netcdfID, groupName, varName, netcdfDataType, numDims, dimNames) &
+                netcdfID, groupName, varName, netcdfDataType, numDims, dimNames, zlibSettings) &
                 bind(C, name = "netcdfAddVar")
             import :: c_int
             import :: c_ptr
@@ -153,6 +155,7 @@ module netcdf_cxx_i_mod
             integer(c_int), value, intent(in) :: netcdfDataType
             integer(c_int), value, intent(in) :: numDims
             type(c_ptr), value, intent(in) :: dimNames
+            type(c_ptr), value, intent(in) :: zlibSettings
             integer(c_int) :: c_netcdfAddVar
         end function c_netcdfAddVar
 

--- a/src/ncar/obs2ioda/src/netcdf_cxx_mod.f90
+++ b/src/ncar/obs2ioda/src/netcdf_cxx_mod.f90
@@ -10,6 +10,13 @@ module netcdf_cxx_mod
     implicit none
     public
 
+    type, bind(C) :: zlib_settings_t
+        integer(c_int) :: enabled = 1
+        integer(c_int) :: shuffle = 1
+        integer(c_int) :: deflate = 1
+        integer(c_int) :: deflateLevel = 4
+    end type zlib_settings_t
+
     interface netcdfPutAtt
         module procedure netcdfPutAtt
         module procedure netcdfPutAttArray
@@ -162,12 +169,14 @@ contains
     !       If not provided, the variable will be added as a global variable.
     !     - fillValue (class(*), intent(in), optional):
     !       The fill value to be used for the variable.
+    !     - zlibSettings (type(zlib_settings_t), intent(in), optional):
+    !       The values used for compression setting, if desired.
     !
     !   Returns:
     !     - integer(c_int): A status code indicating the outcome of the operation:
     !         - 0: Success.
     !         - Non-zero: Failure.
-    function netcdfAddVar(netcdfID, varName, netcdfDataType, numDims, dimNames, groupName, fillValue)
+    function netcdfAddVar(netcdfID, varName, netcdfDataType, numDims, dimNames, groupName, fillValue, zlibSettings)
         integer(c_int), value, intent(in) :: netcdfID
         character(len = *), intent(in) :: varName
         integer(c_int), value, intent(in) :: netcdfDataType
@@ -175,20 +184,27 @@ contains
         character(len = *), dimension(numDims), intent(in) :: dimNames
         character(len = *), optional, intent(in) :: groupName
         class(*), intent(in), optional :: fillValue
+        type(zlib_settings_t), intent(in), optional :: zlibSettings
         integer(c_int) :: netcdfAddVar
         integer :: status
         type(c_ptr) :: c_groupName
         type(c_ptr) :: c_varName
         type(c_ptr) :: c_dimNames
+        type(c_ptr) :: c_zlibSettings
         type(f_c_string_t) :: f_c_string_groupName
         type(f_c_string_t) :: f_c_string_varName
         type(f_c_string_array_t) :: f_c_string_array_dimNames
+        type(zlib_settings_t), target :: zlibSettingsLocal
 
         if (present(groupName)) then
             f_c_string_groupName = f_c_string_t(groupName)
         else
             f_c_string_groupName = f_c_string_t("")
         end if
+        if (present(zlibSettings)) then
+            zlibSettingsLocal = zlibSettings
+        end if
+
         status = check_f_c_string(f_c_string_groupName%to_c())
         c_groupName = check_f_c_string(f_c_string_groupName%get_c_string())
         f_c_string_varName = f_c_string_t(varName)
@@ -197,8 +213,10 @@ contains
         f_c_string_array_dimNames = f_c_string_array_t(dimNames)
         status = check_f_c_string_array(f_c_string_array_dimNames%to_c())
         c_dimNames = check_f_c_string_array(f_c_string_array_dimNames%get_c_string_array())
+        c_zlibSettings = c_loc(zlibSettingsLocal)
+
         netcdfAddVar = c_netcdfAddVar(netcdfID, c_groupName, c_varName, &
-                netcdfDataType, numDims, c_dimNames)
+                netcdfDataType, numDims, c_dimNames, c_zlibSettings)
         if (present(fillValue)) then
             netcdfAddVar = netcdfSetFill(netcdfID, varName, 1, fillValue, groupName)
         end if


### PR DESCRIPTION
## Description

jedi-ci-test-select=gcc


Adding Shuffle and Deflate option to compress files just like in GNSS_RO.
Andy Stokely checked in code in https://github.com/NCAR/obs2ioda/ 
I am merging those code in Jedi and testing the code .

Also adding coding norms test for the C++ files only, so most of the coding norm changes are in C++ files. Fortran code has the shuffle and deflate code changes.

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ioda-converters/issues/1720

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:
None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
