### PR TITLE
Merge release/1.0 into develop (2026.1.0 back-merge)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required( VERSION 3.12 )
 
 
-project( iodaconv VERSION 0.0.1 LANGUAGES CXX Fortran )
+project( iodaconv VERSION 1.0.0 LANGUAGES CXX Fortran )
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
 find_package( ecbuild 3 REQUIRED )


### PR DESCRIPTION
Back-merge of the 2026.1.0 release branch. Contains project VERSION bump and find_package version bumps for peer components.

Refs JCSDA-internal/jedi-bundle#153.