### PR TITLE
Allow forks to use presubmit CI by using "pull_request_target" workflow.

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -1,7 +1,7 @@
 name: start-jedi-ci
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
      - 'master'
      - 'main'

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -3,8 +3,6 @@ name: start-jedi-ci
 on:
   pull_request_target:
     branches:
-     - 'master'
-     - 'main'
      - 'develop'
 
 jobs:


### PR DESCRIPTION
Change the CI trigger to use `on: pull_request_target:...` instead of "on: pull_request:..." this means that all pull requests, including pull requests from forks, will run CI using the checked-in config from the target branch.

This change has been made to enable fork pull requests to test. The previous strategy only allowed tests from branches of this repository forks.

__Issues:__

This change unblocks https://github.com/JCSDA-internal/ioda-converters/pull/1792
