### PR TITLE
Bugfix for missing values in TENET TEC files

### DIFF
--- a/src/space_weather/gnss_tec_ground_based.py
+++ b/src/space_weather/gnss_tec_ground_based.py
@@ -467,6 +467,9 @@ def fill_data_with_missing(local_data):
     local_data['xECEFPositionGNSS'] = np.append(local_data['xECEFPositionGNSS'], float_missing_value)
     local_data['yECEFPositionGNSS'] = np.append(local_data['yECEFPositionGNSS'], float_missing_value)
     local_data['zECEFPositionGNSS'] = np.append(local_data['zECEFPositionGNSS'], float_missing_value)
+    if len(local_data['latitude']) < len(local_data['latitudeIPP']):
+        for key in ['latitude', 'longitude', 'stationIdentifier', 'stationIdentifierWMO', 'xECEFPosition', 'yECEFPosition', 'zECEFPosition']:
+            local_data[key] = np.append(local_data[key], local_data[key][-1])
     return local_data
 
 

--- a/test/testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
+++ b/test/testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68587a47c45107596de5a09927514eab6e09d9eda17c5343389b956e5bcefcdf
+oid sha256:3ff22bc1c2b540dea31122475bb6f468a2646ea03470080ac9c5dcf3a5f4aa0d
 size 52559

--- a/test/testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
+++ b/test/testoutput/obs.20201001T000000Z_PT1M_tec_groundbased.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c531b7618c3c94a9d2d3a14c70f760e4e45d176d8687f0596a95ec1dc5e67053
-size 52770
+oid sha256:68587a47c45107596de5a09927514eab6e09d9eda17c5343389b956e5bcefcdf
+size 52559


### PR DESCRIPTION
## Description

Metadata values were not being added when TENET obs values were missing. This caused a mismatch in array sizes when missing values were present in the file, resulting in a segmentation fault
## Issue(s) addressed

Resolves #1781 

## Dependencies

none
## Impact

none
## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
