### PR TITLE
Add flag to skip the test in intel compiler CI run

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1568,6 +1568,7 @@ ecbuild_add_test( TARGET  test_${PROJECT_NAME}_omps_o3_nm
                   TYPE    SCRIPT
                   ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
                   COMMAND bash
+                  LABELS  ci_oneapi_disable
                   ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
                           netcdf
                           "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/omps_o3_nm_h52ioda.py


### PR DESCRIPTION
## Description

test_iodaconv_omps_o3_nm is failing with `oneapi` compiler due to mismatch in the values. The difference is small, so probably need to fix the tolerance values. For now since it is affecting CI in other repos, adding a flag to skip the test when run with Intel compiler.

jedi-ci-test-select=intel

Failure log:
```
/etc/spack_container_rc.sh: line 2: ulimit: stack size: cannot modify limit: Operation not permitted
Processing variable: ozone_total_column
DIFFER : VARIABLE : aprioriTerm : POSITION : [101] : VALUES : -6.38496e-05 <> -6.385e-05 : PERCENT : 0.000660932
DIFFER : VARIABLE : aprioriTerm : POSITION : [136] : VALUES : 4.62148e-05 <> 4.62145e-05 : PERCENT : 0.000598263
DIFFER : VARIABLE : aprioriTerm : POSITION : [356] : VALUES : 4.90651e-05 <> 4.90656e-05 : PERCENT : 0.000919401
DIFFER : VARIABLE : aprioriTerm : POSITION : [430] : VALUES : 4.55812e-05 <> 4.55816e-05 : PERCENT : 0.000846012
DIFFER : VARIABLE : aprioriTerm : POSITION : [498] : VALUES : 8.03964e-06 <> 8.03988e-06 : PERCENT : 0.00298645
DIFFER : VARIABLE : aprioriTerm : POSITION : [607] : VALUES : 4.56021e-06 <> 4.56059e-06 : PERCENT : 0.00845561
DIFFER : VARIABLE : aprioriTerm : POSITION : [619] : VALUES : -4.85034e-05 <> -4.85037e-05 : PERCENT : 0.00074254
DIFFER : VARIABLE : aprioriTerm : POSITION : [940] : VALUES : -2.51524e-06 <> -2.51521e-06 : PERCENT : 0.00105766
DIFFER : VARIABLE : aprioriTerm : POSITION : [1042] : VALUES : 1.91485e-05 <> 1.9148e-05 : PERCENT : 0.00235585
Variable    Group                   Count        Sum      AbsSum          Min         Max       Range      Mean      StdDev
aprioriTerm /RetrievalAncillaryData     9 2.0691e-11 2.99883e-09 -4.51109e-10 4.51109e-10 9.02219e-10 2.299e-12 3.78645e-10
```

## Issue(s) addressed

Resolves #1772 

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
