### PR TITLE
Add a ctest for the gnss spacebased TEC converter

### DIFF
--- a/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
+++ b/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
@@ -210,7 +210,7 @@ def get_obs_data(ifile, get_obs_data_args):
     obs_data = get_geolocation(obs_data)
     # the observation value
     obs_data[("totalElectronContent", "ObsValue")] = np.array(ds['TEC'][:], dtype=ioda_float_type)
-    obs_data[("totalElectronContent", "ObsError")] = np.zeros(np.shape(ds['TEC'][:]), dtype=ioda_float_type) + args.obserror
+    obs_data[("totalElectronContent", "ObsError")] = np.full(np.shape(ds['TEC'][:]), args.obserror, dtype=ioda_float_type)
 
     return obs_data
 

--- a/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
+++ b/src/space_weather/gnss_tec_spacebased_cdaac2ioda.py
@@ -210,6 +210,7 @@ def get_obs_data(ifile, get_obs_data_args):
     obs_data = get_geolocation(obs_data)
     # the observation value
     obs_data[("totalElectronContent", "ObsValue")] = np.array(ds['TEC'][:], dtype=ioda_float_type)
+    obs_data[("totalElectronContent", "ObsError")] = np.zeros(np.shape(ds['TEC'][:]), dtype=ioda_float_type) + args.obserror
 
     return obs_data
 
@@ -360,6 +361,10 @@ if __name__ == "__main__":
         '-r', '--recordnumber',
         help=' optional record number to associate with profile ',
         type=int, default=1)
+    optional.add_argument(
+        '-e', '--obserror',
+        help=' optional prescribe a fixed obs error for all observations ',
+        type=float, default=3.0)
 
 #   optional.add_argument(
 #       '-q', '--qualitycontrol',

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,6 +111,7 @@ list( APPEND test_input
   testinput/pandora_site_classification.csv
   testinput/balloonsonde_sample_20241001T00Z_PT15M.json
   testinput/tec_groundBased_TENET_20201001T00Z.tec
+  testinput/gnssro_tec_cosmic2_202010012304.nc
   testinput/COWVR_TSDR.020421.20240430T215845.20240430T230345.V1001.sample.h5
   testinput/gfs.231010.t00z.syndata.tcvitals.txt
 )
@@ -215,6 +216,7 @@ list( APPEND test_output
   testoutput/saber_timed.20160101T180000Z.nc4
   testoutput/obs.20241001T000000Z_PT15M_balloonsonde.nc4
   testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
+  testoutput/gnssro_tec_cosmic2_202010012304_output.nc4
   testoutput/obs.20240430T220600Z_PT2M_cowvr_iss.nc4
   testoutput/tcp_obs_2023101000.nc4
 )
@@ -2322,6 +2324,17 @@ endif()
                             -i testinput/tec_groundBased_TENET_20201001T00Z.tec
                             -o testrun/obs.20201001T000000Z_PT1M_tec_groundbased.nc4"
                             obs.20201001T000000Z_PT1M_tec_groundbased.nc4 ${IODA_CONV_COMP_TOL})
+
+  ecbuild_add_test( TARGET  test_${PROJECT_NAME}_tec_spacebased_cdaac
+                    TYPE    SCRIPT
+                    ENVIRONMENT "PYTHONPATH=${IODACONV_PYTHONPATH}"
+                    COMMAND bash
+                    ARGS    ${CMAKE_BINARY_DIR}/bin/iodaconv_comp.sh
+                            netcdf
+                            "${Python3_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/gnss_tec_spacebased_cdaac2ioda.py
+                            -i testinput/gnssro_tec_cosmic2_202010012304.nc
+                            -o testrun/gnssro_tec_cosmic2_202010012304_output.nc4"
+                            gnssro_tec_cosmic2_202010012304_output.nc4 ${IODA_CONV_COMP_TOL})
 
   ecbuild_add_test( TARGET  test_${PROJECT_NAME}_cowvr_iss
                     TYPE    SCRIPT

--- a/test/testinput/gnssro_tec_cosmic2_202010012304.nc
+++ b/test/testinput/gnssro_tec_cosmic2_202010012304.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80349f21fe0ac145e51deca66c64353bf8b39980da7a889aa9536d7bdcb60df
+size 5528

--- a/test/testoutput/gnssro_tec_cosmic2_202010012304_output.nc4
+++ b/test/testoutput/gnssro_tec_cosmic2_202010012304_output.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b072fa75933ada31bb4ff3e5a973a5200376bfff160843d5877e0b4313c0ba75
+size 24031


### PR DESCRIPTION
## Description

This issue proposes adding a ctest for the GNSS Radio Occultation (GNSS-RO) Total Electron Content (TEC) IODA converter.

The converter was recently developed to support TEC measurements from CDAAC, filling a gap where no existing ctest coverage was available. To improve testing robustness and CI integration, a dedicated ctest should be included.

## Issue(s) addressed

Resolves #1778 

## Dependencies

#1774 

The test reference was created based this PR.

## Impact

No impacts on other repos. 


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
