### PR TITLE
Update MODIS AOD converter to use correct variable for PreQC values

### DIFF
--- a/src/compo/modis_aod2ioda.py
+++ b/src/compo/modis_aod2ioda.py
@@ -63,6 +63,11 @@ missing_vals = {'string': string_missing_value,
                 'float': float_missing_value,
                 'double': double_missing_value}
 
+# QC mapping array for MODIS collection (Dark Target and Deep Blue)
+# Land_Ocean_Quality_Flag: 0 = no retrieval, 1 = marginal, 2 = good, 3 = very good/best
+qcmapping = {0: 3, 1: 2, 2: 1, 3: 0}
+nasa_flip_qc = np.array([qcmapping[k] for k in sorted(qcmapping)])
+
 
 class AOD(object):
     def __init__(self, filenames, date_range, pltfrm):
@@ -146,11 +151,17 @@ class AOD(object):
             aod = hdf.select('AOD_550_Dark_Target_Deep_Blue_Combined')[:].ravel()
             aod = aod.astype('float64')
             land_sea_flag = hdf.select('Land_sea_Flag')[:].ravel()
-            QC_flag = hdf.select('Land_Ocean_Quality_Flag')[:].ravel()
-            QC_flag = QC_flag.astype('int32')
             sol_zen = hdf.select('Solar_Zenith')[:].ravel()
             sen_zen = hdf.select('Sensor_Zenith')[:].ravel()
             unc_land = hdf.select('Deep_Blue_Aerosol_Optical_Depth_550_Land_Estimated_Uncertainty')[:].ravel()
+
+            # Special treatment for qc flags
+            QC_flag = hdf.select('Land_Ocean_Quality_Flag')[:].ravel()
+            QC_flag = QC_flag.astype('int32')
+            valid_QC = (QC_flag >= 0) & (QC_flag <= 3)
+            # Flip QC flags for PreQC (0->3, 3->0)
+            QC_flag[valid_QC] = nasa_flip_qc[QC_flag[valid_QC]]
+            QC_flag = np.where((QC_flag < 0), missing_vals['integer'], QC_flag)
 
             # Remove undefined values
             pos_index = np.where(aod > 0)

--- a/src/compo/modis_aod2ioda.py
+++ b/src/compo/modis_aod2ioda.py
@@ -142,7 +142,6 @@ class AOD(object):
                 print(f"An error occurred: {e}")
             #  Get variables
             modis_time = hdf.select(modis_time_key)[:].ravel()
-            print(f"length of time var: {len(modis_time)}")
             modis_time = modis_time.astype('float32')
             lats = hdf.select('Latitude')[:].ravel()
             lats = lats.astype('float32')
@@ -156,12 +155,13 @@ class AOD(object):
             unc_land = hdf.select('Deep_Blue_Aerosol_Optical_Depth_550_Land_Estimated_Uncertainty')[:].ravel()
 
             # Special treatment for qc flags
-            QC_flag = hdf.select('Land_Ocean_Quality_Flag')[:].ravel()
+            QC_flag = hdf.select('AOD_550_Dark_Target_Deep_Blue_Combined_QA_Flag')[:].ravel()
+            #QC_flag = hdf.select('Land_Ocean_Quality_Flag')[:].ravel()
             QC_flag = QC_flag.astype('int32')
             valid_QC = (QC_flag >= 0) & (QC_flag <= 3)
             # Flip QC flags for PreQC (0->3, 3->0)
             QC_flag[valid_QC] = nasa_flip_qc[QC_flag[valid_QC]]
-            QC_flag = np.where((QC_flag < 0), missing_vals['integer'], QC_flag)
+            QC_flag = np.where(~valid_QC, missing_vals['integer'], QC_flag)
 
             # Remove undefined values
             pos_index = np.where(aod > 0)

--- a/src/compo/modis_aod2ioda.py
+++ b/src/compo/modis_aod2ioda.py
@@ -64,7 +64,9 @@ missing_vals = {'string': string_missing_value,
                 'double': double_missing_value}
 
 # QC mapping array for MODIS collection (Dark Target and Deep Blue)
-# Land_Ocean_Quality_Flag: 0 = no retrieval, 1 = marginal, 2 = good, 3 = very good/best
+# https://darktarget.gsfc.nasa.gov/products/viirs-modis/level-2-product-contents
+# AOD_550_Dark_Target_Deep_Blue_Combined_QA_Flag:
+#   0 = no retrieval, 1 = marginal, 2 = good, 3 = very good/best
 qcmapping = {0: 3, 1: 2, 2: 1, 3: 0}
 nasa_flip_qc = np.array([qcmapping[k] for k in sorted(qcmapping)])
 
@@ -140,6 +142,7 @@ class AOD(object):
             except Exception as e:
                 # Catch and print any errors
                 print(f"An error occurred: {e}")
+
             #  Get variables
             modis_time = hdf.select(modis_time_key)[:].ravel()
             modis_time = modis_time.astype('float32')
@@ -156,7 +159,6 @@ class AOD(object):
 
             # Special treatment for qc flags
             QC_flag = hdf.select('AOD_550_Dark_Target_Deep_Blue_Combined_QA_Flag')[:].ravel()
-            #QC_flag = hdf.select('Land_Ocean_Quality_Flag')[:].ravel()
             QC_flag = QC_flag.astype('int32')
             valid_QC = (QC_flag >= 0) & (QC_flag <= 3)
             # Flip QC flags for PreQC (0->3, 3->0)
@@ -181,7 +183,6 @@ class AOD(object):
             # From MODIS file (over ocean) and Levy, 2010 (over land)
             # https://acp.copernicus.org/articles/10/10399/2010/acp-10-10399-2010.pdf
             # flag = 0 (ocean) 1(land) 2(coastal)
-
             over_ocean = np.logical_not(land_sea_flag > 0)
             over_land = np.logical_not(land_sea_flag == 0)
             UNC = np.where(over_land, unc_land, np.add(0.05, np.multiply(0.15, aod)))

--- a/test/testoutput/modis_aod.nc
+++ b/test/testoutput/modis_aod.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3ee009156d1ee2335df595ab5192f2706f481451e4d93af2be18a2f52a3a574
+oid sha256:27316e22aa8e3a5c1fe81bec1910ee3c13db6c78e615826ef14bcb2d8e0e2f23
 size 15065


### PR DESCRIPTION
## Description
This PR updates the MODIS AOD converter to use `AOD_550_Dark_Target_Deep_Blue_Combined_QA_Flag` and flipped for the PreQC values of the AOD retrieval from `AOD_550_Dark_Target_Deep_Blue_Combined`.


## Issue(s) addressed

Resolves #1776 


## Dependencies
N/A

## Impact
N/A

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
