### PR TITLE
Convert IPP longitude from degrees west to degrees east

### DIFF
--- a/src/space_weather/gnss_tec_ground_based.py
+++ b/src/space_weather/gnss_tec_ground_based.py
@@ -314,6 +314,9 @@ def populate_obsValue(line, local_data):
     dateTime = convert_string_to_dateTime(yymmdd, hhmmss)
     PRN, latitudeIPP = parse_station_and_latitude(PRNlatitudeIPP)
 
+    # Convert IPP longitude from degrees West to degrees East
+    longitudeIPP = -longitudeIPP
+
     xECEFPositionGNSS = convert_ECEF_string(xECEFPositionGNSS)
     yECEFPositionGNSS = convert_ECEF_string(yECEFPositionGNSS)
     zECEFPositionGNSS = convert_ECEF_string(zECEFPositionGNSS)


### PR DESCRIPTION
## Description

This PR converts the ionospheric pierce point longitudes read by gnss_tec_ground_based.py from degrees west (the coordinate system used by the input files) to degrees east (the coordinate system stated in the metadata output by this script).

## Issue(s) addressed

Resolves #1804 

## Dependencies

List the other PRs that this PR is dependent on: None

## Impact

Expected impact on downstream repositories: Any downstream scripts or programs that expect IPP longitudes in degrees west would be impacted. Uncertain whether any current repositories contain scripts or tests that read the IPP longitudes.

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
