### PR TITLE
Update JEDI CI action with build cache

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run JEDI CI
-        uses: JCSDA-internal/jedi-ci@develop
+        uses: JCSDA-internal/jedi-ci@v2
         with:
           container_version: latest
           unittest_tag: iodaconv

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -43,8 +43,6 @@ jobs:
           container_version: latest
           unittest_tag: iodaconv
           target_project_name: iodaconv
-          test_dependencies: oops ioda ioda-data
           test_script: run_tests.sh
-          target_repo_dir: target_repository
           bundle_branch: develop
           jedi_ci_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Update to jedi-ci v2 with caching

run-ci-on-draft = true

Issue: https://github.com/JCSDA-internal/jedi-ci/issues/77
