### PR TITLE
Add prescribed ob error option to COSMIC2 to ioda converter

### DIFF
--- a/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
+++ b/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
@@ -210,7 +210,7 @@ def get_obs_data(ifile, get_obs_data_args):
     obs_data = get_geolocation(obs_data)
     # the observation value
     obs_data[("totalElectronContent", "ObsValue")] = np.array(ds['TEC'][:], dtype=ioda_float_type)
-    obs_data[("totalElectronContent", "ObsError")] = np.zeros(np.shape(ds['TEC'][:]), dtype=ioda_float_type) + args.obserror
+    obs_data[("totalElectronContent", "ObsError")] = np.full(np.shape(ds['TEC'][:]), args.obserror, dtype=ioda_float_type)
 
     return obs_data
 

--- a/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
+++ b/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
@@ -210,6 +210,7 @@ def get_obs_data(ifile, get_obs_data_args):
     obs_data = get_geolocation(obs_data)
     # the observation value
     obs_data[("totalElectronContent", "ObsValue")] = np.array(ds['TEC'][:], dtype=ioda_float_type)
+    obs_data[("totalElectronContent", "ObsError")] = np.zeros(np.shape(ds['TEC'][:]), dtype=ioda_float_type) + args.obserror
 
     return obs_data
 
@@ -360,6 +361,10 @@ if __name__ == "__main__":
         '-r', '--recordnumber',
         help=' optional record number to associate with profile ',
         type=int, default=1)
+    optional.add_argument(
+        '-e', '--obserror',
+        help=' optional prescribe a fixed obs error for all observations ',
+        type=float, default=3.0)
 
 #   optional.add_argument(
 #       '-q', '--qualitycontrol',


### PR DESCRIPTION
run-ci-on-draft=true

## Description

For the COSMIC2 to ioda converter, the output observation files were missing observation error, so this fix adds the option to prescribe an observation error.  The input observation files do not have observation errors so the variable "ObsError" is missing from the final converted netcdf file, which is required for assimilation.  

Added an optional argument --obserror or -e which expects a float with a single observation error that is applied to all observations in the file.  Default value is set to 3.0 TECU.   

## Issue(s) addressed

Resolves #1773

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

