### PR TITLE
Add min error of 0.1 for airnow

### DIFF
--- a/src/compo/airnow2ioda_nc.py
+++ b/src/compo/airnow2ioda_nc.py
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     for key in varDict.keys():
         variable = varDict[key][0]
         obsval = data[variable]
-        errval = np.where(obsval < 1e+36, np.maximum(0.1,obsval * 0.1), obsval)  # rough, needs refinement per species TBC
+        errval = np.where(obsval < 1e+36, np.maximum(0.1, obsval * 0.1), obsval)  # rough, needs refinement per species TBC
         qcval = np.where((obsval > 1e+36) | np.isinf(obsval) | np.isnan(obsval), 0, 1)
         ioda_data[(variable, obsValName)] = np.array(obsval, dtype=np.float32)
         ioda_data[(variable, obsErrName)] = np.array(errval, dtype=np.float32)

--- a/src/compo/airnow2ioda_nc.py
+++ b/src/compo/airnow2ioda_nc.py
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     for key in varDict.keys():
         variable = varDict[key][0]
         obsval = data[variable]
-        errval = np.where(obsval < 1e+36, obsval * 0.1, obsval)  # rough, needs refinement per species TBC
+        errval = np.where(obsval < 1e+36, np.maximum(0.1,obsval * 0.1), obsval)  # rough, needs refinement per species TBC
         qcval = np.where((obsval > 1e+36) | np.isinf(obsval) | np.isnan(obsval), 0, 1)
         ioda_data[(variable, obsValName)] = np.array(obsval, dtype=np.float32)
         ioda_data[(variable, obsErrName)] = np.array(errval, dtype=np.float32)


### PR DESCRIPTION
Add min error of 0.1 for AirNOW. Please let me know if there's any comments.

Issues: current version has 0 error in our development test for PM2.5 DA for RRFS-SD https://github.com/NOAA-EMC/rrfs-workflow/tree/rrfs-mpas-jedi. The RDASApp used for RRFS DA directly points to this repo. 

Simple PR, no dependency. 

I have performed a self-review of my own code and tested results.
Original PM2.5 error: _, 0.05, 0.47, 0, 0.12
New PM2.5 error: _, 0.1, 0.47, 0.1, 0.12.

