### PR TITLE
Launch fewer CMake subprocesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # IODA-CONVERTERS
 ################################################################################
 
-cmake_minimum_required( VERSION 3.12 )
+cmake_minimum_required( VERSION 3.23 )
 
 
 project( iodaconv VERSION 1.0.0 LANGUAGES CXX Fortran )

--- a/cmake/iodaconv_extra_macros.cmake
+++ b/cmake/iodaconv_extra_macros.cmake
@@ -3,10 +3,12 @@
 # Macro to copy list of files from source to destination
 macro( copy_files filelist source destination )
   foreach(FILENAME ${filelist})
-    execute_process( COMMAND ${CMAKE_COMMAND} -E copy
-      ${source}/${FILENAME}
-      ${destination}/${FILENAME}
-    )
+    # file(COPY_FILE) does not create the destination directory, and FILENAME may
+    # carry a subdirectory.
+    get_filename_component(_cf_subdir ${FILENAME} DIRECTORY)
+    file( MAKE_DIRECTORY ${destination}/${_cf_subdir} )
+    file( COPY_FILE ${source}/${FILENAME}
+          ${destination}/${FILENAME} ONLY_IF_DIFFERENT )
   endforeach()
 endmacro()
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -37,9 +37,9 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bufr_obs_samples)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bufr_table_samples)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fix)
 foreach(FILENAME ${bufr_obs_samples} ${bufr_table_samples} ${fix})
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
-           ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
+    file( CREATE_LINK
+          ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+          ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} SYMBOLIC )
 endforeach(FILENAME)
 
 install( DIRECTORY fix bufr_obs_samples bufr_table_samples DESTINATION doc )

--- a/src/ncep/CMakeLists.txt
+++ b/src/ncep/CMakeLists.txt
@@ -14,7 +14,7 @@ set_targets_deps( "${libs}"
                    ncep_scripts_deps)
 
 file(MAKE_DIRECTORY ${PYIODACONV_BUILD_LIBDIR})
-execute_process(COMMAND cmake -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/config ${PYIODACONV_BUILD_LIBDIR}/config)
+file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/config ${PYIODACONV_BUILD_LIBDIR}/config SYMBOLIC)
 
 file( RELATIVE_PATH SCRIPT_LIB_PATH ${CMAKE_BINARY_DIR}/bin ${PYIODACONV_BUILD_LIBDIR} )
 conf_targets_deps( "${programs}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -490,9 +490,9 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testrun)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testrun/varbc)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Data)
 foreach(FILENAME ${test_input} ${test_output})
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
-           ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
+    file( CREATE_LINK
+          ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+          ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} SYMBOLIC )
 endforeach(FILENAME)
 
 # create the share directory and link files to test subdir
@@ -500,9 +500,9 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share)
 file( GLOB_RECURSE SHARE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../share/* )
 foreach ( f ${SHARE_FILES} )
     get_filename_component(filename ${f} NAME)
-    execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${CMAKE_CURRENT_SOURCE_DIR}/../share/${filename}
-           ${CMAKE_CURRENT_BINARY_DIR}/share/${filename} )
+    file( CREATE_LINK
+          ${CMAKE_CURRENT_SOURCE_DIR}/../share/${filename}
+          ${CMAKE_CURRENT_BINARY_DIR}/share/${filename} SYMBOLIC )
 endforeach()
 
 #===============================================================================


### PR DESCRIPTION
## Description

This PR updates how symlinks and copies are handled by ioda-converters, to reduce the number of CMake processes being launched and speed up CMake configuration time. See https://github.com/JCSDA-internal/jedi-bundle/issues/157.

- Replace `execute_process( ... -E create_symlink )` with `file( CREATE_LINK ... SYMBOLIC )`
- Similarly, replace `execute_process( ... -E copy )` with `file( COPY_FILE ... )`
- Bumps CMake version requirement to 3.23 to allow `file( COPY_FILE ... )`, but 3.23 is already required by the oops dependency, so this is a non-change

## Issue(s) addressed

Towards https://github.com/JCSDA-internal/jedi-bundle/issues/157

## Dependencies

## Impact

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
