### PR TITLE
update ompso3 for nasa gmao

### DIFF
--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -120,8 +120,11 @@ class omps_nm(object):
             sza = geo.variables['SolarZenithAngle'][:].ravel()
             gpqf = geo.variables['GroundPixelQualityFlags'][:].ravel()
             af = sci.variables['AlgorithmFlags'][:].ravel()
-            mqf = sci.variables['MeasurementQualityFlags'][:].ravel()
-            iqf = geo.variables['InstrumentQualityFlags'][:].ravel()
+            # mqf and iqf are 1D (DimAlongTrack only), need to repeat for each cross-track pixel
+            mqf_scan = sci.variables['MeasurementQualityFlags'][:]  # shape (da,)
+            mqf = np.repeat(mqf_scan, dc)  # expand to da*dc
+            iqf_scan = geo.variables['InstrumentQualityFlags'][:]  # shape (da,)
+            iqf = np.repeat(iqf_scan, dc)  # expand to da*dc
 
             # obs value, we prefer to convert DU to mol.m-2
             obs_du = sci.variables['ColumnAmountO3'][:].ravel()

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -102,7 +102,6 @@ class omps_nm(object):
             lon = geo.variables['Longitude'][:].ravel()
 
             # surface/terrain pressure
-            anc = ncd.groups['AncillaryData']
             terrain_pressure = anc.variables['TerrainPressure'][:].ravel()
 
             # time
@@ -157,9 +156,7 @@ class omps_nm(object):
             # xa is already in DU so this is straightforward,
             # and we can convert to mol.m-2 at the end to match conventions
             apriori_total = np.zeros(len(obs))
-            for lev in range(nlevs):
-                apriori_total += (1.0 - averaging_kernel[:, lev]) * apriori_layers[:, lev]
-            apriori_total *= DU2molsqm
+            apriori_total = ((1.0 - averaging_kernel) * apriori_layers).sum(axis=1) * DU2molsqm
 
             # we want to make sure we adjust the pressure grid if terrain is less than any
             # of the standard pressure levels, as this would cause issues
@@ -364,8 +361,8 @@ def main():
     optional.add_argument(
         '-e', '--error_method',
         help="Observation error calculation method. "
-        "'fixed': use GSI fixed value of 6.0 DU; "
-        "'atbd': linear interpolation from ATBD lookup table (default); ",
+        "'fixed': use GSI fixed value of 6.0 DU"
+        "'atbd': linear interpolation from ATBD lookup table",
         type=str, default='fixed', choices=['fixed', 'atbd'])
 
     args = parser.parse_args()

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -36,7 +36,14 @@ DimDict = {
 VarDims = {
     'ozoneTotal': ['Location'],
     'averagingKernel': ['Location', 'Layer'],
-    'pressureVertices': ['Location', 'Vertice']
+    'pressureVertices': ['Location', 'Vertice'],
+    'aprioriTerm': ['Location'],
+    'solarZenithAngle': ['Location'],
+    'qualityFlags': ['Location'],
+    'groundPixelQualityFlags': ['Location'],
+    'algorithmFlags': ['Location'],
+    'measurementQualityFlags': ['Location'],
+    'instrumentQualityFlags': ['Location']
 }
 
 # DU to mol.m-2 conversion factor
@@ -108,6 +115,13 @@ class omps_nm(object):
             # other quantities could be used for future filtering in UFO
             qa_value = sci.variables['QualityFlags'][:].ravel()
             flg = qa_value <= self.qa_flg
+            
+            # read all quality and geometry metadata variables
+            sza = geo.variables['SolarZenithAngle'][:].ravel()
+            gpqf = geo.variables['GroundPixelQualityFlags'][:].ravel()
+            af = sci.variables['AlgorithmFlags'][:].ravel()
+            mqf = sci.variables['MeasurementQualityFlags'][:].ravel()
+            iqf = geo.variables['InstrumentQualityFlags'][:].ravel()
 
             # obs value, we prefer to convert DU to mol.m-2
             obs_du = sci.variables['ColumnAmountO3'][:].ravel()
@@ -164,6 +178,11 @@ class omps_nm(object):
             time = np.ma.array(time, mask=mask)
             qa_value = np.ma.array(qa_value, mask=mask)
             flg = np.ma.array(flg, mask=mask)
+            sza = np.ma.array(sza, mask=mask)
+            gpqf = np.ma.array(gpqf, mask=mask)
+            af = np.ma.array(af, mask=mask)
+            mqf = np.ma.array(mqf, mask=mask)
+            iqf = np.ma.array(iqf, mask=mask)
             press_vert = np.ma.array(press_vert, mask=np.column_stack([mask] * (nlevs + 1)))
             averaging_kernel = np.ma.array(averaging_kernel, mask=np.column_stack([mask] * nlevs))
             apriori_total = np.ma.array(apriori_total, mask=mask)
@@ -175,6 +194,11 @@ class omps_nm(object):
             qa_value = np.ma.compressed(qa_value).astype('int32')
             obs = np.ma.compressed(obs).astype('float32')
             err = np.ma.compressed(err).astype('float32')
+            sza = np.ma.compressed(sza).astype('float32')
+            gpqf = np.ma.compressed(gpqf).astype('int32')
+            af = np.ma.compressed(af).astype('int32')
+            mqf = np.ma.compressed(mqf).astype('int32')
+            iqf = np.ma.compressed(iqf).astype('int32')
             press_vert = np.ma.compressed(press_vert).astype('float32').reshape(-1, nlevs + 1)
             averaging_kernel = np.ma.compressed(averaging_kernel).astype('float32').reshape(-1, nlevs)
             apriori_total = np.ma.compressed(apriori_total).astype('float32')
@@ -184,6 +208,12 @@ class omps_nm(object):
                 self.outdata[('dateTime', 'MetaData')] = time[flg]
                 self.outdata[('latitude', 'MetaData')] = lat[flg]
                 self.outdata[('longitude', 'MetaData')] = lon[flg]
+                self.outdata[('solarZenithAngle', 'MetaData')] = sza[flg]
+                self.outdata[('qualityFlags', 'MetaData')] = qa_value[flg]
+                self.outdata[('groundPixelQualityFlags', 'MetaData')] = gpqf[flg]
+                self.outdata[('algorithmFlags', 'MetaData')] = af[flg]
+                self.outdata[('measurementQualityFlags', 'MetaData')] = mqf[flg]
+                self.outdata[('instrumentQualityFlags', 'MetaData')] = iqf[flg]
                 self.outdata[self.varDict[iodavar]['valKey']] = obs[flg]
                 self.outdata[self.varDict[iodavar]['errKey']] = err[flg]
                 self.outdata[self.varDict[iodavar]['qcKey']] = qa_value[flg]
@@ -197,6 +227,18 @@ class omps_nm(object):
                     self.outdata[('latitude', 'MetaData')], lat[flg]))
                 self.outdata[('longitude', 'MetaData')] = np.concatenate((
                     self.outdata[('longitude', 'MetaData')], lon[flg]))
+                self.outdata[('solarZenithAngle', 'MetaData')] = np.concatenate((
+                    self.outdata[('solarZenithAngle', 'MetaData')], sza[flg]))
+                self.outdata[('qualityFlags', 'MetaData')] = np.concatenate((
+                    self.outdata[('qualityFlags', 'MetaData')], qa_value[flg]))
+                self.outdata[('groundPixelQualityFlags', 'MetaData')] = np.concatenate((
+                    self.outdata[('groundPixelQualityFlags', 'MetaData')], gpqf[flg]))
+                self.outdata[('algorithmFlags', 'MetaData')] = np.concatenate((
+                    self.outdata[('algorithmFlags', 'MetaData')], af[flg]))
+                self.outdata[('measurementQualityFlags', 'MetaData')] = np.concatenate((
+                    self.outdata[('measurementQualityFlags', 'MetaData')], mqf[flg]))
+                self.outdata[('instrumentQualityFlags', 'MetaData')] = np.concatenate((
+                    self.outdata[('instrumentQualityFlags', 'MetaData')], iqf[flg]))
                 self.outdata[self.varDict[iodavar]['valKey']] = np.concatenate(
                     (self.outdata[self.varDict[iodavar]['valKey']], obs[flg]))
                 self.outdata[self.varDict[iodavar]['errKey']] = np.concatenate(
@@ -218,6 +260,37 @@ class omps_nm(object):
         AttrData['Layer'] = np.int32(DimDict['Layer'])
         DimDict['Vertice'] = nlevs + 1
         AttrData['Vertice'] = np.int32(DimDict['Vertice'])
+
+        # Add attributes for metadata variables
+        varname = 'solarZenithAngle'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = 'degrees'
+
+        varname = 'qualityFlags'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
+
+        varname = 'groundPixelQualityFlags'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
+
+        varname = 'algorithmFlags'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
+
+        varname = 'measurementQualityFlags'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
+
+        varname = 'instrumentQualityFlags'
+        vkey = (varname, 'MetaData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
 
         varname = 'pressureVertice'
         vkey = (varname, 'RetrievalAncillaryData')

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -23,23 +23,33 @@ locationKeyList = [
     ("dateTime", "string"),
 ]
 
+obsVar = {'ozone_total_column': 'ozoneTotal'}
+
 AttrData = {
     'converter': os.path.basename(__file__),
-    'nvars': np.int32(1),
+    'nvars': np.int32(len(obsvar)),
 }
 
 DimDict = {
 }
 
+VarDims = {
+    'ozoneTotal': ['Location'],
+    'averagingKernel': ['Location', 'Layer'],
+    'pressureVertices': ['Location', 'Vertice']
+}
+
 # DU to mol.m-2 conversion factor
 DU2molsqm = 4.4615E-4
 
-# ATBD lookup table for observation error (from ATBD section 7.1)
 # In the ATBD: https://www.star.nesdis.noaa.gov/jpss/
 # ATBD/D0001-M01-S01-006_JPSS_ATBD_OMPS-TC-Ozone_C.pdf
-# Total ozone column (DU) and corresponding obs error (DU)        
+# Total ozone column (DU) and corresponding obs error (DU)  
+# # ATBD lookup table for observation error (from ATBD section 7.1)      
 ATBD_OBS_DU = np.array([50, 125, 175, 225, 275, 325, 375, 425, 475, 525, 575, 625])
 ATBD_ERR_DU = np.array([5.43, 5.54, 5.65, 5.89, 6.08, 6.63, 7.54, 7.85, 7.79, 8.05, 8.32, 8.79])
+# OMPS Umkehr pressure interfaces (hPa) deduced from OMPS ATBD table 2.3-2
+PRESSURE_INTERFACES = np.array([1013.0, 507.0, 253.0, 127.0, 63.3, 31.7, 15.80, 7.92, 3.96, 1.98, 0.99, 0.0])
 
 
 class omps_nm(object):
@@ -75,12 +85,18 @@ class omps_nm(object):
             # get dimensions
             da = ncd.dimensions['DimAlongTrack'].size
             dc = ncd.dimensions['DimCrossTrack'].size
+            nlevs = ncd.dimensions['DimPressureLevel'].size
             geo = ncd.groups['GeolocationData']
             sci = ncd.groups['ScienceData']
+            anc = ncd.groups['AncillaryData']
 
             # geolocation
             lat = geo.variables['Latitude'][:].ravel()
             lon = geo.variables['Longitude'][:].ravel()
+            
+            # surface/terrain pressure
+            anc = ncd.groups['AncillaryData']
+            terrain_pressure = anc.variables['TerrainPressure'][:].ravel()
 
             # time
             time_ref = np.datetime64('1993-01-01T00:00')
@@ -108,14 +124,49 @@ class omps_nm(object):
                                f"Choose from: 'fixed', 'atbd'")
             err = err_du * DU2molsqm
 
-            # seems like obs (hence err) has a mask so need to apply to all other
-            # quantities
+            
+            # make pressure interface matrix
+            press_vert = np.tile(PRESSURE_INTERFACES, (da * dc, 1))
+
+            # get averaging kernel and reshape
+            layer_eff_raw = sci.variables['LayerEfficiency'][:]  # shape (da, dc, 11)
+            averaging_kernel = layer_eff_raw.reshape(da * dc, -1)  # shape (nlocs, 11)
+
+            # get apriori profile
+            apriori_layers = anc.variables['O3AprioriProfile'][:]  # shape (da, dc, 11) 
+            apriori_layers = apriori_layers.reshape(da * dc, -1)  # shape (nlocs, 11)
+
+            # calculate the apriori term which is (I-A)*xa
+            # xa is already in DU so this is straightforward, 
+            # and we can convert to mol.m-2 at the end to match conventions
+            apriori_total = np.zeros(len(obs))
+            for lev in range(nlevs):
+                apriori_total += (1.0 - averaging_kernel[:, lev]) * apriori_layers[:, lev]
+            apriori_total *= DU2molsqm
+
+            # we want to make sure we adjust the pressure grid if terrain is less than any
+            # of the standard pressure levels, as this would cause issues
+            press_vert[:, 0] = terrain_pressure
+            for lev in range(nlevs):
+                zlev = press_vert[:, lev] - press_vert[:, lev+1]
+                press_vert[:, lev+1][zlev < 0] = press_vert[:, lev][zlev < 0]
+
+            # flip pressure levels so they go from surface to TOA (IODA convention), 
+            # and convert to Pa
+            press_vert = np.flip(press_vert, axis=1) * 100.0
+            averaging_kernel = np.flip(averaging_kernel, axis=1)
+
+            # get mask consistent with obs and apply to all variables
             mask = np.ma.getmask(obs)
+            err = np.ma.array(err, mask=mask)
             lat = np.ma.array(lat, mask=mask)
             lon = np.ma.array(lon, mask=mask)
             time = np.ma.array(time, mask=mask)
             qa_value = np.ma.array(qa_value, mask=mask)
             flg = np.ma.array(flg, mask=mask)
+            press_vert = np.ma.array(press_vert, mask=np.column_stack([mask] * (nlevs + 1)))
+            averaging_kernel = np.ma.array(averaging_kernel, mask=np.column_stack([mask] * nlevs))
+            apriori_total = np.ma.array(apriori_total, mask=mask)
 
             # remove masked values and types
             lat = np.ma.compressed(lat).astype('float32')
@@ -124,6 +175,8 @@ class omps_nm(object):
             qa_value = np.ma.compressed(qa_value).astype('int32')
             obs = np.ma.compressed(obs).astype('float32')
             err = np.ma.compressed(err).astype('float32')
+            press_vert = np.ma.compressed(press_vert).astype('float32').reshape(-1, nlevs + 1)
+            averaging_kernel = np.ma.compressed(averaging_kernel).astype('float32').reshape(-1, nlevs)
             flg = np.ma.compressed(flg)
 
             if first:
@@ -133,6 +186,9 @@ class omps_nm(object):
                 self.outdata[self.varDict[iodavar]['valKey']] = obs[flg]
                 self.outdata[self.varDict[iodavar]['errKey']] = err[flg]
                 self.outdata[self.varDict[iodavar]['qcKey']] = qa_value[flg]
+                self.outdata[('aprioriTerm', 'RetrievalAncillaryData')] = apriori_total[flg]
+                self.outdata[('averagingKernel', 'RetrievalAncillaryData')] = averaging_kernel[flg]
+                self.outdata[('pressureVertice', 'RetrievalAncillaryData')] = press_vert[flg]
             else:
                 self.outdata[('dateTime', 'MetaData')] = np.concatenate((
                     self.outdata[('dateTime', 'MetaData')], time[flg]))
@@ -146,11 +202,36 @@ class omps_nm(object):
                     (self.outdata[self.varDict[iodavar]['errKey']], err[flg]))
                 self.outdata[self.varDict[iodavar]['qcKey']] = np.concatenate(
                     (self.outdata[self.varDict[iodavar]['qcKey']], qa_value[flg]))
+                self.outdata[('aprioriTerm', 'RetrievalAncillaryData')] = np.concatenate((
+                    self.outdata[('aprioriTerm', 'RetrievalAncillaryData')], apriori_total[flg]))
+                self.outdata[('pressureVertice', 'RetrievalAncillaryData')] = np.concatenate((
+                    self.outdata[('pressureVertice', 'RetrievalAncillaryData')], press_vert[flg]))
+                self.outdata[('averagingKernel', 'RetrievalAncillaryData')] = np.concatenate((
+                    self.outdata[('averagingKernel', 'RetrievalAncillaryData')], averaging_kernel[flg]))
 
             first = False
 
         DimDict['Location'] = len(self.outdata[('dateTime', 'MetaData')])
         AttrData['Location'] = np.int32(DimDict['Location'])
+        DimDict['Layer'] = nlevs
+        AttrData['Layer'] = np.int32(DimDict['Layer'])
+        DimDict['Vertice'] = nlevs + 1
+        AttrData['Vertice'] = np.int32(DimDict['Vertice'])
+
+        varname = 'pressureVertice'
+        vkey = (varname, 'RetrievalAncillaryData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = 'Pa'
+
+        varname = 'averagingKernel'
+        vkey = (varname, 'RetrievalAncillaryData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = ''
+
+        varname = 'aprioriTerm'
+        vkey = (varname, 'RetrievalAncillaryData')
+        self.varAttrs[vkey]['coordinates'] = 'longitude latitude'
+        self.varAttrs[vkey]['units'] = 'mol m-2'
 
 
 def main():
@@ -189,9 +270,6 @@ def main():
         type=str, default='fixed', choices=['fixed', 'atbd'])
 
     args = parser.parse_args()
-
-    obsVar = {'ozone_total_column': 'ozoneTotal'}
-    varDims = {'ozoneTotal': ['Location']}
 
     # Read in the O3 data
     var = omps_nm(args.input, args.qa_value, obsVar, args.error_method)

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -51,8 +51,8 @@ DU2molsqm = 4.4615E-4
 
 # In the ATBD: https://www.star.nesdis.noaa.gov/jpss/
 # ATBD/D0001-M01-S01-006_JPSS_ATBD_OMPS-TC-Ozone_C.pdf
-# Total ozone column (DU) and corresponding obs error (DU)  
-# # ATBD lookup table for observation error (from ATBD section 7.1)      
+# Total ozone column (DU) and corresponding obs error (DU)
+# # ATBD lookup table for observation error (from ATBD section 7.1)
 ATBD_OBS_DU = np.array([50, 125, 175, 225, 275, 325, 375, 425, 475, 525, 575, 625])
 ATBD_ERR_DU = np.array([5.43, 5.54, 5.65, 5.89, 6.08, 6.63, 7.54, 7.85, 7.79, 8.05, 8.32, 8.79])
 # OMPS Umkehr pressure interfaces (hPa) deduced from OMPS ATBD table 2.3-2
@@ -100,7 +100,7 @@ class omps_nm(object):
             # geolocation
             lat = geo.variables['Latitude'][:].ravel()
             lon = geo.variables['Longitude'][:].ravel()
-            
+
             # surface/terrain pressure
             anc = ncd.groups['AncillaryData']
             terrain_pressure = anc.variables['TerrainPressure'][:].ravel()
@@ -115,7 +115,7 @@ class omps_nm(object):
             # other quantities could be used for future filtering in UFO
             qa_value = sci.variables['QualityFlags'][:].ravel()
             flg = qa_value <= self.qa_flg
-            
+
             # read all quality and geometry metadata variables
             sza = geo.variables['SolarZenithAngle'][:].ravel()
             gpqf = geo.variables['GroundPixelQualityFlags'][:].ravel()
@@ -137,8 +137,9 @@ class omps_nm(object):
             elif self.error_method == 'atbd':
                 err_du = np.interp(obs_du, ATBD_OBS_DU, ATBD_ERR_DU)
             else:
-                raise ValueError(f"Unknown error_method: {self.error_method}. "
-                               f"Choose from: 'fixed', 'atbd'")
+                raise ValueError(
+                    f"Unknown error_method: {self.error_method}. "
+                    f"Choose from: 'fixed', 'atbd'")
             err = err_du * DU2molsqm
 
             # make pressure interface matrix
@@ -149,11 +150,11 @@ class omps_nm(object):
             averaging_kernel = layer_eff_raw.reshape(da * dc, -1)  # shape (nlocs, 11)
 
             # get apriori profile
-            apriori_layers = anc.variables['APrioriLayerO3'][:]  # shape (da, dc, 11) 
+            apriori_layers = anc.variables['APrioriLayerO3'][:]  # shape (da, dc, 11)
             apriori_layers = apriori_layers.reshape(da * dc, -1)  # shape (nlocs, 11)
 
             # calculate the apriori term which is (I-A)*xa
-            # xa is already in DU so this is straightforward, 
+            # xa is already in DU so this is straightforward,
             # and we can convert to mol.m-2 at the end to match conventions
             apriori_total = np.zeros(len(obs))
             for lev in range(nlevs):
@@ -167,14 +168,14 @@ class omps_nm(object):
                 zlev = press_vert[:, lev] - press_vert[:, lev+1]
                 press_vert[:, lev+1][zlev < 0] = press_vert[:, lev][zlev < 0]
 
-            # flip pressure levels so they go from surface to TOA (IODA convention), 
+            # flip pressure levels so they go from surface to TOA (IODA convention),
             # and convert to Pa
             press_vert = np.flip(press_vert, axis=1) * 100.0
             averaging_kernel = np.flip(averaging_kernel, axis=1)
 
             # get mask consistent with obs and apply to all variables
             mask = np.ma.getmask(obs)
-            
+
             # Unmask all variables cleanly - extract data from any masked arrays from netCDF
             lat = np.ma.getdata(lat)
             lon = np.ma.getdata(lon)
@@ -193,7 +194,7 @@ class omps_nm(object):
             apriori_layers = np.ma.getdata(apriori_layers)
             press_vert = np.ma.getdata(press_vert)
             apriori_total = np.ma.getdata(apriori_total)
-            
+
             # Now remask everything with consistent mask from obs
             obs = np.ma.array(obs, mask=mask)
             err = np.ma.array(err, mask=mask)

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -36,7 +36,7 @@ DimDict = {
 VarDims = {
     'ozoneTotal': ['Location'],
     'averagingKernel': ['Location', 'Layer'],
-    'pressureVertices': ['Location', 'Vertice'],
+    'pressureVertice': ['Location', 'Vertice'],
     'aprioriTerm': ['Location'],
     'solarZenithAngle': ['Location'],
     'qualityFlags': ['Location'],

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -195,6 +195,7 @@ class omps_nm(object):
             apriori_total = np.ma.getdata(apriori_total)
             
             # Now remask everything with consistent mask from obs
+            obs = np.ma.array(obs, mask=mask)
             err = np.ma.array(err, mask=mask)
             lat = np.ma.array(lat, mask=mask)
             lon = np.ma.array(lon, mask=mask)

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -23,11 +23,11 @@ locationKeyList = [
     ("dateTime", "string"),
 ]
 
-obsVar = {'ozone_total_column': 'ozoneTotal'}
+ObsVar = {'ozone_total_column': 'ozoneTotal'}
 
 AttrData = {
     'converter': os.path.basename(__file__),
-    'nvars': np.int32(len(obsvar)),
+    'nvars': np.int32(len(ObsVar)),
 }
 
 DimDict = {
@@ -53,10 +53,10 @@ PRESSURE_INTERFACES = np.array([1013.0, 507.0, 253.0, 127.0, 63.3, 31.7, 15.80, 
 
 
 class omps_nm(object):
-    def __init__(self, filenames, qa_flg, obsVar, error_method='fixed'):
+    def __init__(self, filenames, qa_flg, ObsVar, error_method='fixed'):
         self.filenames = filenames
         self.qa_flg = qa_flg
-        self.obsVar = obsVar
+        self.obsVar = ObsVar
         self.error_method = error_method
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
@@ -116,7 +116,7 @@ class omps_nm(object):
             # for obs error, it is not provided in the product.
             # Use selected error calculation method
             if self.error_method == 'fixed':
-                err_du = 6.0
+                err_du = np.full_like(obs_du, 6.0)
             elif self.error_method == 'atbd':
                 err_du = np.interp(obs_du, ATBD_OBS_DU, ATBD_ERR_DU)
             else:
@@ -133,7 +133,7 @@ class omps_nm(object):
             averaging_kernel = layer_eff_raw.reshape(da * dc, -1)  # shape (nlocs, 11)
 
             # get apriori profile
-            apriori_layers = anc.variables['O3AprioriProfile'][:]  # shape (da, dc, 11) 
+            apriori_layers = anc.variables['APrioriLayerO3'][:]  # shape (da, dc, 11) 
             apriori_layers = apriori_layers.reshape(da * dc, -1)  # shape (nlocs, 11)
 
             # calculate the apriori term which is (I-A)*xa
@@ -177,6 +177,7 @@ class omps_nm(object):
             err = np.ma.compressed(err).astype('float32')
             press_vert = np.ma.compressed(press_vert).astype('float32').reshape(-1, nlevs + 1)
             averaging_kernel = np.ma.compressed(averaging_kernel).astype('float32').reshape(-1, nlevs)
+            apriori_total = np.ma.compressed(apriori_total).astype('float32')
             flg = np.ma.compressed(flg)
 
             if first:
@@ -272,13 +273,13 @@ def main():
     args = parser.parse_args()
 
     # Read in the O3 data
-    var = omps_nm(args.input, args.qa_value, obsVar, args.error_method)
+    var = omps_nm(args.input, args.qa_value, ObsVar, args.error_method)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)
 
     # write everything out
-    writer.BuildIoda(var.outdata, varDims, var.varAttrs, AttrData)
+    writer.BuildIoda(var.outdata, VarDims, var.varAttrs, AttrData)
 
 
 if __name__ == '__main__':

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -34,12 +34,20 @@ DimDict = {
 # DU to mol.m-2 conversion factor
 DU2molsqm = 4.4615E-4
 
+# ATBD lookup table for observation error (from ATBD section 7.1)
+# In the ATBD: https://www.star.nesdis.noaa.gov/jpss/
+# ATBD/D0001-M01-S01-006_JPSS_ATBD_OMPS-TC-Ozone_C.pdf
+# Total ozone column (DU) and corresponding obs error (DU)        
+ATBD_OBS_DU = np.array([50, 125, 175, 225, 275, 325, 375, 425, 475, 525, 575, 625])
+ATBD_ERR_DU = np.array([5.43, 5.54, 5.65, 5.89, 6.08, 6.63, 7.54, 7.85, 7.79, 8.05, 8.32, 8.79])
+
 
 class omps_nm(object):
-    def __init__(self, filenames, qa_flg, obsVar):
+    def __init__(self, filenames, qa_flg, obsVar, error_method='fixed'):
         self.filenames = filenames
         self.qa_flg = qa_flg
         self.obsVar = obsVar
+        self.error_method = error_method
         self.varDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         self.varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -86,14 +94,19 @@ class omps_nm(object):
             flg = qa_value <= self.qa_flg
 
             # obs value, we prefer to convert DU to mol.m-2
-            obs = sci.variables['ColumnAmountO3'][:].ravel() * DU2molsqm
+            obs_du = sci.variables['ColumnAmountO3'][:].ravel()
+            obs = obs_du * DU2molsqm
 
-            # for obs error, it is not provided in the
-            # product. In the ATBD: https://www.star.nesdis.noaa.gov/jpss/documents/
-            # ATBD/D0001-M01-S01-006_JPSS_ATBD_OMPS-TC-Ozone_C.pdf
-            # using section 7.1 and figure and tables 7.1-1 and 7.1-2 we can derive
-            # a linear relationship between obs value and obs error
-            err = (5.84347E-3 * obs + 18.58484) * DU2molsqm
+            # for obs error, it is not provided in the product.
+            # Use selected error calculation method
+            if self.error_method == 'fixed':
+                err_du = 6.0
+            elif self.error_method == 'atbd':
+                err_du = np.interp(obs_du, ATBD_OBS_DU, ATBD_ERR_DU)
+            else:
+                raise ValueError(f"Unknown error_method: {self.error_method}. "
+                               f"Choose from: 'fixed', 'atbd'")
+            err = err_du * DU2molsqm
 
             # seems like obs (hence err) has a mask so need to apply to all other
             # quantities
@@ -168,14 +181,20 @@ def main():
         " https://snpp-omps.gesdisc.eosdis.nasa.gov/data/SNPP_OMPS_Level2/"
         "OMPS_NPP_NMTO3_L2.2/doc/README.OMPS_NPP_NMTO3_L2.2.pdf",
         type=float, default=128)
+    optional.add_argument(
+        '-e', '--error_method',
+        help="Observation error calculation method. "
+        "'fixed': use GSI fixed value of 6.0 DU; "
+        "'atbd': linear interpolation from ATBD lookup table (default); ",
+        type=str, default='fixed', choices=['fixed', 'atbd'])
 
     args = parser.parse_args()
 
     obsVar = {'ozone_total_column': 'ozoneTotal'}
     varDims = {'ozoneTotal': ['Location']}
 
-    # Read in the NO2 data
-    var = omps_nm(args.input, args.qa_value, obsVar)
+    # Read in the O3 data
+    var = omps_nm(args.input, args.qa_value, obsVar, args.error_method)
 
     # setup the IODA writer
     writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)

--- a/src/compo/omps_o3_nm_h52ioda.py
+++ b/src/compo/omps_o3_nm_h52ioda.py
@@ -141,7 +141,6 @@ class omps_nm(object):
                                f"Choose from: 'fixed', 'atbd'")
             err = err_du * DU2molsqm
 
-            
             # make pressure interface matrix
             press_vert = np.tile(PRESSURE_INTERFACES, (da * dc, 1))
 
@@ -175,6 +174,27 @@ class omps_nm(object):
 
             # get mask consistent with obs and apply to all variables
             mask = np.ma.getmask(obs)
+            
+            # Unmask all variables cleanly - extract data from any masked arrays from netCDF
+            lat = np.ma.getdata(lat)
+            lon = np.ma.getdata(lon)
+            terrain_pressure = np.ma.getdata(terrain_pressure)
+            time = np.ma.getdata(time)
+            qa_value = np.ma.getdata(qa_value)
+            flg = np.ma.getdata(flg)
+            obs = np.ma.getdata(obs)
+            err = np.ma.getdata(err)
+            sza = np.ma.getdata(sza)
+            gpqf = np.ma.getdata(gpqf)
+            af = np.ma.getdata(af)
+            mqf = np.ma.getdata(mqf)
+            iqf = np.ma.getdata(iqf)
+            averaging_kernel = np.ma.getdata(averaging_kernel)
+            apriori_layers = np.ma.getdata(apriori_layers)
+            press_vert = np.ma.getdata(press_vert)
+            apriori_total = np.ma.getdata(apriori_total)
+            
+            # Now remask everything with consistent mask from obs
             err = np.ma.array(err, mask=mask)
             lat = np.ma.array(lat, mask=mask)
             lon = np.ma.array(lon, mask=mask)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1574,7 +1574,8 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omps_o3_nm
                           -i testinput/OMPS-NPP_NMTO3-L2_v2.1_2020m0903t162415_small.h5
                              testinput/OMPS-NPP_NMTO3-L2_v2.1_2020m0903t180544_small.h5
                           -o testrun/omps_o3_nm.nc
-                          -q 128"
+                          -q 128
+                          -e atbd"
                           omps_o3_nm.nc ${IODA_CONV_COMP_TOL})
 
 ecbuild_add_test( TARGET  test_${PROJECT_NAME}_viirs_j1_l1b_albedo

--- a/test/testoutput/omps_o3_nm.nc
+++ b/test/testoutput/omps_o3_nm.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80868b0acb823f00e113dea89df630c6a20ee914326c3fa8d0b45c2ea62d259a
-size 34037
+oid sha256:05bcab49e1ff7d596b84542991df685a52b4b4cdcdf5f818effa667b9d9a3024
+size 98766

--- a/test/testoutput/omps_o3_nm.nc
+++ b/test/testoutput/omps_o3_nm.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05bcab49e1ff7d596b84542991df685a52b4b4cdcdf5f818effa667b9d9a3024
-size 98766
+oid sha256:2a68d5e6cb4937df2cece3d4e270a7b52eb44b1dcb3a26d9ba335fbf98ebc96b
+size 98768


### PR DESCRIPTION
## Description

This PR adds/updates the OMPS O3 converter to support the ColumnRetrieval operator with averging kernel and apriori. The converter processes OMPS Nadir Mapper (NM) Level 2 ozone data and converts it to IODA format for use with JEDI's `ColumnRetrieval` operator.

**Key Changes**
Updated OMPS O3 converter to handle ColumnRetrieval operator requirements
Minimal filtering applied in the converter to preserve data quality information
Comprehensive flag preservation for downstream use in UFO observation filters

Only essential quality checks are performed during conversion
All available quality flags and metadata are preserved and saved to IODA output
