### PR TITLE
Flip the quality control flags for NASA products

### DIFF
--- a/src/compo/viirs_aod2ioda.py
+++ b/src/compo/viirs_aod2ioda.py
@@ -61,6 +61,17 @@ missing_vals = {'string': string_missing_value,
                 'float': float_missing_value,
                 'double': double_missing_value}
 
+# QC mapping array for NASA products (Dark Target and Deep Blue)
+# Dark Target flags: 0 = Bad, 1 = Marginal, 2 = Good, 3 = Very Good
+# Deep Blue flags: 0=no retrieval, 1=poor, 2=moderate, 3=good
+qcmapping = {
+    0: 3,
+    1: 2,
+    2: 1,
+    3: 0,
+}
+nasa_flip_qc = np.array([qcmapping[k] for k in sorted(qcmapping)])
+
 
 class AOD(object):
     def __init__(self, in_dict):
@@ -192,12 +203,15 @@ class AOD(object):
         self.lsfs = self.lsfs[valid_pts]
         self.vals = self.vals[valid_pts]
         self.errs = self.errs[valid_pts]
-        self.qcfs = self.qcfs[valid_pts]
+
+        # Flip QC flags for PreQC (0->3, 3->0)
+        self.qcfs = nasa_flip_qc[self.qcfs[valid_pts].astype(np.int32)]
 
     def get_nasa_db_data(self):
         # For NASA Deep Blue
         self.lons = self.ncd.variables['Longitude'][:].ravel()
         self.lats = self.ncd.variables['Latitude'][:].ravel()
+        # Only QC=3 pixels are retained with Aerosol_Optical_Thickness_550_Land_Ocean_Best_Estimate
         self.vals = self.ncd.variables['Aerosol_Optical_Thickness_550_Land_Ocean_Best_Estimate'][:].ravel()
 
         # Keep valid data points only
@@ -248,6 +262,8 @@ class AOD(object):
             self.errs[mix_equal_pts] = 0.5 * eu_land[mix_equal_pts] + 0.5 * eu_ocean[mix_equal_pts]
             self.qcfs[mix_equal_pts] = np.where(qaf_land[mix_equal_pts] < qaf_ocean[mix_equal_pts],
                                                 qaf_land[mix_equal_pts], qaf_ocean[mix_equal_pts])
+        # Flip QC flags for PreQC (0->3, 3->0)
+        self.qcfs = nasa_flip_qc[self.qcfs.astype(np.int32)]
 
         AttrData['errorMethod'] = 'Pixel-level Uncertainty Estimates (PUE)'
         if self.error_method != "pue":

--- a/test/testoutput/viirs_db_aod.nc
+++ b/test/testoutput/viirs_db_aod.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:398289dd89272864af33a3dd1fc5c6b8f53f885caea4d82f971af014cab79dc0
+oid sha256:ba5b7921736215ab589247c2682ffb66cdb25909a504ccdbed42135646c7de05
 size 15256

--- a/test/testoutput/viirs_dt_aod.nc
+++ b/test/testoutput/viirs_dt_aod.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71830eaa7307e9ab5aea05695c59a7a44eab12bf624f00dc8db46336ae19296c
+oid sha256:9f20907b39f3eadba760aab94c934c9cf7ec6dd153a45ea0971be0b9cabe9080
 size 15256


### PR DESCRIPTION
## Description
This PR fixes the quality control flags for NASA's VIIRS AOD products (Dark Target and Deep Blue).
The QC flags in products:
```
Dark Target flags: 0 = Bad, 1 = Marginal, 2 = Good, 3 = Very Good
Deep Blue flags: 0=no retrieval, 1=poor, 2=moderate, 3=good
```
Direct usage of these QC flags assigns `Bad` quality data to PreQC = 0, which results in bad or no data to be assimilated.


## Issue(s) addressed
Resolves #1760 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
